### PR TITLE
[NOT FOR MERGE] test latest grpc plugin snapshot

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,6 +29,6 @@ addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.5.0").excludeAll(
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 // Pekko gRPC -- sync with PekkoGrpcBinaryVersion in Dependencies.scala
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2-15-767a4b87-SNAPSHOT")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,6 +29,6 @@ addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.5.0").excludeAll(
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 // Pekko gRPC -- sync with PekkoGrpcBinaryVersion in Dependencies.scala
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2-15-767a4b87-SNAPSHOT")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M0-10-e0346183-SNAPSHOT")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")


### PR DESCRIPTION
* unfortunately plugins.sbt does not allow code (as far as I can see) - so mechanisms like PekkoHttpDependency don't work
* still useful to occasionally test with latest 1.1 snapshots