### PR TITLE
Pin Scala 3.3 LTS in scala steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -26,6 +26,8 @@ updates.pin  = [
   { groupId = "ch.qos.logback", version="1.3." }
   # https://github.com/apache/pekko-connectors/issues/503
   { groupId = "com.couchbase.client", artifactId = "java-client", version = "2." }
+  # Scala 3.3 is a LTS
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]
 
 updates.ignore = [


### PR DESCRIPTION
I noticed in Scala OS projects that Scala Steward has been bumping 3.3.x to 3.4.x