### PR TITLE
add pekko-connectors-bom

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,58 +15,60 @@ ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
+lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](
+  amqp,
+  avroparquet,
+  awslambda,
+  azureStorageQueue,
+  cassandra,
+  couchbase,
+  csv,
+  dynamodb,
+  elasticsearch,
+  eventbridge,
+  files,
+  ftp,
+  geode,
+  googleCommon,
+  googleCloudBigQuery,
+  googleCloudBigQueryStorage,
+  googleCloudPubSub,
+  googleCloudPubSubGrpc,
+  googleCloudStorage,
+  googleFcm,
+  hbase,
+  hdfs,
+  huaweiPushKit,
+  influxdb,
+  ironmq,
+  jms,
+  jsonStreaming,
+  kinesis,
+  kudu,
+  mongodb,
+  mqtt,
+  mqttStreaming,
+  orientdb,
+  pravega,
+  reference,
+  s3,
+  springWeb,
+  simpleCodecs,
+  slick,
+  sns,
+  solr,
+  sqs,
+  sse,
+  text,
+  udp,
+  unixdomainsocket,
+  xml)
+
 lazy val `pekko-connectors` = project
   .in(file("."))
   .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(MimaPlugin, SitePlugin)
-  .aggregate(
-    amqp,
-    avroparquet,
-    awslambda,
-    azureStorageQueue,
-    cassandra,
-    couchbase,
-    csv,
-    dynamodb,
-    elasticsearch,
-    eventbridge,
-    files,
-    ftp,
-    geode,
-    googleCommon,
-    googleCloudBigQuery,
-    googleCloudBigQueryStorage,
-    googleCloudPubSub,
-    googleCloudPubSubGrpc,
-    googleCloudStorage,
-    googleFcm,
-    hbase,
-    hdfs,
-    huaweiPushKit,
-    influxdb,
-    ironmq,
-    jms,
-    jsonStreaming,
-    kinesis,
-    kudu,
-    mongodb,
-    mqtt,
-    mqttStreaming,
-    orientdb,
-    pravega,
-    reference,
-    s3,
-    springWeb,
-    simpleCodecs,
-    slick,
-    sns,
-    solr,
-    sqs,
-    sse,
-    text,
-    udp,
-    unixdomainsocket,
-    xml)
+  .aggregate(userProjects: _*)
   .aggregate(`doc-examples`)
   .settings(
     name := "pekko-connectors-root",
@@ -433,6 +435,16 @@ lazy val `doc-examples` = project
     name := s"pekko-connectors-doc-examples",
     publish / skip := true,
     Dependencies.`Doc-examples`)
+
+lazy val billOfMaterials = Project("bill-of-materials", file("bill-of-materials"))
+  .enablePlugins(BillOfMaterialsPlugin)
+  .disablePlugins(MimaPlugin, SitePlugin)
+  .settings(
+    name := "pekko-connectors-bom",
+    licenses := List(License.Apache2),
+    libraryDependencies := Seq.empty,
+    bomIncludeProjects := userProjects,
+    description := s"${description.value} (depending on Scala ${CrossVersion.binaryScalaVersion(scalaVersion.value)})")
 
 val mimaCompareVersion = "1.0.2"
 

--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,7 @@ lazy val `pekko-connectors` = project
   .enablePlugins(ScalaUnidocPlugin)
   .disablePlugins(MimaPlugin, SitePlugin)
   .aggregate(userProjects: _*)
-  .aggregate(`doc-examples`)
+  .aggregate(`doc-examples`, billOfMaterials)
   .settings(
     name := "pekko-connectors-root",
     onLoadMessage :=

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,6 +13,7 @@ addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.3")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
+addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 // discipline
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
We have BOMs for Pekko(Core) and Pekko-HTTP.

* https://repo1.maven.org/maven2/org/apache/pekko/pekko-bom_2.13/1.0.2/pekko-bom_2.13-1.0.2.pom
* https://repo1.maven.org/maven2/org/apache/pekko/pekko-http-bom_2.13/1.0.1/pekko-http-bom_2.13-1.0.1.pom

I think it useful to have one for Pekko-Connectors.