### PR TITLE
pin jetty in .scala-steward.conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -19,6 +19,9 @@ updates.pin  = [
   { groupId = "org.apache.activemq", version = "5.16." }
   # wiremock 3.0+ requires Java 11 (only used in tests)
   { groupId = "com.github.tomakehurst", version = "2." }
+  # jetty 10.+ requires Java 11 (only used in tests - via wiremock)
+  { groupId = "org.eclipse.jetty", version = "9." }
+  { groupId = "org.eclipse.jetty.http2", version = "9." }
   # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." },
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }


### PR DESCRIPTION
Newer versions of jetty need java 11