### PR TITLE
zip: use ByteString conversions because we know they are safe in this case

### DIFF
--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipArchiveFlow.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipArchiveFlow.scala
@@ -60,8 +60,7 @@ import pekko.util.{ ByteString, ByteStringBuilder }
           case b: ByteString if FileByteStringSeparators.isEndingByteString(b) =>
             zip.closeEntry()
           case b: ByteString =>
-            val array = b.toArray
-            zip.write(array, 0, array.length)
+            zip.write(b.toArrayUnsafe())
         }
         zip.flush()
         val result = builder.result()

--- a/file/src/test/java/docs/javadsl/ArchiveHelper.java
+++ b/file/src/test/java/docs/javadsl/ArchiveHelper.java
@@ -25,7 +25,8 @@ import java.util.zip.ZipInputStream;
 public class ArchiveHelper {
 
   public Map<String, ByteString> unzip(ByteString zipArchive) throws Exception {
-    ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipArchive.toArray()));
+    // toArrayUnsafe is ok here because we know that ZipInputStream will not mutate the array
+    ZipInputStream zis = new ZipInputStream(new ByteArrayInputStream(zipArchive.toArrayUnsafe()));
     ZipEntry entry;
     Map<String, ByteString> result = new HashMap<>();
     try {
@@ -40,7 +41,8 @@ public class ArchiveHelper {
         dest.flush();
         dest.close();
         zis.closeEntry();
-        result.putIfAbsent(entry.getName(), ByteString.fromArray(dest.toByteArray()));
+        // fromArrayUnsafe is ok here because we know the `dest` data is not mutated
+        result.putIfAbsent(entry.getName(), ByteString.fromArrayUnsafe(dest.toByteArray()));
       }
     } finally {
       zis.close();


### PR DESCRIPTION
ByteString unsafe functions should only be used if you know if other code can mutate the arrays