### PR TITLE
s3: avoid array copies when dealing with ByteStrings

### DIFF
--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBuffer.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBuffer.scala
@@ -78,7 +78,7 @@ import pekko.annotation.InternalApi
           throw new BufferOverflowException()
         }
 
-        pathOut.write(elem.toArray)
+        pathOut.write(elem.toArrayUnsafe())
         pull(in)
       }
 

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/Signer.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/Signer.scala
@@ -32,7 +32,7 @@ import pekko.stream.scaladsl.Source
       signAnonymousRequests: Boolean): Source[HttpRequest, NotUsed] =
     if (!signAnonymousRequests && key.anonymous) Source.single(request)
     else {
-      val hashedBody = request.entity.dataBytes.via(digest()).map(hash => encodeHex(hash.toArray))
+      val hashedBody = request.entity.dataBytes.via(digest()).map(hash => encodeHex(hash))
 
       hashedBody
         .map { hb =>

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/package.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/package.scala
@@ -36,7 +36,16 @@ package object auth {
     new String(out)
   }
 
-  @InternalApi private[impl] def encodeHex(bytes: ByteString): String = encodeHex(bytes.toArray)
+  @InternalApi private[impl] def encodeHex(bytes: ByteString): String = {
+    val length = bytes.length
+    val out = new Array[Char](length * 2)
+    for (i <- 0 until length) {
+      val b = bytes(i)
+      out(i * 2) = Digits((b >> 4) & 0xF)
+      out(i * 2 + 1) = Digits(b & 0xF)
+    }
+    new String(out)
+  }
 
   @InternalApi private[impl] def digest(algorithm: String = "SHA-256"): Flow[ByteString, ByteString, NotUsed] =
     Flow[ByteString]
@@ -45,5 +54,5 @@ package object auth {
           digest.update(bytes.asByteBuffer)
           digest
       }
-      .map(d => ByteString(d.digest()))
+      .map(d => ByteString.fromArrayUnsafe(d.digest()))
 }

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/package.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/package.scala
@@ -36,16 +36,8 @@ package object auth {
     new String(out)
   }
 
-  @InternalApi private[impl] def encodeHex(bytes: ByteString): String = {
-    val length = bytes.length
-    val out = new Array[Char](length * 2)
-    for (i <- 0 until length) {
-      val b = bytes(i)
-      out(i * 2) = Digits((b >> 4) & 0xF)
-      out(i * 2 + 1) = Digits(b & 0xF)
-    }
-    new String(out)
-  }
+  @InternalApi private[impl] def encodeHex(bytes: ByteString): String =
+    encodeHex(bytes.toArrayUnsafe())
 
   @InternalApi private[impl] def digest(algorithm: String = "SHA-256"): Flow[ByteString, ByteString, NotUsed] =
     Flow[ByteString]


### PR DESCRIPTION
the 'unsafe' methods are ok if you know the data is not being mutated