### PR TITLE
bigquery: use fromArrayUnsafe

### DIFF
--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/scaladsl/BigQueryStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/scaladsl/BigQueryStorage.scala
@@ -75,7 +75,7 @@ object BigQueryStorage {
                       resp.arrowRecordBatch.get.serializedRecordBatch
                     else
                       resp.avroRows.get.serializedBinaryRows
-                  um(ByteString(bytes.toByteArray))
+                  um(ByteString.fromArrayUnsafe(bytes.toByteArray))
                 })
             }
           }


### PR DESCRIPTION
the byte array passed in is safe (not reused)