### PR TITLE
build with pekko grpc 1.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,6 @@ import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCh
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := false
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
-ThisBuild / resolvers += Resolver.ApacheMavenStagingRepo
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCh
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := false
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+ThisBuild / resolvers += Resolver.ApacheMavenStagingRepo
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 

--- a/google-cloud-pub-sub-grpc/src/main/mima-filters/1.1.x.backwards.excludes/io.grpc.backwards.excludes
+++ b/google-cloud-pub-sub-grpc/src/main/mima-filters/1.1.x.backwards.excludes/io.grpc.backwards.excludes
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Upgrading to io.grpc 1.64 caused these issues
+ProblemFilters.exclude[IncompatibleSignatureProblem]("io.grpc.alts.internal.handshaker.HandshakeProtocol.values")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("io.grpc.alts.internal.handshaker.NetworkProtocol.values")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("io.grpc.alts.internal.transport_security_common.SecurityLevel.values")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -30,7 +30,7 @@ object Dependencies {
   val AwsSpiPekkoHttpVersion = "0.1.1"
   val NettyVersion = "4.1.110.Final"
   // Sync with plugins.sbt
-  val PekkoGrpcBinaryVersion = "1.0"
+  val PekkoGrpcBinaryVersion = "1.1"
   val PekkoHttpVersion = PekkoHttpDependency.version
   val PekkoHttpBinaryVersion = "1.0"
   val ScalaTestVersion = "3.2.18"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,6 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
-resolvers += Resolver.ApacheMavenStagingRepo
-
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,6 +7,8 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
+ resolvers += Resolver.ApacheMavenStagingRepo
+
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
@@ -28,6 +30,6 @@ addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.7.0").excludeAll(
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 // Pekko gRPC -- sync with PekkoGrpcBinaryVersion in Dependencies.scala
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.0.2")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,6 +30,6 @@ addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.7.0").excludeAll(
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 // Pekko gRPC -- sync with PekkoGrpcBinaryVersion in Dependencies.scala
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1-RC1")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
- resolvers += Resolver.ApacheMavenStagingRepo
+resolvers += Resolver.ApacheMavenStagingRepo
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.0.1")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -30,6 +30,6 @@ addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.7.0").excludeAll(
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.5.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 // Pekko gRPC -- sync with PekkoGrpcBinaryVersion in Dependencies.scala
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1-RC1")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.0-M1")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")


### PR DESCRIPTION
we have changed the main branch on our other repos to use Pekko 1.1 - updating connectors now that gRPC 1.1.0-M1 is released