### PR TITLE
refer to FTPS

### DIFF
--- a/docs/src/main/paradox/ftp.md
+++ b/docs/src/main/paradox/ftp.md
@@ -1,6 +1,6 @@
 # FTP
 
-The FTP connector provides Apache Pekko Stream sources to connect to FTP, FTPs and SFTP servers. Currently, two kinds of sources are provided:
+The FTP connector provides Apache Pekko Stream sources to connect to FTP, FTPS and SFTP servers. Currently, two kinds of sources are provided:
 
 * one for browsing or traversing the server recursively and,
 * another for retrieving files as a stream of bytes.
@@ -27,7 +27,7 @@ The table below shows direct dependencies of this module and the second tab show
 
 ## Configuring the connection settings
 
-In order to establish a connection with the remote server, you need to provide a specialized version of a @scaladoc[RemoteFileSettings](org.apache.pekko.stream.connectors.ftp.RemoteFileSettings) instance. It's specialized as it depends on the kind of server you're connecting to: FTP, FTPs or SFTP.
+In order to establish a connection with the remote server, you need to provide a specialized version of a @scaladoc[RemoteFileSettings](org.apache.pekko.stream.connectors.ftp.RemoteFileSettings) instance. It's specialized as it depends on the kind of server you're connecting to: FTP, FTPS or SFTP.
 
 Scala
 : @@snip [snip](/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala) { #create-settings }
@@ -35,10 +35,10 @@ Scala
 Java
 : @@snip [snip](/ftp/src/test/java/docs/javadsl/FtpWritingTest.java) { #create-settings }
 
-The configuration above will create an anonymous connection with a remote FTP server in passive mode. For both FTPs and SFTP servers, you will need to provide the specialized versions of these settings: @scaladoc[FtpsSettings](org.apache.pekko.stream.connectors.ftp.FtpsSettings) or @scaladoc[SftpSettings](org.apache.pekko.stream.connectors.ftp.SftpSettings)
+The configuration above will create an anonymous connection with a remote FTP server in passive mode. For both FTPS and SFTP servers, you will need to provide the specialized versions of these settings: @scaladoc[FtpsSettings](org.apache.pekko.stream.connectors.ftp.FtpsSettings) or @scaladoc[SftpSettings](org.apache.pekko.stream.connectors.ftp.SftpSettings)
 respectively.
 
-The example demonstrates optional use of `configureConnection` option available on FTP and FTPs clients. Use it to configure any custom parameters the server may require, such as explicit or implicit data transfer encryption.
+The example demonstrates optional use of `configureConnection` option available on FTP and FTPS clients. Use it to configure any custom parameters the server may require, such as explicit or implicit data transfer encryption.
 
 For non-anonymous connection, please provide an instance of @scaladoc[NonAnonFtpCredentials](org.apache.pekko.stream.connectors.ftp.FtpCredentials$$NonAnonFtpCredentials) instead.
 
@@ -76,7 +76,7 @@ Java
 
 This source will emit @scaladoc[FtpFile](org.apache.pekko.stream.connectors.ftp.FtpFile) elements with no significant materialization.
 
-For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
+For both FTPS and SFTP servers, you will need to use the `FTPS` and `SFTP` API respectively.
 
 ## Retrieving files
 
@@ -90,7 +90,7 @@ Java
 
 This source will emit @scaladoc[ByteString](org.apache.pekko.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @javadoc[CompletionStage](java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](org.apache.pekko.stream.IOResult) when the stream finishes.
 
-For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
+For both FTPS and SFTP servers, you will need to use the `FTPS` and `SFTP` API respectively.
 
 ## Writing files
 
@@ -104,7 +104,7 @@ Java
 
 This sink will consume @scaladoc[ByteString](org.apache.pekko.util.ByteString) elements and materializes to @scaladoc[Future](scala.concurrent.Future) in Scala API and @javadoc[CompletionStage](java/util/concurrent/CompletionStage) in Java API of @scaladoc[IOResult](org.apache.pekko.stream.IOResult) when the stream finishes.
 
-For both FTPs and SFTP servers, you will need to use the `FTPs` and `SFTP` API respectively.
+For both FTPS and SFTP servers, you will need to use the `FTPS` and `SFTP` API respectively.
 
 ## Removing files
 

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/javadsl/FtpApi.scala
@@ -36,7 +36,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
    * Java API: creates a [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
    * By default, `anonymous` credentials will be used.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @return A [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s
    */
   def ls(host: String): Source[FtpFile, NotUsed]
@@ -45,7 +45,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
    * Java API: creates a [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s from a base path.
    * By default, `anonymous` credentials will be used.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param basePath Base path from which traverse the remote file server
    * @return A [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s
    */
@@ -56,7 +56,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Java API: creates a [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param username username
    * @param password password
    * @return A [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s
@@ -69,7 +69,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Java API: creates a [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s from a base path.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param username username
    * @param password password
    * @param basePath Base path from which traverse the remote file server
@@ -133,7 +133,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Java API: creates a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]] from some file path.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param path the file path
    * @return A [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]] that materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[IOResult]]
    */
@@ -144,7 +144,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Java API: creates a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]] from some file path.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param username username
    * @param password password
    * @param path the file path

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/model.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/model.scala
@@ -54,7 +54,7 @@ abstract sealed class RemoteFileSettings {
 }
 
 /**
- * Common settings for FTP and FTPs.
+ * Common settings for FTP and FTPS.
  */
 @DoNotInherit
 abstract sealed class FtpFileSettings extends RemoteFileSettings {
@@ -166,7 +166,7 @@ object FtpSettings {
 }
 
 /**
- * FTPs settings
+ * FTPS settings
  *
  * @param host host
  * @param port port
@@ -267,11 +267,11 @@ final class FtpsSettings private (
 }
 
 /**
- * FTPs settings factory
+ * FTPS settings factory
  */
 object FtpsSettings {
 
-  /** Default FTPs port (2222) */
+  /** Default FTPS port (2222) */
   final val DefaultFtpsPort = 2222
 
   /** Scala API */

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/scaladsl/FtpApi.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/scaladsl/FtpApi.scala
@@ -34,7 +34,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
    * Scala API: creates a [[pekko.stream.scaladsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
    * By default, `anonymous` credentials will be used.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @return A [[pekko.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
   def ls(host: String): Source[FtpFile, NotUsed]
@@ -43,7 +43,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
    * Scala API: creates a [[pekko.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
    * By default, `anonymous` credentials will be used.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param basePath Base path from which traverse the remote file server
    * @return A [[pekko.stream.scaladsl.Source Source]] of [[FtpFile]]s
    */
@@ -52,7 +52,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Scala API: creates a [[pekko.stream.scaladsl.Source Source]] of [[FtpFile]]s from the remote user `root` directory.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param username username
    * @param password password
    * @return A [[pekko.stream.scaladsl.Source Source]] of [[FtpFile]]s
@@ -62,7 +62,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Scala API: creates a [[pekko.stream.scaladsl.Source Source]] of [[FtpFile]]s from a base path.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param username username
    * @param password password
    * @param basePath Base path from which traverse the remote file server
@@ -139,7 +139,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Scala API: creates a [[pekko.stream.scaladsl.Source Source]] of [[pekko.util.ByteString ByteString]] from some file path.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param path the file path
    * @return A [[pekko.stream.scaladsl.Source Source]] of [[pekko.util.ByteString ByteString]] that materializes to a [[scala.concurrent.Future Future]] of [[IOResult]]
    */
@@ -148,7 +148,7 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
   /**
    * Scala API: creates a [[pekko.stream.scaladsl.Source Source]] of [[pekko.util.ByteString ByteString]] from some file path.
    *
-   * @param host FTP, FTPs or SFTP host
+   * @param host FTP, FTPS or SFTP host
    * @param username username
    * @param password password
    * @param path the file path


### PR DESCRIPTION
More commonly called FTPS as opposed to FTPs - the latter can be mistaken for a plural of FTP.

https://en.wikipedia.org/wiki/FTPS

