### PR TITLE
Revert "Update auth, dynamodb, eventbridge, firehose, ... to 2.26.7"

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val InfluxDBJavaVersion = "2.23"
 
   val AvroVersion = "1.11.3"
-  val AwsSdk2Version = "2.26.7"
+  val AwsSdk2Version = "2.25.70"
   val AwsSpiPekkoHttpVersion = "0.1.1"
   val NettyVersion = "4.1.111.Final"
   // Sync with plugins.sbt


### PR DESCRIPTION
Reverts apache/pekko-connectors#705

There is a compile issue because AWS SDK RetryPolicy has been deprecated in favour of RetryStrategy.

See https://github.com/apache/pekko-connectors/issues/707