### PR TITLE
add jakartams to sbt project list

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -475,7 +475,8 @@ lazy val billOfMaterials = Project("bill-of-materials", file("bill-of-materials"
     bomIncludeProjects := userProjects,
     description := s"${description.value} (depending on Scala ${CrossVersion.binaryScalaVersion(scalaVersion.value)})")
 
-val mimaCompareVersion = "1.0.2"
+private val mimaCompareVersion = "1.0.2"
+private val noMimaChecks = Set("slick", "couchbase3", "jakartams", "aws.api.pekko.http")
 
 def pekkoConnectorProject(projectId: String,
     moduleName: String,
@@ -489,7 +490,7 @@ def pekkoConnectorProject(projectId: String,
       licenses := List(License.Apache2),
       AutomaticModuleName.settings(s"pekko.stream.connectors.$moduleName"),
       mimaPreviousArtifacts := {
-        if (moduleName == "slick" || moduleName == "couchbase3" || moduleName == "aws.api.pekko.http") {
+        if (noMimaChecks.contains(moduleName)) {
           Set.empty
         } else {
           Set(organization.value %% name.value % mimaCompareVersion)

--- a/build.sbt
+++ b/build.sbt
@@ -43,6 +43,7 @@ lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](
   huaweiPushKit,
   influxdb,
   ironmq,
+  jakartams,
   jms,
   jsonStreaming,
   kinesis,

--- a/build.sbt
+++ b/build.sbt
@@ -475,8 +475,8 @@ lazy val billOfMaterials = Project("bill-of-materials", file("bill-of-materials"
     bomIncludeProjects := userProjects,
     description := s"${description.value} (depending on Scala ${CrossVersion.binaryScalaVersion(scalaVersion.value)})")
 
-private val mimaCompareVersion = "1.0.2"
-private val noMimaChecks = Set("slick", "couchbase3", "jakartams", "aws.api.pekko.http")
+val mimaCompareVersion = "1.0.2"
+val noMimaChecks = Set("slick", "couchbase3", "jakartams", "aws.api.pekko.http")
 
 def pekkoConnectorProject(projectId: String,
     moduleName: String,

--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -12,11 +12,11 @@ The JMS message model supports several types of message bodies in (see @javadoc[
 
 ## Receiving messages
 
-@apidoc[JmsConsumer$] offers factory methods to consume JMS messages in a number of ways.
+@apidoc[.jms.*.JmsConsumer$] offers factory methods to consume JMS messages in a number of ways.
 
 This examples shows how to listen to a JMS queue and emit @javadoc[javax.jms.Message](javax.jms.Message) elements into the stream.
 
-The materialized value @apidoc[JmsConsumerControl] is used to shut down the consumer (it is a @apidoc[KillSwitch]) and offers the possibility to inspect the connectivity state of the consumer. 
+The materialized value @apidoc[.jms.*.JmsConsumerControl] is used to shut down the consumer (it is a @apidoc[KillSwitch]) and offers the possibility to inspect the connectivity state of the consumer. 
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #jms-source }
@@ -38,7 +38,7 @@ Java
 
 The created @javadoc[ConnectionFactory](javax.jms.ConnectionFactory) is then used for the creation of the different JMS sources.
 
-The @apidoc[JmsConsumerSettings$] factories allow for passing the actor system to read from the default `pekko.connectors.jms.consumer` section, or you may pass a `Config` instance which is resolved to a section of the same structure. 
+The @apidoc[.jms.*.JmsConsumerSettings$] factories allow for passing the actor system to read from the default `pekko.connectors.jms.consumer` section, or you may pass a `Config` instance which is resolved to a section of the same structure. 
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala) { #consumer-settings }
@@ -198,8 +198,8 @@ Java
 
 ## Request / Reply
 
-The request / reply pattern can be implemented by streaming a @apidoc[JmsConsumer$]
-to a @apidoc[JmsProducer$],
+The request / reply pattern can be implemented by streaming a @apidoc[.jms.*.JmsConsumer$]
+to a @apidoc[.jms.*.JmsProducer$],
 with a stage in between that extracts the `ReplyTo` and `CorrelationID` from the original message and adds them to the response.
 
 Scala

--- a/docs/src/main/paradox/jms/consumer.md
+++ b/docs/src/main/paradox/jms/consumer.md
@@ -12,11 +12,11 @@ The JMS message model supports several types of message bodies in (see @javadoc[
 
 ## Receiving messages
 
-@apidoc[.jms.*.JmsConsumer$] offers factory methods to consume JMS messages in a number of ways.
+@apidoc[org.apache.pekko.stream.connectors.jms.*.JmsConsumer$] offers factory methods to consume JMS messages in a number of ways.
 
 This examples shows how to listen to a JMS queue and emit @javadoc[javax.jms.Message](javax.jms.Message) elements into the stream.
 
-The materialized value @apidoc[.jms.*.JmsConsumerControl] is used to shut down the consumer (it is a @apidoc[KillSwitch]) and offers the possibility to inspect the connectivity state of the consumer. 
+The materialized value @apidoc[org.apache.pekko.stream.connectors.jms.*.JmsConsumerControl] is used to shut down the consumer (it is a @apidoc[KillSwitch]) and offers the possibility to inspect the connectivity state of the consumer. 
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #jms-source }
@@ -38,7 +38,7 @@ Java
 
 The created @javadoc[ConnectionFactory](javax.jms.ConnectionFactory) is then used for the creation of the different JMS sources.
 
-The @apidoc[.jms.*.JmsConsumerSettings$] factories allow for passing the actor system to read from the default `pekko.connectors.jms.consumer` section, or you may pass a `Config` instance which is resolved to a section of the same structure. 
+The @apidoc[org.apache.pekko.stream.connectors.jms.JmsConsumerSettings$] factories allow for passing the actor system to read from the default `pekko.connectors.jms.consumer` section, or you may pass a `Config` instance which is resolved to a section of the same structure. 
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala) { #consumer-settings }
@@ -198,8 +198,8 @@ Java
 
 ## Request / Reply
 
-The request / reply pattern can be implemented by streaming a @apidoc[.jms.*.JmsConsumer$]
-to a @apidoc[.jms.*.JmsProducer$],
+The request / reply pattern can be implemented by streaming a @apidoc[org.apache.pekko.stream.connectors.jms.*.JmsConsumer$]
+to a @apidoc[org.apache.pekko.stream.connectors.jms.*.JmsProducer$],
 with a stage in between that extracts the `ReplyTo` and `CorrelationID` from the original message and adds them to the response.
 
 Scala

--- a/docs/src/main/paradox/jms/index.md
+++ b/docs/src/main/paradox/jms/index.md
@@ -10,6 +10,8 @@ The Java Message Service (JMS) API is a Java message-oriented middleware API for
 
 The Apache Pekko Connectors JMS connector provides Apache Pekko Stream sources and sinks to connect to JMS providers.
 
+In v1.1.0, there is also a Jakarta MS connector that provides the equivalent support for [Jakarta Messaging](https://jakarta.ee/learn/docs/jakartaee-tutorial/current/messaging/jms-concepts/jms-concepts.html).
+
 @@project-info{ projectId="jms" }
 
 ## Artifacts

--- a/docs/src/main/paradox/jms/producer.md
+++ b/docs/src/main/paradox/jms/producer.md
@@ -38,8 +38,8 @@ The created @javadoc[ConnectionFactory](javax.jms.ConnectionFactory) is then use
 
 ### A `JmsMessage` sub-type sink
 
-Use a case class with the subtype of @apidoc[JmsMessage] to wrap the messages you want to send and optionally set message specific properties or headers.
-@apidoc[JmsProducer$] contains factory methods to facilitate the creation of sinks according to the message type.
+Use a case class with the subtype of @apidoc[.jms.*.JmsMessage] to wrap the messages you want to send and optionally set message specific properties or headers.
+@apidoc[.jms.*.JmsProducer$] contains factory methods to facilitate the creation of sinks according to the message type.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-jms-sink }
@@ -50,7 +50,7 @@ Java
 
 #### Setting JMS message properties
 
-For every @apidoc[JmsMessage] you can set JMS message properties.
+For every @apidoc[.jms.*.JmsMessage] you can set JMS message properties.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-properties }
@@ -60,7 +60,7 @@ Java
 
 
 #### Setting JMS message header attributes
-For every @apidoc[JmsMessage] you can set also JMS message headers.
+For every @apidoc[.jms.*.JmsMessage] you can set also JMS message headers.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-headers }
@@ -73,7 +73,7 @@ Java
 
 #### Text sinks
 
-Create a sink, that accepts and forwards @apidoc[JmsTextMessage$]s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[.jms.*.JmsTextMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #text-sink }
@@ -83,7 +83,7 @@ Java
 
 #### Byte array sinks
 
-Create a sink, that accepts and forwards @apidoc[JmsByteMessage$]s to the JMS provider.
+Create a sink, that accepts and forwards @apidoc[.jms.*.JmsByteMessage$]s to the JMS provider.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #bytearray-sink }
@@ -94,7 +94,7 @@ Java
 
 #### Map message sink
 
-Create a sink, that accepts and forwards @apidoc[JmsMapMessage$]s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[.jms.*.JmsMapMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #map-sink }
@@ -107,7 +107,7 @@ Java
 
 Create and configure ActiveMQ connection factory to support serialization.
 See [ActiveMQ Security](https://activemq.apache.org/objectmessage.html) for more information on this.
-Create a sink, that accepts and forwards @apidoc[JmsObjectMessage$]s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[.jms.*.JmsObjectMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #object-sink }

--- a/docs/src/main/paradox/jms/producer.md
+++ b/docs/src/main/paradox/jms/producer.md
@@ -38,8 +38,8 @@ The created @javadoc[ConnectionFactory](javax.jms.ConnectionFactory) is then use
 
 ### A `JmsMessage` sub-type sink
 
-Use a case class with the subtype of @apidoc[.jms.*.JmsMessage] to wrap the messages you want to send and optionally set message specific properties or headers.
-@apidoc[.jms.*.JmsProducer$] contains factory methods to facilitate the creation of sinks according to the message type.
+Use a case class with the subtype of @apidoc[org.apache.pekko.stream.connectors.jms.JmsMessage] to wrap the messages you want to send and optionally set message specific properties or headers.
+@apidoc[org.apache.pekko.stream.connectors.jms.*.JmsProducer$] contains factory methods to facilitate the creation of sinks according to the message type.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-jms-sink }
@@ -50,7 +50,7 @@ Java
 
 #### Setting JMS message properties
 
-For every @apidoc[.jms.*.JmsMessage] you can set JMS message properties.
+For every @apidoc[org.apache.pekko.stream.connectors.jms.JmsMessage] you can set JMS message properties.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-properties }
@@ -60,7 +60,7 @@ Java
 
 
 #### Setting JMS message header attributes
-For every @apidoc[.jms.*.JmsMessage] you can set also JMS message headers.
+For every @apidoc[org.apache.pekko.stream.connectors.jms.JmsMessage] you can set also JMS message headers.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #create-messages-with-headers }
@@ -73,7 +73,7 @@ Java
 
 #### Text sinks
 
-Create a sink, that accepts and forwards @apidoc[.jms.*.JmsTextMessage$]s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[org.apache.pekko.stream.connectors.jms.JmsTextMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #text-sink }
@@ -83,7 +83,7 @@ Java
 
 #### Byte array sinks
 
-Create a sink, that accepts and forwards @apidoc[.jms.*.JmsByteMessage$]s to the JMS provider.
+Create a sink, that accepts and forwards @apidoc[org.apache.pekko.stream.connectors.jms.JmsByteMessage$]s to the JMS provider.
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #bytearray-sink }
@@ -94,7 +94,7 @@ Java
 
 #### Map message sink
 
-Create a sink, that accepts and forwards @apidoc[.jms.*.JmsMapMessage$]s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[org.apache.pekko.stream.connectors.jms.JmsMapMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #map-sink }
@@ -107,7 +107,7 @@ Java
 
 Create and configure ActiveMQ connection factory to support serialization.
 See [ActiveMQ Security](https://activemq.apache.org/objectmessage.html) for more information on this.
-Create a sink, that accepts and forwards @apidoc[.jms.*.JmsObjectMessage$]s to the JMS provider:
+Create a sink, that accepts and forwards @apidoc[org.apache.pekko.stream.connectors.jms.JmsObjectMessage$]s to the JMS provider:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala) { #object-sink }

--- a/jakartams/src/main/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsConnectorState.java
+++ b/jakartams/src/main/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsConnectorState.java
@@ -14,7 +14,11 @@
 package org.apache.pekko.stream.connectors.jakartams.javadsl;
 
 public enum JmsConnectorState {
-
-    Disconnected, Connecting, Connected, Completing, Completed, Failing, Failed
-
+  Disconnected,
+  Connecting,
+  Connected,
+  Completing,
+  Completed,
+  Failing,
+  Failed
 }

--- a/jakartams/src/main/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsConsumerControl.java
+++ b/jakartams/src/main/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsConsumerControl.java
@@ -19,9 +19,9 @@ import org.apache.pekko.stream.javadsl.Source;
 
 public interface JmsConsumerControl extends KillSwitch {
 
-    /**
-     * source that provides connector status change information.
-     * Only the most recent connector state is buffered if the source is not consumed.
-     */
-    Source<JmsConnectorState, NotUsed> connectorState();
+  /**
+   * source that provides connector status change information. Only the most recent connector state
+   * is buffered if the source is not consumed.
+   */
+  Source<JmsConnectorState, NotUsed> connectorState();
 }

--- a/jakartams/src/main/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsProducerStatus.java
+++ b/jakartams/src/main/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsProducerStatus.java
@@ -18,9 +18,9 @@ import org.apache.pekko.stream.javadsl.Source;
 
 public interface JmsProducerStatus {
 
-    /**
-     * source that provides connector status change information.
-     * Only the most recent connector state is buffered if the source is not consumed.
-     */
-    Source<JmsConnectorState, NotUsed> connectorState();
+  /**
+   * source that provides connector status change information. Only the most recent connector state
+   * is buffered if the source is not consumed.
+   */
+  Source<JmsConnectorState, NotUsed> connectorState();
 }

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/ConnectionRetrySettings.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/ConnectionRetrySettings.scala
@@ -14,8 +14,9 @@
 package org.apache.pekko.stream.connectors.jakartams
 
 import com.typesafe.config.Config
-import org.apache.pekko.actor.{ ActorSystem, ClassicActorSystemProvider }
-import org.apache.pekko.util.JavaDurationConverters._
+import org.apache.pekko
+import pekko.actor.{ ActorSystem, ClassicActorSystemProvider }
+import pekko.util.JavaDurationConverters._
 
 import scala.concurrent.duration._
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Destinations.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Destinations.scala
@@ -14,7 +14,8 @@
 package org.apache.pekko.stream.connectors.jakartams
 
 import jakarta.jms
-import org.apache.pekko.util.FunctionConverters._
+import org.apache.pekko
+import pekko.util.FunctionConverters._
 
 /**
  * A destination to send to/receive from.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Envelopes.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Envelopes.scala
@@ -14,7 +14,8 @@
 package org.apache.pekko.stream.connectors.jakartams
 
 import jakarta.jms
-import org.apache.pekko.stream.connectors.jakartams.impl.{ JmsAckSession, JmsSession }
+import org.apache.pekko
+import pekko.stream.connectors.jakartams.impl.{ JmsAckSession, JmsSession }
 
 import java.util.concurrent.atomic.AtomicBoolean
 import scala.concurrent.{ Future, Promise }

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/JmsMessages.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/JmsMessages.scala
@@ -15,11 +15,11 @@ package org.apache.pekko.stream.connectors.jakartams
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.connectors.jakartams.impl.JmsMessageReader._
-import org.apache.pekko.util.ByteString
-import org.apache.pekko.util.OptionConverters._
-import org.apache.pekko.util.ccompat.JavaConverters._
+import pekko.NotUsed
+import pekko.stream.connectors.jakartams.impl.JmsMessageReader._
+import pekko.util.ByteString
+import pekko.util.OptionConverters._
+import pekko.util.ccompat.JavaConverters._
 
 /**
  * Base interface for messages handled by JmsProducers. Sub-classes support pass-through or use [[pekko.NotUsed]] as type for pass-through.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/JmsSettings.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/JmsSettings.scala
@@ -14,7 +14,8 @@
 package org.apache.pekko.stream.connectors.jakartams
 
 import jakarta.jms
-import org.apache.pekko.annotation.DoNotInherit
+import org.apache.pekko
+import pekko.annotation.DoNotInherit
 
 /**
  * Shared settings for all JMS stages.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsBrowseStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsBrowseStage.scala
@@ -15,10 +15,10 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.connectors.jakartams.{ Destination, JmsBrowseSettings }
-import org.apache.pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
-import org.apache.pekko.stream.{ ActorAttributes, Attributes, Outlet, SourceShape }
+import pekko.annotation.InternalApi
+import pekko.stream.connectors.jakartams.{ Destination, JmsBrowseSettings }
+import pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
+import pekko.stream.{ ActorAttributes, Attributes, Outlet, SourceShape }
 
 /**
  * Internal API.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsConnector.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsConnector.scala
@@ -15,16 +15,16 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.dispatch.ExecutionContexts
-import org.apache.pekko.pattern.after
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.connectors.jakartams.impl.InternalConnectionState._
-import org.apache.pekko.stream.scaladsl.{ BroadcastHub, Keep, Sink, Source, SourceQueueWithComplete }
-import org.apache.pekko.stream.stage.{ AsyncCallback, StageLogging, TimerGraphStageLogic }
-import org.apache.pekko.stream.{ ActorAttributes, Attributes, OverflowStrategy }
-import org.apache.pekko.{ Done, NotUsed }
+import pekko.actor.ActorSystem
+import pekko.annotation.InternalApi
+import pekko.dispatch.ExecutionContexts
+import pekko.pattern.after
+import pekko.stream.connectors.jakartams._
+import pekko.stream.connectors.jakartams.impl.InternalConnectionState._
+import pekko.stream.scaladsl.{ BroadcastHub, Keep, Sink, Source, SourceQueueWithComplete }
+import pekko.stream.stage.{ AsyncCallback, StageLogging, TimerGraphStageLogic }
+import pekko.stream.{ ActorAttributes, Attributes, OverflowStrategy }
+import pekko.{ Done, NotUsed }
 
 import java.util.concurrent.atomic.AtomicReference
 import scala.concurrent.{ ExecutionContext, Future, Promise }

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsConsumerStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsConsumerStage.scala
@@ -15,10 +15,10 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.stage._
+import pekko.annotation.InternalApi
+import pekko.stream._
+import pekko.stream.connectors.jakartams._
+import pekko.stream.stage._
 
 import java.util.concurrent.Semaphore
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsInternalMatValues.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsInternalMatValues.scala
@@ -14,10 +14,10 @@
 package org.apache.pekko.stream.connectors.jakartams.impl
 
 import org.apache.pekko
-import org.apache.pekko.NotUsed
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.KillSwitch
-import org.apache.pekko.stream.scaladsl.Source
+import pekko.NotUsed
+import pekko.annotation.InternalApi
+import pekko.stream.KillSwitch
+import pekko.stream.scaladsl.Source
 
 /**
  * Internal API.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsMessageProducer.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsMessageProducer.scala
@@ -15,8 +15,8 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.connectors.jakartams._
+import pekko.annotation.InternalApi
+import pekko.stream.connectors.jakartams._
 
 /**
  * Internal API.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsMessageReader.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsMessageReader.scala
@@ -15,10 +15,10 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.util.ByteString
-import org.apache.pekko.util.ccompat.JavaConverters._
+import pekko.annotation.InternalApi
+import pekko.stream.connectors.jakartams._
+import pekko.util.ByteString
+import pekko.util.ccompat.JavaConverters._
 
 import scala.annotation.tailrec
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsProducerStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsProducerStage.scala
@@ -15,15 +15,15 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.ActorAttributes.SupervisionStrategy
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.impl.Buffer
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.stream.stage._
-import org.apache.pekko.util.OptionVal
-import org.apache.pekko.{ Done, NotUsed }
+import pekko.annotation.InternalApi
+import pekko.stream.ActorAttributes.SupervisionStrategy
+import pekko.stream._
+import pekko.stream.connectors.jakartams._
+import pekko.stream.impl.Buffer
+import pekko.stream.scaladsl.Source
+import pekko.stream.stage._
+import pekko.util.OptionVal
+import pekko.{ Done, NotUsed }
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsTxSourceStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsTxSourceStage.scala
@@ -15,10 +15,10 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue }
-import org.apache.pekko.stream.{ Attributes, Outlet, SourceShape }
+import pekko.annotation.InternalApi
+import pekko.stream.connectors.jakartams._
+import pekko.stream.stage.{ GraphStageLogic, GraphStageWithMaterializedValue }
+import pekko.stream.{ Attributes, Outlet, SourceShape }
 
 import scala.concurrent.{ Await, TimeoutException }
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/Sessions.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/Sessions.scala
@@ -15,9 +15,9 @@ package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.connectors.jakartams.{ Destination, DurableTopic }
-import org.apache.pekko.util.OptionVal
+import pekko.annotation.InternalApi
+import pekko.stream.connectors.jakartams.{ Destination, DurableTopic }
+import pekko.util.OptionVal
 
 import java.util.concurrent.ArrayBlockingQueue
 import scala.annotation.tailrec

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/SoftReferenceCache.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/SoftReferenceCache.scala
@@ -14,7 +14,7 @@
 package org.apache.pekko.stream.connectors.jakartams.impl
 
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
+import pekko.annotation.InternalApi
 
 import scala.collection.mutable
 import scala.ref.SoftReference

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsConsumer.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsConsumer.scala
@@ -15,10 +15,10 @@ package org.apache.pekko.stream.connectors.jakartams.javadsl
 
 import jakarta.jms.Message
 import org.apache.pekko
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.javadsl.Source
-import org.apache.pekko.util.ccompat.JavaConverters._
+import pekko.NotUsed
+import pekko.stream.connectors.jakartams._
+import pekko.stream.javadsl.Source
+import pekko.util.ccompat.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsProducer.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsProducer.scala
@@ -14,13 +14,13 @@
 package org.apache.pekko.stream.connectors.jakartams.javadsl
 
 import org.apache.pekko
-import org.apache.pekko.stream.connectors.jakartams.{ scaladsl, JmsEnvelope, JmsMessage, JmsProducerSettings }
-import org.apache.pekko.stream.javadsl.Source
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep }
-import org.apache.pekko.util.ByteString
-import org.apache.pekko.util.FutureConverters._
-import org.apache.pekko.util.ccompat.JavaConverters._
-import org.apache.pekko.{ Done, NotUsed }
+import pekko.stream.connectors.jakartams.{ scaladsl, JmsEnvelope, JmsMessage, JmsProducerSettings }
+import pekko.stream.javadsl.Source
+import pekko.stream.scaladsl.{ Flow, Keep }
+import pekko.util.ByteString
+import pekko.util.FutureConverters._
+import pekko.util.ccompat.JavaConverters._
+import pekko.{ Done, NotUsed }
 
 import java.util.concurrent.CompletionStage
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsConnectorState.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsConnectorState.scala
@@ -14,11 +14,11 @@
 package org.apache.pekko.stream.connectors.jakartams.scaladsl
 
 import org.apache.pekko
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.KillSwitch
-import org.apache.pekko.stream.connectors.jakartams.javadsl
-import org.apache.pekko.stream.connectors.jakartams.scaladsl.JmsConnectorState._
-import org.apache.pekko.stream.scaladsl.Source
+import pekko.NotUsed
+import pekko.stream.KillSwitch
+import pekko.stream.connectors.jakartams.javadsl
+import pekko.stream.connectors.jakartams.scaladsl.JmsConnectorState._
+import pekko.stream.scaladsl.Source
 
 trait JmsProducerStatus {
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsConsumer.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsConsumer.scala
@@ -15,11 +15,11 @@ package org.apache.pekko.stream.connectors.jakartams.scaladsl
 
 import jakarta.jms
 import org.apache.pekko
-import org.apache.pekko.NotUsed
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.connectors.jakartams.impl._
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.util.ccompat.JavaConverters._
+import pekko.NotUsed
+import pekko.stream.connectors.jakartams._
+import pekko.stream.connectors.jakartams.impl._
+import pekko.stream.scaladsl.Source
+import pekko.util.ccompat.JavaConverters._
 
 /**
  * Factory methods to create JMS consumers.

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsProducer.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsProducer.scala
@@ -14,11 +14,11 @@
 package org.apache.pekko.stream.connectors.jakartams.scaladsl
 
 import org.apache.pekko
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.connectors.jakartams.impl.{ JmsProducerMatValue, JmsProducerStage }
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import org.apache.pekko.util.ByteString
-import org.apache.pekko.{ Done, NotUsed }
+import pekko.stream.connectors.jakartams._
+import pekko.stream.connectors.jakartams.impl.{ JmsProducerMatValue, JmsProducerStage }
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.util.ByteString
+import pekko.{ Done, NotUsed }
 
 import scala.concurrent.Future
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/package.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/package.scala
@@ -14,10 +14,10 @@
 package org.apache.pekko.stream.connectors.jakartams
 
 import org.apache.pekko
-import org.apache.pekko.annotation.InternalApi
-import org.apache.pekko.stream.connectors.jakartams.impl.InternalConnectionState
-import org.apache.pekko.stream.scaladsl.Source
-import org.apache.pekko.{ Done, NotUsed }
+import pekko.annotation.InternalApi
+import pekko.stream.connectors.jakartams.impl.InternalConnectionState
+import pekko.stream.scaladsl.Source
+import pekko.{ Done, NotUsed }
 
 import scala.util.{ Failure, Success }
 

--- a/jakartams/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -15,6 +15,7 @@ package docs.scaladsl
 
 import jakarta.jms.{ JMSException, TextMessage }
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants
+import org.apache.pekko
 import pekko.Done
 import pekko.stream.connectors.jakartams._
 import pekko.stream.connectors.jakartams.scaladsl.{ JmsConsumer, JmsConsumerControl, JmsProducer }

--- a/jakartams/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsBufferedAckConnectorsSpec.scala
@@ -15,12 +15,12 @@ package docs.scaladsl
 
 import jakarta.jms.{ JMSException, TextMessage }
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSConstants
-import org.apache.pekko.Done
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.connectors.jakartams.scaladsl.{ JmsConsumer, JmsConsumerControl, JmsProducer }
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import org.apache.pekko.stream.testkit.scaladsl.TestSink
-import org.apache.pekko.stream.{ KillSwitches, ThrottleMode }
+import pekko.Done
+import pekko.stream.connectors.jakartams._
+import pekko.stream.connectors.jakartams.scaladsl.{ JmsConsumer, JmsConsumerControl, JmsProducer }
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.stream.testkit.scaladsl.TestSink
+import pekko.stream.{ KillSwitches, ThrottleMode }
 import org.scalatest.Inspectors._
 import org.scalatest.time.Span.convertSpanToDuration
 

--- a/jakartams/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -1132,7 +1132,6 @@ class JmsConnectorsSpec extends JmsSpec {
   }
 
   "publish and subscribe with a durable subscription" in withServer() { server =>
-    import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory
     val producerConnectionFactory = server.createConnectionFactory
     // #create-connection-factory-with-client-id
     val consumerConnectionFactory = server.createConnectionFactory

--- a/jakartams/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -15,6 +15,7 @@ package docs.scaladsl
 
 import jakarta.jms._
 import org.apache.activemq.artemis.jms.client.{ ActiveMQConnectionFactory, ActiveMQQueue, ActiveMQSession }
+import org.apache.pekko
 import pekko.stream._
 import pekko.stream.connectors.jakartams._
 import pekko.stream.connectors.jakartams.scaladsl._

--- a/jakartams/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsConnectorsSpec.scala
@@ -15,11 +15,11 @@ package docs.scaladsl
 
 import jakarta.jms._
 import org.apache.activemq.artemis.jms.client.{ ActiveMQConnectionFactory, ActiveMQQueue, ActiveMQSession }
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.connectors.jakartams.scaladsl._
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import org.apache.pekko.{ Done, NotUsed }
+import pekko.stream._
+import pekko.stream.connectors.jakartams._
+import pekko.stream.connectors.jakartams.scaladsl._
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.{ Done, NotUsed }
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock

--- a/jakartams/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
@@ -15,7 +15,7 @@ package docs.scaladsl
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource
-import org.apache.pekko.stream.connectors.jakartams._
+import pekko.stream.connectors.jakartams._
 import org.scalatest.OptionValues
 
 import scala.concurrent.duration._

--- a/jakartams/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala
@@ -15,7 +15,7 @@ package docs.scaladsl
 
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource
-import pekko.stream.connectors.jakartams._
+import org.apache.pekko.stream.connectors.jakartams._
 import org.scalatest.OptionValues
 
 import scala.concurrent.duration._

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsConnectionStatusSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsConnectionStatusSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.stream.connectors.jakartams
 
 import com.github.pjfanning.jakartamswrapper.WrappedConnectionFactory
 import jakarta.jms._
+import org.apache.pekko
 import pekko.stream.OverflowStrategy
 import pekko.stream.connectors.jakartams.scaladsl.JmsConnectorState._
 import pekko.stream.connectors.jakartams.scaladsl.{

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsConnectionStatusSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsConnectionStatusSpec.scala
@@ -15,15 +15,15 @@ package org.apache.pekko.stream.connectors.jakartams
 
 import com.github.pjfanning.jakartamswrapper.WrappedConnectionFactory
 import jakarta.jms._
-import org.apache.pekko.stream.OverflowStrategy
-import org.apache.pekko.stream.connectors.jakartams.scaladsl.JmsConnectorState._
-import org.apache.pekko.stream.connectors.jakartams.scaladsl.{
+import pekko.stream.OverflowStrategy
+import pekko.stream.connectors.jakartams.scaladsl.JmsConnectorState._
+import pekko.stream.connectors.jakartams.scaladsl.{
   JmsConnectorState,
   JmsConsumer,
   JmsProducer,
   JmsProducerStatus
 }
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, SinkQueueWithCancel, Source }
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, SinkQueueWithCancel, Source }
 import org.mockito.ArgumentMatchers.{ any, anyBoolean, anyInt }
 import org.mockito.Mockito._
 import org.mockito.invocation.InvocationOnMock

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsConnectionStatusSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsConnectionStatusSpec.scala
@@ -18,12 +18,7 @@ import jakarta.jms._
 import org.apache.pekko
 import pekko.stream.OverflowStrategy
 import pekko.stream.connectors.jakartams.scaladsl.JmsConnectorState._
-import pekko.stream.connectors.jakartams.scaladsl.{
-  JmsConnectorState,
-  JmsConsumer,
-  JmsProducer,
-  JmsProducerStatus
-}
+import pekko.stream.connectors.jakartams.scaladsl.{ JmsConnectorState, JmsConsumer, JmsProducer, JmsProducerStatus }
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, SinkQueueWithCancel, Source }
 import org.mockito.ArgumentMatchers.{ any, anyBoolean, anyInt }
 import org.mockito.Mockito._

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsProducerRetrySpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsProducerRetrySpec.scala
@@ -15,9 +15,9 @@ package org.apache.pekko.stream.connectors.jakartams
 
 import com.github.pjfanning.jakartamswrapper.WrappedConnectionFactory
 import jakarta.jms.{ JMSException, Message, TextMessage }
-import org.apache.pekko.stream._
-import org.apache.pekko.stream.connectors.jakartams.scaladsl.{ JmsConsumer, JmsProducer }
-import org.apache.pekko.stream.scaladsl.{ Keep, Sink, Source }
+import pekko.stream._
+import pekko.stream.connectors.jakartams.scaladsl.{ JmsConsumer, JmsProducer }
+import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import org.mockito.ArgumentMatchers.{ any, anyInt, anyLong }
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsProducerRetrySpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsProducerRetrySpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.stream.connectors.jakartams
 
 import com.github.pjfanning.jakartamswrapper.WrappedConnectionFactory
 import jakarta.jms.{ JMSException, Message, TextMessage }
+import org.apache.pekko
 import pekko.stream._
 import pekko.stream.connectors.jakartams.scaladsl.{ JmsConsumer, JmsProducer }
 import pekko.stream.scaladsl.{ Keep, Sink, Source }

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsSpec.scala
@@ -15,9 +15,9 @@ package org.apache.pekko.stream.connectors.jakartams
 
 import jakarta.jms._
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing
-import org.apache.pekko.testkit.TestKit
+import pekko.actor.ActorSystem
+import pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import pekko.testkit.TestKit
 import org.mockito.ArgumentMatchers.{ any, anyBoolean, anyInt }
 import org.mockito.Mockito.when
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsSpec.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.stream.connectors.jakartams
 
 import jakarta.jms._
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource
+import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.testkit.TestKit

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsMessageProducerSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsMessageProducerSpec.scala
@@ -14,7 +14,8 @@
 package org.apache.pekko.stream.connectors.jakartams.impl
 
 import jakarta.jms.{ Destination => JmsDestination, _ }
-import org.apache.pekko.stream.connectors.jakartams.{ Destination, _ }
+import org.apache.pekko
+import pekko.stream.connectors.jakartams.{ Destination, _ }
 import org.mockito.ArgumentMatchers.{ any, anyBoolean, anyInt, anyString }
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsAckConnectorsSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/scaladsl/JmsAckConnectorsSpec.scala
@@ -15,11 +15,11 @@ package org.apache.pekko.stream.connectors.jakartams.scaladsl
 
 import jakarta.jms.{ JMSException, TextMessage }
 import org.apache.pekko
-import org.apache.pekko.Done
-import org.apache.pekko.stream.connectors.jakartams._
-import org.apache.pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
-import org.apache.pekko.stream.testkit.scaladsl.TestSink
-import org.apache.pekko.stream.{ KillSwitches, ThrottleMode }
+import pekko.Done
+import pekko.stream.connectors.jakartams._
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.stream.testkit.scaladsl.TestSink
+import pekko.stream.{ KillSwitches, ThrottleMode }
 import org.scalatest.Inspectors._
 import org.scalatest.time.Span.convertSpanToDuration
 


### PR DESCRIPTION
Added in #674 but this sbt issue seems to stop the jar being published

see https://repository.apache.org/content/groups/snapshots/org/apache/pekko/ - no jakartams there

* also tidies up imports
* fixes doc build issues - the class names in the new connector clash with those in the jms connector 
* fix mima issue - there is no previous jar to compare against 

