### PR TITLE
some small jakarta ms branding changes

### DIFF
--- a/jakartams/src/main/resources/reference.conf
+++ b/jakartams/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-# Settings for the Apache Pekko Connectors JMS connector
+# Settings for the Apache Pekko Connectors JakartaMS connector
 #
 pekko.connectors.jakartams {
   #connection-retry

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsAckSourceStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsAckSourceStage.scala
@@ -28,7 +28,7 @@ import pekko.stream.{ Attributes, Outlet, SourceShape }
 private[jakartams] final class JmsAckSourceStage(settings: JmsConsumerSettings, destination: Destination)
     extends GraphStageWithMaterializedValue[SourceShape[AckEnvelope], JmsConsumerMatValue] {
 
-  private val out = Outlet[AckEnvelope]("JmsSource.out")
+  private val out = Outlet[AckEnvelope]("JakartaMsSource.out")
 
   override def shape: SourceShape[AckEnvelope] = SourceShape[AckEnvelope](out)
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsTxSourceStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsTxSourceStage.scala
@@ -29,7 +29,7 @@ import scala.concurrent.{ Await, TimeoutException }
 private[jakartams] final class JmsTxSourceStage(settings: JmsConsumerSettings, destination: Destination)
     extends GraphStageWithMaterializedValue[SourceShape[TxEnvelope], JmsConsumerMatValue] {
 
-  private val out = Outlet[TxEnvelope]("JmsSource.out")
+  private val out = Outlet[TxEnvelope]("JakartaMsSource.out")
 
   override def shape: SourceShape[TxEnvelope] = SourceShape[TxEnvelope](out)
 


### PR DESCRIPTION
I'm not sure that I like keeping the Jms prefix in the new class names for #718 but the API is jakarta.jms so it isn't inaccurate.

This PR just has a few fairly cosmetic changes to differentiate from the pre-existing JMS connector