### PR TITLE
add stub doc for couchbase3 client

### DIFF
--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -14,6 +14,7 @@ Apache Pekko Connectors Couchbase allows you to read and write to Couchbase. You
 
 The Couchbase connector supports all document formats which are supported by the SDK. All those formats use the @java[`Document<T>`]@scala[`Document[T]`] interface and this is the level of abstraction that this connector is using.
 
+In v1.1.0, there is also a Couchbase3 connector that provides the equivalent support using the Couchbase Client v3. This conector continues to use the Couchbase Client v2.
 
 @@project-info{ projectId="couchbase" }
 

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -103,6 +103,17 @@ project-info {
       }
     ]
   }
+  couchbase3: ${project-info.shared-info} {
+    title: "Apache Pekko Connectors Couchbase3"
+    jpms-name: "pekko.stream.connectors.couchbase3"
+    issues.url: ${project-info.labels}"couchbase3"
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"couchbase3/index.html"
+        text: "API (Scaladoc)"
+      }
+    ]
+  }
   csv: ${project-info.shared-info} {
     title: "Apache Pekko Connectors CSV"
     jpms-name: "pekko.stream.connectors.csv"
@@ -301,6 +312,17 @@ project-info {
     api-docs: [
       {
         url: ${project-info.scaladoc}"ironmq/index.html"
+        text: "API (Scaladoc)"
+      }
+    ]
+  }
+  jakartams: ${project-info.shared-info} {
+    title: "Apache Pekko Connectors JakartaMS"
+    jpms-name: "pekko.stream.connectors.jakartams"
+    issues.url: ${project-info.labels}"jakartams"
+    api-docs: [
+      {
+        url: ${project-info.scaladoc}"jakartams/index.html"
         text: "API (Scaladoc)"
       }
     ]


### PR DESCRIPTION
relates to https://github.com/apache/pekko-connectors/issues/623

we need fuller docs but at least this mentions the alternative connector