### PR TITLE
chore: avoid scala-steward opening multiple PRs for Jackson

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,8 +2,6 @@ updates.pin  = [
   # pin to hadoop 3.3.x until 3.4.x beomes more widely adopted
   { groupId = "org.apache.hadoop", version = "3.3." }
   # pin to jackson 2.17.x becomes more stable
-  { groupId = "com.fasterxml.jackson.core", version = "2.17." }
-  { groupId = "com.fasterxml.jackson.datatype", version = "2.17." }
   { groupId = "com.fasterxml.jackson.module", version = "2.17." }
   # pin to protobuf-java 3 - see https://github.com/apache/pekko-grpc/issues/245
   { groupId = "com.google.protobuf", version = "3." }
@@ -43,6 +41,10 @@ updates.ignore = [
   # we are stuck while we support Pekko gRPC 1.0
   { groupId = "com.google.cloud", artifactId = "google-cloud-pubsub" }
   { groupId = "com.google.api.grpc", artifactId = "proto-google-cloud-bigquerystorage-v1" }
+  # Avoid scala-steward opening multiple PRs for Jackson version updates,
+  # as they are managed by a single variable in our build
+  { groupId = "com.fasterxml.jackson.core" }
+  { groupId = "com.fasterxml.jackson.datatype" }
 ]
 
 updatePullRequests = "always"


### PR DESCRIPTION
As those versions are managed by a single variable in our build