### PR TITLE
Fix`geode` `PdxEncoder/Decoder` derivation on Scala 3.4+

### DIFF
--- a/geode/src/main/scala-3/org/apache/pekko/stream/connectors/geode/impl/pdx/LabelledGenericGeneric.scala
+++ b/geode/src/main/scala-3/org/apache/pekko/stream/connectors/geode/impl/pdx/LabelledGenericGeneric.scala
@@ -53,7 +53,7 @@ private[pekko] object LabelledGeneric {
 
   inline def apply[A](using l: LabelledGeneric[A]): LabelledGeneric.Aux[A, l.Repr] = l
 
-  inline given productInst[A <: Product](
+  transparent inline given productInst[A <: Product](
       using m: Mirror.ProductOf[A])
       : LabelledGeneric.Aux[A, ZipWith[m.MirroredElemLabels, m.MirroredElemTypes, FieldType]] =
     new LabelledGeneric[A] {


### PR DESCRIPTION
Makes `LabelledGeneric.productInst` a `transparent inline` to allow consuming it on Scala 3.4+ due to new constraints introduced by the compiler - see https://github.com/scala/scala3/pull/19253 for more details and https://github.com/scala/scala3/issues/21236 for minimization of problem found in this project. 

Without this change users are forced to use `-source:3.3` option when building on Scala 3.4 or later.

The problem was found by the Scala 3 Open Community Build - [build logs](https://github.com/VirtusLab/community-build3/actions/runs/9915156118/job/27395911414)
