### PR TITLE
aws-spi-pekko-http: remove unnecessary implicit

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/RequestRunner.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/RequestRunner.scala
@@ -21,7 +21,6 @@ import java.util.concurrent.CompletableFuture
 import java.util.Collections
 
 import org.apache.pekko
-import pekko.actor.ActorSystem
 import pekko.http.scaladsl.model.{ ContentTypes, HttpResponse }
 import pekko.http.scaladsl.model.headers.{ `Content-Length`, `Content-Type` }
 import pekko.stream.Materializer
@@ -33,7 +32,7 @@ import software.amazon.awssdk.http.async.SdkAsyncHttpResponseHandler
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-class RequestRunner()(implicit sys: ActorSystem, ec: ExecutionContext, mat: Materializer) {
+class RequestRunner()(implicit ec: ExecutionContext, mat: Materializer) {
 
   val logger = LoggerFactory.getLogger(this.getClass)
 

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsSourceSettings.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsSourceSettings.scala
@@ -168,7 +168,7 @@ object SqsSourceSettings {
 }
 
 /**
- * Message attribure names described at
+ * Message attribute names described at
  * https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_ReceiveMessage.html#API_ReceiveMessage_RequestParameters
  */
 final class MessageAttributeName private (val name: String) {


### PR DESCRIPTION
compile warning in build:

```
[warn] /code/incubator-pekko-connectors/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/RequestRunner.scala:36:32: parameter sys in class RequestRunner is never used
[warn] class RequestRunner()(implicit sys: ActorSystem, ec: ExecutionContext, mat: Materializer) {
[warn]    
```

aws-spi-pekko-http is a new module in Pekko 1.1 so I think it is ok to remove this implicit param.
