### PR TITLE
sqs: update call due to deprecation warning

### DIFF
--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsSource.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/SqsSource.scala
@@ -43,7 +43,7 @@ object SqsSource {
           ReceiveMessageRequest
             .builder()
             .queueUrl(queueUrl)
-            .attributeNamesWithStrings(settings.attributeNames.map(_.name).asJava)
+            .messageSystemAttributeNamesWithStrings(settings.attributeNames.map(_.name).asJava)
             .messageAttributeNames(settings.messageAttributeNames.map(_.name).asJava)
             .maxNumberOfMessages(settings.maxBatchSize)
             .waitTimeSeconds(settings.waitTimeSeconds)


### PR DESCRIPTION
https://sdk.amazonaws.com/java/api/2.26.21/software/amazon/awssdk/services/sqs/model/ReceiveMessageRequest.Builder.html#attributeNamesWithStrings(java.lang.String...)