### PR TITLE
try latest google-cloud-pubsub

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -43,7 +43,6 @@ updates.ignore = [
   { groupId = "org.apache.hadoop" }
   # these google api libs can only be updated if we update our io.grpc libs (Pekko gRPC 1.1 uses the latest)
   # we are stuck while we support Pekko gRPC 1.0
-  { groupId = "com.google.cloud", artifactId = "google-cloud-pubsub" }
   { groupId = "com.google.api.grpc", artifactId = "proto-google-cloud-bigquerystorage-v1" }
   # Avoid scala-steward opening multiple PRs for Jackson version updates,
   # as they are managed by a single variable in our build

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -41,8 +41,7 @@ updates.ignore = [
   # https://github.com/apache/pekko-connectors/issues/61
   { groupId = "org.apache.hbase" }
   { groupId = "org.apache.hadoop" }
-  # these google api libs can only be updated if we update our io.grpc libs (Pekko gRPC 1.1 uses the latest)
-  # we are stuck while we support Pekko gRPC 1.0
+  # these google api libs need careful testing - very sensitive to protobuf version changes
   { groupId = "com.google.api.grpc", artifactId = "proto-google-cloud-bigquerystorage-v1" }
   # Avoid scala-steward opening multiple PRs for Jackson version updates,
   # as they are managed by a single variable in our build

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -298,7 +298,7 @@ object Dependencies {
     // see Pekko gRPC version in plugins.sbt
     libraryDependencies ++= Seq(
       // https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/
-      "com.google.cloud" % "google-cloud-pubsub" % "1.123.20" % "protobuf-src",
+      "com.google.cloud" % "google-cloud-pubsub" % "1.132.1" % "protobuf-src",
       "io.grpc" % "grpc-auth" % org.apache.pekko.grpc.gen.BuildInfo.grpcVersion,
       "com.google.auth" % "google-auth-library-oauth2-http" % GoogleAuthVersion,
       "com.google.protobuf" % "protobuf-java" % protobufJavaVersion % Runtime,


### PR DESCRIPTION
Had been set up to not be updated but we've sorted out our protobuf and grpc-java issues so this should be ok to upgrade now. I will do a separate PR for the remaining pinned google jar.