### PR TITLE
proto-google-cloud-bigquerystorage-v1 and google-cloud-pubsub upgrade

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -41,8 +41,6 @@ updates.ignore = [
   # https://github.com/apache/pekko-connectors/issues/61
   { groupId = "org.apache.hbase" }
   { groupId = "org.apache.hadoop" }
-  # these google api libs need careful testing - very sensitive to protobuf version changes
-  { groupId = "com.google.api.grpc", artifactId = "proto-google-cloud-bigquerystorage-v1" }
   # Avoid scala-steward opening multiple PRs for Jackson version updates,
   # as they are managed by a single variable in our build
   { groupId = "com.fasterxml.jackson.core" }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -274,7 +274,7 @@ object Dependencies {
     // see Pekko gRPC version in plugins.sbt
     libraryDependencies ++= Seq(
       // https://github.com/googleapis/java-bigquerystorage/tree/master/proto-google-cloud-bigquerystorage-v1
-      "com.google.api.grpc" % "proto-google-cloud-bigquerystorage-v1" % "2.36.1" % "protobuf-src",
+      "com.google.api.grpc" % "proto-google-cloud-bigquerystorage-v1" % "3.9.0" % "protobuf-src",
       "org.apache.avro" % "avro" % AvroVersion % "provided",
       "org.apache.arrow" % "arrow-vector" % ArrowVersion % "provided",
       "io.grpc" % "grpc-auth" % org.apache.pekko.grpc.gen.BuildInfo.grpcVersion,


### PR DESCRIPTION
Had been set up to not be updated but we've sorted out our protobuf and grpc-java issues so this should be ok to upgrade now.
Upgrades proto-google-cloud-bigquerystorage-v1 and google-cloud-pubsub.