### PR TITLE
Update Pekko Stream Circe to 1.1.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -31,6 +31,7 @@ object Dependencies {
   // Sync with plugins.sbt
   val PekkoGrpcBinaryVersion = "1.1"
   val PekkoHttpVersion = PekkoHttpDependency.version
+  val PekkoStreamsCirceVersion = "1.1.0"
   val PekkoHttpBinaryVersion = "1.0"
   val ScalaTestVersion = "3.2.19"
   val TestContainersScalaTestVersion = "0.41.4"
@@ -359,8 +360,8 @@ object Dependencies {
   val IronMq = Seq(
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
-      "org.mdedetrich" %% "pekko-stream-circe" % "1.0.0",
-      "org.mdedetrich" %% "pekko-http-circe" % "1.0.0"))
+      "org.mdedetrich" %% "pekko-stream-circe" % PekkoStreamsCirceVersion,
+      "org.mdedetrich" %% "pekko-http-circe" % PekkoStreamsCirceVersion))
 
   val JakartaMs = {
     val artemisVersion = "2.19.1"


### PR DESCRIPTION
This updates fixes critical bug, see https://github.com/mdedetrich/pekko-streams-circe/pull/93 and https://github.com/apache/pekko-http/issues/595.

Release notes are here https://github.com/mdedetrich/pekko-streams-circe/releases/tag/v1.1.0