### PR TITLE
upgrade sbt, pekko and some minor lib bumps

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -330,7 +330,7 @@ object Dependencies {
         organization = "org.apache.pekko"))) ++ Seq(
       "software.amazon.awssdk" % "kinesis" % AwsSdk2Version,
       "software.amazon.awssdk" % "firehose" % AwsSdk2Version,
-      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3").map(
+      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.0").map(
       _.excludeAll(
         ExclusionRule("software.amazon.awssdk", "apache-client"),
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Mockito)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -330,7 +330,7 @@ object Dependencies {
         organization = "org.apache.pekko"))) ++ Seq(
       "software.amazon.awssdk" % "kinesis" % AwsSdk2Version,
       "software.amazon.awssdk" % "firehose" % AwsSdk2Version,
-      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.8").map(
+      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.3").map(
       _.excludeAll(
         ExclusionRule("software.amazon.awssdk", "apache-client"),
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Mockito)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,10 +25,10 @@ object Dependencies {
 
   val InfluxDBJavaVersion = "2.15"
 
-  val AvroVersion = "1.11.3"
+  val AvroVersion = "1.11.4"
   val AwsSdk2Version = "2.17.113"
-  val AwsSpiPekkoHttpVersion = "0.1.0"
-  val NettyVersion = "4.1.104.Final"
+  val AwsSpiPekkoHttpVersion = "0.1.1"
+  val NettyVersion = "4.1.113.Final"
   // Sync with plugins.sbt
   val PekkoGrpcBinaryVersion = "1.0"
   val PekkoHttpVersion = PekkoHttpDependency.version
@@ -175,7 +175,7 @@ object Dependencies {
       ("org.apache.hadoop" % "hadoop-common" % "3.2.1" % Test).exclude("log4j", "log4j"),
       "com.sksamuel.avro4s" %% "avro4s-core" % avro4sVersion.value % Test,
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % Test,
-      "org.specs2" %% "specs2-core" % "4.20.0" % Test,
+      "org.specs2" %% "specs2-core" % "4.20.8" % Test,
       "org.slf4j" % "log4j-over-slf4j" % log4jOverSlf4jVersion % Test))
 
   val Ftp = Seq(
@@ -184,7 +184,7 @@ object Dependencies {
       "com.hierynomus" % "sshj" % "0.38.0",
       "ch.qos.logback" % "logback-classic" % LogbackForSlf4j2Version % Test) ++ Mockito)
 
-  val GeodeVersion = "1.15.0"
+  val GeodeVersion = "1.15.1"
   val GeodeVersionForDocs = "115"
 
   val Geode = Seq(
@@ -224,7 +224,7 @@ object Dependencies {
       // https://github.com/googleapis/java-bigquerystorage/tree/master/proto-google-cloud-bigquerystorage-v1
       "com.google.api.grpc" % "proto-google-cloud-bigquerystorage-v1" % "1.22.0" % "protobuf-src",
       "org.apache.avro" % "avro" % AvroVersion % "provided",
-      "org.apache.arrow" % "arrow-vector" % "4.0.0" % "provided",
+      "org.apache.arrow" % "arrow-vector" % "4.0.1" % "provided",
       "io.grpc" % "grpc-auth" % org.apache.pekko.grpc.gen.BuildInfo.grpcVersion,
       "com.google.protobuf" % "protobuf-java" % protobufJavaVersion,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,
@@ -344,7 +344,7 @@ object Dependencies {
   val MongoDb = Seq(
     crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
-      "org.mongodb.scala" %% "mongo-scala-driver" % "4.4.0"))
+      "org.mongodb.scala" %% "mongo-scala-driver" % "4.4.2"))
 
   val Mqtt = Seq(
     libraryDependencies ++= Seq(
@@ -455,8 +455,8 @@ object Dependencies {
 
   val UnixDomainSocket = Seq(
     libraryDependencies ++= Seq(
-      "com.github.jnr" % "jffi" % "1.3.1", // classifier "complete", // Is the classifier needed anymore?
-      "com.github.jnr" % "jnr-unixsocket" % "0.38.5"))
+      "com.github.jnr" % "jffi" % "1.3.13", // classifier "complete", // Is the classifier needed anymore?
+      "com.github.jnr" % "jnr-unixsocket" % "0.38.22"))
 
   val Xml = Seq(
     libraryDependencies ++= Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,7 +26,7 @@ object Dependencies {
   val InfluxDBJavaVersion = "2.15"
 
   val AvroVersion = "1.11.4"
-  val AwsSdk2Version = "2.17.113"
+  val AwsSdk2Version = "2.17.295"
   val AwsSpiPekkoHttpVersion = "0.1.1"
   val NettyVersion = "4.1.113.Final"
   // Sync with plugins.sbt
@@ -194,7 +194,7 @@ object Dependencies {
       Seq(
         "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % JacksonDatabindVersion,
         "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonDatabindVersion,
-        "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.17.1" % Test) ++ JacksonDatabindDependencies ++
+        "org.apache.logging.log4j" % "log4j-to-slf4j" % "2.17.2" % Test) ++ JacksonDatabindDependencies ++
       (if (isScala3.value)
          Seq.empty // Equivalent and relevant shapeless functionality has been mainlined into Scala 3 language/stdlib
        else Seq(
@@ -321,7 +321,7 @@ object Dependencies {
 
   val JsonStreaming = Seq(
     libraryDependencies ++= Seq(
-      "com.github.jsurfer" % "jsurfer-jackson" % "1.6.0") ++ JacksonDatabindDependencies)
+      "com.github.jsurfer" % "jsurfer-jackson" % "1.6.5") ++ JacksonDatabindDependencies)
 
   val Kinesis = Seq(
     libraryDependencies ++= Seq(
@@ -330,7 +330,7 @@ object Dependencies {
         organization = "org.apache.pekko"))) ++ Seq(
       "software.amazon.awssdk" % "kinesis" % AwsSdk2Version,
       "software.amazon.awssdk" % "firehose" % AwsSdk2Version,
-      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.0").map(
+      "software.amazon.kinesis" % "amazon-kinesis-client" % "2.4.8").map(
       _.excludeAll(
         ExclusionRule("software.amazon.awssdk", "apache-client"),
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Mockito)
@@ -390,8 +390,8 @@ object Dependencies {
       "org.scalatestplus" %% scalaTestScalaCheckArtifact % scalaTestScalaCheckVersion % Test))
 
   val SpringWeb = {
-    val SpringVersion = "5.1.17.RELEASE"
-    val SpringBootVersion = "2.1.16.RELEASE"
+    val SpringVersion = "5.1.20.RELEASE"
+    val SpringBootVersion = "2.1.18.RELEASE"
     Seq(
       libraryDependencies ++= Seq(
         "org.springframework" % "spring-core" % SpringVersion,

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.0.2"
+  override val currentVersion: String = "1.0.3"
 }

--- a/project/PekkoHttpDependency.scala
+++ b/project/PekkoHttpDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoHttpDependency extends PekkoDependency {
   override val checkProject: String = "pekko-http-testkit"
   override val module: Option[String] = Some("http")
-  override val currentVersion: String = "1.0.0"
+  override val currentVersion: String = "1.0.1"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.7
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,14 +9,14 @@
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.3")
 addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
-addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.31")
-addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.11")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.3")
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
+addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.3.4")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 // discipline
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.3")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
 addSbtPlugin("com.lightbend.sbt" % "sbt-java-formatter" % "0.7.0")
 
 // docs


### PR DESCRIPTION
* Latest 1.0.x pekko releases
* upgrade some sbt plugins
* some minor bumps in other dependencies (just looking at patch level version bumps)

I got these suggestions from sbt-updates plugin
```
[info] No dependency updates found for pekko-connectors-root
[info] Found 2 dependency updates for pekko-connectors-reference
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 5 dependency updates for pekko-connectors-doc-examples
[info]   org.apache.pekko:pekko-slf4j               : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.apache.pekko:pekko-stream              : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.apache.pekko:pekko-stream-testkit:test : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library               : 2.13.13 -> 2.13.14         
[info]   org.scalatest:scalatest:test               : 3.2.14  -> 3.2.19          
[info] Found 7 dependency updates for pekko-connectors-elasticsearch
[info]   com.fasterxml.jackson.core:jackson-core     : 2.14.3             -> 2.17.2          
[info]   com.fasterxml.jackson.core:jackson-databind : 2.14.3             -> 2.17.2          
[info]   org.apache.pekko:pekko-http                 : 1.0.0   -> 1.0.1                      
[info]   org.apache.pekko:pekko-http-spray-json      : 1.0.0   -> 1.0.1                      
[info]   org.apache.pekko:pekko-stream               : 1.0.2   -> 1.0.3   -> 1.1.0           
[info]   org.scala-lang:scala-library                : 2.13.13 -> 2.13.14                    
[info]   org.slf4j:jcl-over-slf4j:test               : 1.7.36                       -> 2.0.16
[info] Found 5 dependency updates for pekko-connectors-json-streaming
[info]   com.fasterxml.jackson.core:jackson-core     : 2.14.3             -> 2.17.2
[info]   com.fasterxml.jackson.core:jackson-databind : 2.14.3             -> 2.17.2
[info]   com.github.jsurfer:jsurfer-jackson          : 1.6.0   -> 1.6.5            
[info]   org.apache.pekko:pekko-stream               : 1.0.2   -> 1.0.3   -> 1.1.0 
[info]   org.scala-lang:scala-library                : 2.13.13 -> 2.13.14          
[info] Found 6 dependency updates for pekko-connectors-orientdb
[info]   com.fasterxml.jackson.core:jackson-core     : 2.14.3             -> 2.17.2
[info]   com.fasterxml.jackson.core:jackson-databind : 2.14.3             -> 2.17.2
[info]   com.orientechnologies:orientdb-graphdb      : 3.1.20             -> 3.2.33
[info]   com.orientechnologies:orientdb-object       : 3.1.20             -> 3.2.33
[info]   org.apache.pekko:pekko-stream               : 1.0.2   -> 1.0.3   -> 1.1.0 
[info]   org.scala-lang:scala-library                : 2.13.13 -> 2.13.14          
[info] Found 4 dependency updates for pekko-connectors-sse
[info]   org.apache.pekko:pekko-http              : 1.0.0   -> 1.0.1           
[info]   org.apache.pekko:pekko-http-testkit:test : 1.0.0   -> 1.0.1           
[info]   org.apache.pekko:pekko-stream            : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library             : 2.13.13 -> 2.13.14         
[info] Found 3 dependency updates for pekko-connectors-xml
[info]   com.fasterxml:aalto-xml       : 1.2.2              -> 1.3.3
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 3 dependency updates for pekko-connectors-influxdb
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.influxdb:influxdb-java    : 2.15               -> 2.24 
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 7 dependency updates for pekko-connectors-hbase
[info]   org.apache.hadoop:hadoop-common                : 2.7.7              -> 2.10.2 -> 3.4.0 
[info]   org.apache.hadoop:hadoop-mapreduce-client-core : 2.7.7              -> 2.10.2 -> 3.4.0 
[info]   org.apache.hbase:hbase-common                  : 1.4.13  -> 1.4.14  -> 1.7.2  -> 2.6.0 
[info]   org.apache.hbase:hbase-shaded-client           : 1.4.13  -> 1.4.14  -> 1.7.2  -> 2.6.0 
[info]   org.apache.pekko:pekko-stream                  : 1.0.2   -> 1.0.3   -> 1.1.0           
[info]   org.scala-lang:scala-library                   : 2.13.13 -> 2.13.14                    
[info]   org.slf4j:log4j-over-slf4j:test                : 1.7.36                       -> 2.0.16
[info] Found 2 dependency updates for pekko-connectors-simple-codecs
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 5 dependency updates for pekko-connectors-solr
[info]   org.apache.pekko:pekko-stream            : 1.0.2   -> 1.0.3   -> 1.1.0          
[info]   org.apache.solr:solr-solrj               : 7.7.3                       -> 9.7.0 
[info]   org.apache.solr:solr-test-framework:test : 7.7.3                       -> 9.7.0 
[info]   org.scala-lang:scala-library             : 2.13.13 -> 2.13.14                   
[info]   org.slf4j:log4j-over-slf4j:test          : 1.7.36                      -> 2.0.16
[info] Found 3 dependency updates for pekko-connectors-ironmq
[info]   org.apache.pekko:pekko-http   : 1.0.0   -> 1.0.1           
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 5 dependency updates for pekko-connectors-amqp
[info]   com.rabbitmq:amqp-client           : 5.14.2   -> 5.14.3   -> 5.21.0          
[info]   org.apache.pekko:pekko-stream      : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test      : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library       : 2.13.13  -> 2.13.14                     
[info]   org.scalatestplus:mockito-4-6:test : 3.2.14.0 -> 3.2.15.0                    
[info] Found 3 dependency updates for pekko-connectors-azure-storage-queue
[info]   com.microsoft.azure:azure-storage : 8.0.0              -> 8.6.6
[info]   org.apache.pekko:pekko-stream     : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library      : 2.13.13 -> 2.13.14         
[info] Found 5 dependency updates for pekko-connectors-dynamodb
[info]   com.github.pjfanning:aws-spi-pekko-http : 0.1.0    -> 0.1.1              
[info]   org.apache.pekko:pekko-http             : 1.0.0    -> 1.0.1              
[info]   org.apache.pekko:pekko-stream           : 1.0.2    -> 1.0.3    -> 1.1.0  
[info]   org.scala-lang:scala-library            : 2.13.13  -> 2.13.14            
[info]   software.amazon.awssdk:dynamodb         : 2.17.113 -> 2.17.295 -> 2.27.24
[info] Found 7 dependency updates for pekko-connectors-sns
[info]   com.github.pjfanning:aws-spi-pekko-http : 0.1.0    -> 0.1.1                        
[info]   org.apache.pekko:pekko-http             : 1.0.0    -> 1.0.1                        
[info]   org.apache.pekko:pekko-stream           : 1.0.2    -> 1.0.3    -> 1.1.0            
[info]   org.mockito:mockito-core:test           : 4.2.0                -> 4.11.0  -> 5.13.0
[info]   org.scala-lang:scala-library            : 2.13.13  -> 2.13.14                      
[info]   org.scalatestplus:mockito-4-6:test      : 3.2.14.0 -> 3.2.15.0                     
[info]   software.amazon.awssdk:sns              : 2.17.113 -> 2.17.295 -> 2.27.24          
[info] Found 7 dependency updates for pekko-connectors-cassandra
[info]   com.datastax.oss:java-driver-core           : 4.15.0                         -> 4.17.0
[info]   com.fasterxml.jackson.core:jackson-core     : 2.14.3                         -> 2.17.2
[info]   com.fasterxml.jackson.core:jackson-databind : 2.14.3                         -> 2.17.2
[info]   io.netty:netty-handler                      : 4.1.104.Final -> 4.1.113.Final          
[info]   org.apache.pekko:pekko-discovery:provided   : 1.0.2         -> 1.0.3         -> 1.1.0 
[info]   org.apache.pekko:pekko-stream               : 1.0.2         -> 1.0.3         -> 1.1.0 
[info]   org.scala-lang:scala-library                : 2.13.13       -> 2.13.14                
[info] Found 9 dependency updates for pekko-connectors-kinesis
[info]   com.github.pjfanning:aws-spi-pekko-http       : 0.1.0    -> 0.1.1                        
[info]   org.apache.pekko:pekko-http                   : 1.0.0    -> 1.0.1                        
[info]   org.apache.pekko:pekko-stream                 : 1.0.2    -> 1.0.3    -> 1.1.0            
[info]   org.mockito:mockito-core:test                 : 4.2.0                -> 4.11.0  -> 5.13.0
[info]   org.scala-lang:scala-library                  : 2.13.13  -> 2.13.14                      
[info]   org.scalatestplus:mockito-4-6:test            : 3.2.14.0 -> 3.2.15.0                     
[info]   software.amazon.awssdk:firehose               : 2.17.113 -> 2.17.295 -> 2.27.24          
[info]   software.amazon.awssdk:kinesis                : 2.17.113 -> 2.17.295 -> 2.27.24          
[info]   software.amazon.kinesis:amazon-kinesis-client : 2.4.0    -> 2.4.8    -> 2.6.0            
[info] Found 6 dependency updates for pekko-connectors-mqtt-streaming
[info]   org.apache.pekko:pekko-actor-testkit-typed:test : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.apache.pekko:pekko-actor-typed              : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.apache.pekko:pekko-stream                   : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.apache.pekko:pekko-stream-testkit:test      : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.apache.pekko:pekko-stream-typed             : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library                    : 2.13.13 -> 2.13.14         
[info] Found 7 dependency updates for pekko-connectors-jms
[info]   com.ibm.mq:com.ibm.mq.allclient:test     : 9.2.5.0              -> 9.4.0.5          
[info]   org.apache.activemq:activemq-broker:test : 5.16.4   -> 5.16.7   -> 5.18.5  -> 6.1.3 
[info]   org.apache.activemq:activemq-client:test : 5.16.4   -> 5.16.7   -> 5.18.5  -> 6.1.3 
[info]   org.apache.pekko:pekko-stream            : 1.0.2    -> 1.0.3    -> 1.1.0            
[info]   org.mockito:mockito-core:test            : 4.2.0                -> 4.11.0  -> 5.13.0
[info]   org.scala-lang:scala-library             : 2.13.13  -> 2.13.14                      
[info]   org.scalatestplus:mockito-4-6:test       : 3.2.14.0 -> 3.2.15.0                     
[info] Found 3 dependency updates for pekko-connectors-file
[info]   com.google.jimfs:jimfs:test   : 1.2                -> 1.3.0
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 4 dependency updates for pekko-connectors-pravega
[info]   io.pravega:pravega-client       : 0.10.2             -> 0.13.0          
[info]   org.apache.pekko:pekko-stream   : 1.0.2   -> 1.0.3   -> 1.1.0           
[info]   org.scala-lang:scala-library    : 2.13.13 -> 2.13.14                    
[info]   org.slf4j:log4j-over-slf4j:test : 1.7.36                       -> 2.0.16
[info] Found 6 dependency updates for pekko-connectors-ftp
[info]   ch.qos.logback:logback-classic:test : 1.3.14               -> 1.5.8                    
[info]   commons-net:commons-net             : 3.8.0                -> 3.11.1 -> 20030805.205232
[info]   org.apache.pekko:pekko-stream       : 1.0.2    -> 1.0.3    -> 1.1.0                    
[info]   org.mockito:mockito-core:test       : 4.2.0                -> 4.11.0 -> 5.13.0         
[info]   org.scala-lang:scala-library        : 2.13.13  -> 2.13.14                              
[info]   org.scalatestplus:mockito-4-6:test  : 3.2.14.0 -> 3.2.15.0                             
[info] Found 7 dependency updates for pekko-connectors-awslambda
[info]   com.github.pjfanning:aws-spi-pekko-http : 0.1.0    -> 0.1.1                        
[info]   org.apache.pekko:pekko-http             : 1.0.0    -> 1.0.1                        
[info]   org.apache.pekko:pekko-stream           : 1.0.2    -> 1.0.3    -> 1.1.0            
[info]   org.mockito:mockito-core:test           : 4.2.0                -> 4.11.0  -> 5.13.0
[info]   org.scala-lang:scala-library            : 2.13.13  -> 2.13.14                      
[info]   org.scalatestplus:mockito-4-6:test      : 3.2.14.0 -> 3.2.15.0                     
[info]   software.amazon.awssdk:lambda           : 2.17.113 -> 2.17.295 -> 2.27.24          
[info] Found 2 dependency updates for pekko-connectors-csv
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 4 dependency updates for pekko-connectors-kudu
[info]   org.apache.kudu:kudu-client-tools : 1.7.1              -> 1.14.0
[info]   org.apache.kudu:kudu-client:test  : 1.7.1              -> 1.17.0
[info]   org.apache.pekko:pekko-stream     : 1.0.2   -> 1.0.3   -> 1.1.0 
[info]   org.scala-lang:scala-library      : 2.13.13 -> 2.13.14          
[info] Found 7 dependency updates for pekko-connectors-couchbase
[info]   com.couchbase.client:java-client                       : 2.7.16  -> 2.7.23            -> 3.7.2
[info]   com.fasterxml.jackson.core:jackson-databind:test       : 2.14.3             -> 2.17.2         
[info]   com.fasterxml.jackson.module:jackson-module-scala:test : 2.14.3             -> 2.17.2         
[info]   org.apache.pekko:pekko-discovery:provided              : 1.0.2   -> 1.0.3   -> 1.1.0          
[info]   org.apache.pekko:pekko-http:test                       : 1.0.0   -> 1.0.1                     
[info]   org.apache.pekko:pekko-stream                          : 1.0.2   -> 1.0.3   -> 1.1.0          
[info]   org.scala-lang:scala-library                           : 2.13.13 -> 2.13.14                   
[info] Found 7 dependency updates for pekko-connectors-spring-web
[info]   org.apache.pekko:pekko-stream                                         : 1.0.2          -> 1.0.3          -> 1.1.0           
[info]   org.scala-lang:scala-library                                          : 2.13.13        -> 2.13.14                           
[info]   org.springframework.boot:spring-boot-autoconfigure                    : 2.1.16.RELEASE -> 2.1.18.RELEASE -> 2.7.18 -> 3.3.3 
[info]   org.springframework.boot:spring-boot-configuration-processor:optional : 2.1.16.RELEASE -> 2.1.18.RELEASE -> 2.7.18 -> 3.3.3 
[info]   org.springframework.boot:spring-boot-starter-web:test                 : 2.1.16.RELEASE -> 2.1.18.RELEASE -> 2.7.18 -> 3.3.3 
[info]   org.springframework:spring-context                                    : 5.1.17.RELEASE -> 5.1.20.RELEASE -> 5.3.39 -> 6.1.13
[info]   org.springframework:spring-core                                       : 5.1.17.RELEASE -> 5.1.20.RELEASE -> 5.3.39 -> 6.1.13
[info] Found 7 dependency updates for pekko-connectors-aws-event-bridge
[info]   com.github.pjfanning:aws-spi-pekko-http : 0.1.0    -> 0.1.1                        
[info]   org.apache.pekko:pekko-http             : 1.0.0    -> 1.0.1                        
[info]   org.apache.pekko:pekko-stream           : 1.0.2    -> 1.0.3    -> 1.1.0            
[info]   org.mockito:mockito-core:test           : 4.2.0                -> 4.11.0  -> 5.13.0
[info]   org.scala-lang:scala-library            : 2.13.13  -> 2.13.14                      
[info]   org.scalatestplus:mockito-4-6:test      : 3.2.14.0 -> 3.2.15.0                     
[info]   software.amazon.awssdk:eventbridge      : 2.17.113 -> 2.17.295 -> 2.27.24          
[info] Found 2 dependency updates for pekko-connectors-udp
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 9 dependency updates for pekko-connectors-avroparquet
[info]   org.apache.avro:avro                 : 1.11.3  -> 1.11.4  -> 1.12.0          
[info]   org.apache.hadoop:hadoop-client:test : 3.2.1   -> 3.2.4   -> 3.4.0           
[info]   org.apache.hadoop:hadoop-common:test : 3.2.1   -> 3.2.4   -> 3.4.0           
[info]   org.apache.parquet:parquet-avro      : 1.13.1             -> 1.14.2          
[info]   org.apache.pekko:pekko-stream        : 1.0.2   -> 1.0.3   -> 1.1.0           
[info]   org.scala-lang:scala-library         : 2.13.13 -> 2.13.14                    
[info]   org.scalacheck:scalacheck:test       : 1.16.0             -> 1.18.0          
[info]   org.slf4j:log4j-over-slf4j:test      : 1.7.36                       -> 2.0.16
[info]   org.specs2:specs2-core:test          : 4.20.0  -> 4.20.8                     
[info] Found 7 dependency updates for pekko-connectors-huawei-push-kit
[info]   com.github.jwt-scala:jwt-json-common   : 7.1.5                          -> 10.0.1
[info]   org.apache.pekko:pekko-http            : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-spray-json : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream          : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test          : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library           : 2.13.13  -> 2.13.14                     
[info]   org.scalatestplus:mockito-4-6:test     : 3.2.14.0 -> 3.2.15.0                    
[info] Found 9 dependency updates for pekko-connectors-google-common
[info]   com.github.jwt-scala:jwt-json-common            : 7.1.5                          -> 10.0.1
[info]   com.google.auth:google-auth-library-credentials : 1.20.0               -> 1.25.0          
[info]   io.specto:hoverfly-java:test                    : 0.14.1   -> 0.14.4   -> 0.19.1          
[info]   org.apache.pekko:pekko-http                     : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-spray-json          : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream                   : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test                   : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library                    : 2.13.13  -> 2.13.14                     
[info]   org.scalatestplus:mockito-4-6:test              : 3.2.14.0 -> 3.2.15.0                    
[info] Found 3 dependency updates for pekko-connectors-mongodb
[info]   org.apache.pekko:pekko-stream        : 1.0.2   -> 1.0.3   -> 1.1.0          
[info]   org.mongodb.scala:mongo-scala-driver : 4.4.0   -> 4.4.2   -> 4.11.4 -> 5.1.4
[info]   org.scala-lang:scala-library         : 2.13.13 -> 2.13.14                   
[info] Found 2 dependency updates for pekko-connectors-text
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 4 dependency updates for pekko-connectors-unix-domain-socket
[info]   com.github.jnr:jffi           : 1.3.1   -> 1.3.13          
[info]   com.github.jnr:jnr-unixsocket : 0.38.5  -> 0.38.22         
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 7 dependency updates for pekko-connectors-google-cloud-storage
[info]   io.specto:hoverfly-java:test           : 0.14.1   -> 0.14.4   -> 0.19.1          
[info]   org.apache.pekko:pekko-http            : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-spray-json : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream          : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test          : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library           : 2.13.13  -> 2.13.14                     
[info]   org.scalatestplus:mockito-4-6:test     : 3.2.14.0 -> 3.2.15.0                    
[info] Found 5 dependency updates for pekko-connectors-slick
[info]   com.h2database:h2:test            : 2.1.210 -> 2.1.214 -> 2.3.232
[info]   com.typesafe.slick:slick          : 3.3.3              -> 3.5.1  
[info]   com.typesafe.slick:slick-hikaricp : 3.3.3              -> 3.5.1  
[info]   org.apache.pekko:pekko-stream     : 1.0.2   -> 1.0.3   -> 1.1.0  
[info]   org.scala-lang:scala-library      : 2.13.13 -> 2.13.14           
[info] Found 2 dependency updates for pekko-connectors-mqtt
[info]   org.apache.pekko:pekko-stream : 1.0.2   -> 1.0.3   -> 1.1.0
[info]   org.scala-lang:scala-library  : 2.13.13 -> 2.13.14         
[info] Found 8 dependency updates for pekko-connectors-s3
[info]   com.github.tomakehurst:wiremock-jre8:test : 2.32.0               -> 2.35.2  -> 3.0.1
[info]   com.google.jimfs:jimfs:test               : 1.2                  -> 1.3.0           
[info]   org.apache.pekko:pekko-http               : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-xml           : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream             : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.scala-lang:scala-library              : 2.13.13  -> 2.13.14                     
[info]   org.scalacheck:scalacheck:test            : 1.16.0               -> 1.18.0          
[info]   software.amazon.awssdk:auth               : 2.17.113 -> 2.17.295 -> 2.27.24         
[info] Found 6 dependency updates for pekko-connectors-google-fcm
[info]   org.apache.pekko:pekko-http            : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-spray-json : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream          : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test          : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library           : 2.13.13  -> 2.13.14                     
[info]   org.scalatestplus:mockito-4-6:test     : 3.2.14.0 -> 3.2.15.0                    
[info] Found 8 dependency updates for pekko-connectors-hdfs
[info]   org.apache.hadoop:hadoop-client           : 3.2.1   -> 3.2.4   -> 3.4.0           
[info]   org.apache.hadoop:hadoop-common:test      : 3.2.1   -> 3.2.4   -> 3.4.0           
[info]   org.apache.hadoop:hadoop-hdfs:test        : 3.2.1   -> 3.2.4   -> 3.4.0           
[info]   org.apache.hadoop:hadoop-minicluster:test : 3.2.1   -> 3.2.4   -> 3.4.0           
[info]   org.apache.pekko:pekko-stream             : 1.0.2   -> 1.0.3   -> 1.1.0           
[info]   org.scala-lang:scala-library              : 2.13.13 -> 2.13.14                    
[info]   org.slf4j:log4j-over-slf4j:test           : 1.7.36                       -> 2.0.16
[info]   org.typelevel:cats-core                   : 2.9.0              -> 2.12.0          
[info] Found 7 dependency updates for pekko-connectors-google-cloud-pub-sub
[info]   com.github.tomakehurst:wiremock:test   : 2.27.2                         -> 3.0.1 
[info]   org.apache.pekko:pekko-http            : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-spray-json : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream          : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test          : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library           : 2.13.13  -> 2.13.14                     
[info]   org.scalatestplus:mockito-4-6:test     : 3.2.14.0 -> 3.2.15.0                    
[info] Found 7 dependency updates for pekko-connectors-google-cloud-pub-sub-grpc
[info]   com.google.auth:google-auth-library-oauth2-http   : 1.20.0             -> 1.25.0           
[info]   com.google.cloud:google-cloud-pubsub:protobuf-src : 1.112.5            -> 1.132.2          
[info]   com.google.protobuf:protobuf-java                 : 3.21.12            -> 3.25.4  -> 4.28.1
[info]   io.grpc:grpc-auth                                 : 1.54.2             -> 1.66.0           
[info]   org.apache.pekko:pekko-discovery                  : 1.0.2   -> 1.0.3   -> 1.1.0            
[info]   org.apache.pekko:pekko-stream                     : 1.0.2   -> 1.0.3   -> 1.1.0            
[info]   org.scala-lang:scala-library                      : 2.13.13 -> 2.13.14                     
[info] Found 9 dependency updates for pekko-connectors-geode
[info]   com.fasterxml.jackson.core:jackson-core                : 2.14.3             -> 2.17.2
[info]   com.fasterxml.jackson.core:jackson-databind            : 2.14.3             -> 2.17.2
[info]   com.fasterxml.jackson.datatype:jackson-datatype-joda   : 2.14.3             -> 2.17.2
[info]   com.fasterxml.jackson.datatype:jackson-datatype-jsr310 : 2.14.3             -> 2.17.2
[info]   org.apache.geode:geode-core                            : 1.15.0  -> 1.15.1           
[info]   org.apache.geode:geode-cq                              : 1.15.0  -> 1.15.1           
[info]   org.apache.logging.log4j:log4j-to-slf4j:test           : 2.17.1  -> 2.17.2  -> 2.24.0
[info]   org.apache.pekko:pekko-stream                          : 1.0.2   -> 1.0.3   -> 1.1.0 
[info]   org.scala-lang:scala-library                           : 2.13.13 -> 2.13.14          
[info] Found 8 dependency updates for pekko-connectors-sqs
[info]   com.github.pjfanning:aws-spi-pekko-http : 0.1.0    -> 0.1.1                        
[info]   org.apache.pekko:pekko-http             : 1.0.0    -> 1.0.1                        
[info]   org.apache.pekko:pekko-stream           : 1.0.2    -> 1.0.3    -> 1.1.0            
[info]   org.mockito:mockito-core:test           : 4.2.0                -> 4.11.0  -> 5.13.0
[info]   org.mockito:mockito-inline:test         : 4.2.0                -> 4.11.0  -> 5.2.0 
[info]   org.scala-lang:scala-library            : 2.13.13  -> 2.13.14                      
[info]   org.scalatestplus:mockito-4-6:test      : 3.2.14.0 -> 3.2.15.0                     
[info]   software.amazon.awssdk:sqs              : 2.17.113 -> 2.17.295 -> 2.27.24          
[info] Found 10 dependency updates for pekko-connectors-google-cloud-bigquery
[info]   com.fasterxml.jackson.core:jackson-annotations              : 2.14.3               -> 2.17.2          
[info]   com.fasterxml.jackson.datatype:jackson-datatype-jsr310:test : 2.14.3               -> 2.17.2          
[info]   io.specto:hoverfly-java:test                                : 0.14.1   -> 0.14.4   -> 0.19.1          
[info]   org.apache.pekko:pekko-http                                 : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-jackson:provided                : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-spray-json                      : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream                               : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test                               : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library                                : 2.13.13  -> 2.13.14                     
[info] Found 15 dependency updates for pekko-connectors-google-cloud-bigquery-storage
[info]   com.google.api.grpc:proto-google-cloud-bigquerystorage-v1:protobuf-src : 1.22.0   -> 1.22.8   -> 1.23.2 -> 3.9.1 
[info]   com.google.protobuf:protobuf-java                                      : 3.21.12              -> 3.25.4 -> 4.28.1
[info]   io.grpc:grpc-auth                                                      : 1.54.2               -> 1.66.0          
[info]   org.scalatestplus:mockito-4-6:test                          : 3.2.14.0 -> 3.2.15.0                    
[info]   org.apache.arrow:arrow-memory-netty:test                               : 4.0.1                          -> 17.0.0
[info]   org.apache.arrow:arrow-vector:provided                                 : 4.0.0    -> 4.0.1              -> 17.0.0
[info]   org.apache.avro:avro:provided                                          : 1.11.3   -> 1.11.4   -> 1.12.0          
[info]   org.apache.pekko:pekko-discovery                                       : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.apache.pekko:pekko-http                                            : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-core                                       : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-http-spray-json                                 : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-parsing                                         : 1.0.0    -> 1.0.1                       
[info]   org.apache.pekko:pekko-stream                                          : 1.0.2    -> 1.0.3    -> 1.1.0           
[info]   org.mockito:mockito-core:test                                          : 4.2.0                -> 4.11.0 -> 5.13.0
[info]   org.scala-lang:scala-library                                           : 2.13.13  -> 2.13.14                     
[info]   org.scalatestplus:mockito-4-6:test                                     : 3.2.14.0 -> 3.2.15.0                    
[success] Total time: 17 s, completed 12 Sep 2024, 15:21:12
```