### PR TITLE
don't use 'current' for doc links

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -392,7 +392,7 @@ lazy val docs = project
       "hadoop.version" -> Dependencies.HadoopVersion,
       "extref.github.base_url" -> s"https://github.com/apache/pekko-connectors/tree/${if (isSnapshot.value) "main"
         else "v" + version.value}/%s",
-      "extref.pekko.base_url" -> s"https://pekko.apache.org/docs/pekko/current/%s",
+      "extref.pekko.base_url" -> s"https://pekko.apache.org/docs/pekko/${Dependencies.PekkoBinaryVersion}/%s",
       "scaladoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/api/pekko/${Dependencies.PekkoBinaryVersion}",
       "javadoc.org.apache.pekko.base_url" -> s"https://pekko.apache.org/japi/pekko/${Dependencies.PekkoBinaryVersion}/",
       "javadoc.org.apache.pekko.link_style" -> "direct",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,7 +21,7 @@ object Dependencies {
   val ScalaVersions = Seq(Scala213, Scala212, Scala3)
 
   val PekkoVersion = PekkoCoreDependency.version
-  val PekkoBinaryVersion = PekkoVersion.take(3)
+  val PekkoBinaryVersion = PekkoCoreDependency.default.link
 
   val InfluxDBJavaVersion = "2.23"
 
@@ -32,7 +32,7 @@ object Dependencies {
   val PekkoGrpcBinaryVersion = "1.1"
   val PekkoHttpVersion = PekkoHttpDependency.version
   val PekkoStreamsCirceVersion = "1.1.0"
-  val PekkoHttpBinaryVersion = PekkoHttpVersion.take(3)
+  val PekkoHttpBinaryVersion = PekkoHttpDependency.default.link
   val ScalaTestVersion = "3.2.19"
   val TestContainersScalaTestVersion = "0.41.4"
   val mockitoVersion = "4.11.0" // check even https://github.com/scalatest/scalatestplus-mockito/releases

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
   val PekkoGrpcBinaryVersion = "1.1"
   val PekkoHttpVersion = PekkoHttpDependency.version
   val PekkoStreamsCirceVersion = "1.1.0"
-  val PekkoHttpBinaryVersion = "1.0"
+  val PekkoHttpBinaryVersion = PekkoHttpVersion.take(3)
   val ScalaTestVersion = "3.2.19"
   val TestContainersScalaTestVersion = "0.41.4"
   val mockitoVersion = "4.11.0" // check even https://github.com/scalatest/scalatestplus-mockito/releases


### PR DESCRIPTION
* the main branch is intended for 1.1 release and is best to direct specifically to 1.1 docs of other pekko modules
* I intend to backport this to 1.0 branch because that branch needs to direct towards 1.0 versions of other pekko module docs