### PR TITLE
Set current version to latest 1.0.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,6 +22,7 @@ object Dependencies {
 
   val PekkoVersion = PekkoCoreDependency.version
   val PekkoBinaryVersion = PekkoVersion.take(3)
+  val PekkoConnectorsKafkaVersion = "1.0.0"
 
   val InfluxDBJavaVersion = "2.23"
 
@@ -189,7 +190,7 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-slf4j" % PekkoVersion,
       "org.apache.pekko" %% "pekko-stream-testkit" % PekkoVersion % Test,
-      "org.apache.pekko" %% "pekko-connectors-kafka" % "1.1.0-M1" % Test,
+      "org.apache.pekko" %% "pekko-connectors-kafka" % PekkoConnectorsKafkaVersion % Test,
       "junit" % "junit" % "4.13.2" % Test,
       "org.scalatest" %% "scalatest" % ScalaTestVersion % Test))
 

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.1.1"
+  override val currentVersion: String = "1.0.3"
 }

--- a/project/PekkoHttpDependency.scala
+++ b/project/PekkoHttpDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoHttpDependency extends PekkoDependency {
   override val checkProject: String = "pekko-http-testkit"
   override val module: Option[String] = Some("http")
-  override val currentVersion: String = "1.1.0-M1"
+  override val currentVersion: String = "1.0.1"
 }


### PR DESCRIPTION
Currently the Pekko artifacts/snapshots are broken, here are the stats from today

```
latest = 1.1.0-M1+65-53ed673e-SNAPSHOT (not working)
2 days = 1.1.0-M1+64-600516f4-SNAPSHOT (not working)
3 days = 1.1.0-M1+58-20bcdd5f-SNAPSHOT (working)
4 days = 1.1.0-M1+57-eb3ae265-SNAPSHOT (working)
one week = 1.1.0-M1+56-67d9adfa-SNAPSHOT (working)
```

The commit which broke the changes is https://github.com/apache/pekko-connectors/pull/801. The issue here is if you set `currentVersion` to some version, that is actually setting the minimum bound. More specifically, at work I had my pekko core version still set to 1.1.0 but if I set pekko-connectors to a not working snapshot (lets say `1.1.0-M1+65-53ed673e-SNAPSHOT`) then it would fail with class not found errors.

This is because Pekko is doing a check on the major/minor version, so we have to use the latest 1.0.x version.