### PR TITLE
configure aws-spi-pekko-http integration tests in nightly builds

### DIFF
--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -56,12 +56,14 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 
-      - name: S3 Integration tests
+      - name: AWS connectors Integration tests
+        env:
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
         run:  |-
           sbt \
-          -Dpekko.connectors.s3.aws.credentials.provider=static \
-          -Dpekko.connectors.s3.aws.credentials.access-key-id=${{ secrets.AWS_ACCESS_KEY }} \
-          -Dpekko.connectors.s3.aws.credentials.secret-access-key=${{ secrets.AWS_SECRET_KEY }} \
           -Dpekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec.enableListAllMyBucketsTests=false \
           -Dpekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec.enableMFATests=false \
           + "s3/Test/runMain org.scalatest.tools.Runner -o -s org.apache.pekko.stream.connectors.s3.scaladsl.AWSS3IntegrationSpec"
+          sbt \
+          + "aws-spi-pekko-http/it:test"


### PR DESCRIPTION
As discussed in https://github.com/apache/pekko-connectors/pull/827#issuecomment-2375129573, this PR configures `aws-spi-pekko-http` integration tests.

I understand that S3 module integration tests are setup in a different way (using `@DoNotDiscover` and explicitly calling `org.scalatest.tools.Runner`) , but I don't want to touch for now.

I changed the way credentials are passed to use environment variables. I did this, because for the `aws-spi-pekko-http` tests the credentials cannot be configured using JVM system properties, but both tests support environment variables as part of the default credential provider.