### PR TITLE
remove snapshot resolver

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,6 @@ import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCh
 
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := false
-ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 


### PR DESCRIPTION
You can test pekko snapshots still by using the [sbt-pekko-build](https://github.com/pjfanning/sbt-pekko-build) system properties 