### PR TITLE
Revert "remove snapshot resolver"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,6 +11,7 @@ import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCh
 
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := false
+ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 


### PR DESCRIPTION
Reverts apache/pekko-connectors#875

This broke https://github.com/apache/pekko-connectors/actions/runs/11528373543/job/32095426830

Looks like sbt-pekko-build only adds the snapshot resolver implicitly if you use addPekkoModuleDependency

The PR that tried to do that was running into build issues that I don't yet have a cause for. https://github.com/apache/pekko-connectors/pull/860