### PR TITLE
[WIP] try to support building some connectors with a min of java 11 or 17

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -88,6 +88,13 @@ object Common extends AutoPlugin {
       }
     },
     Compile / doc / scalacOptions -= "-Werror",
+    compile / javacOptions ++= {
+      if (JdkOptions.isJdk8) {
+        Seq.empty
+      } else {
+        Seq("--release", "8")
+      }
+    },
     compile / javacOptions ++= Seq(
       "-Xlint:cast",
       "-Xlint:deprecation",

--- a/project/JdkOptions.scala
+++ b/project/JdkOptions.scala
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2022 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+import java.io.File
+
+import sbt._
+import sbt.librarymanagement.SemanticSelector
+import sbt.librarymanagement.VersionNumber
+
+object JdkOptions extends AutoPlugin {
+
+  lazy val specificationVersion: String = sys.props("java.specification.version")
+
+  lazy val isJdk8: Boolean =
+    VersionNumber(specificationVersion).matchesSemVer(SemanticSelector(s"=1.8"))
+  lazy val isJdk11orHigher: Boolean =
+    VersionNumber(specificationVersion).matchesSemVer(SemanticSelector(">=11"))
+  lazy val isJdk17orHigher: Boolean =
+    VersionNumber(specificationVersion).matchesSemVer(SemanticSelector(">=17"))
+
+}


### PR DESCRIPTION
* Some of our jar dependencies no longer support Java 8 (see the scala steward conf)
* idea would be to keep java 8 support for most connectors
* some connectors would require java > 8
* releases would be built with java 17 but javac will have `--release 8`
* WIP and not definitely going to be merged