### PR TITLE
CI: restrict number of parallel jobs

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -90,6 +90,7 @@ jobs:
 
     strategy:
       fail-fast: false
+      max-parallel: 10
       matrix:
         include:
           - { connector: amqp,                         pre_cmd: 'docker compose up -d amqp' }


### PR DESCRIPTION
GitHub CI have requested generally that ASF projects avoid running more than 15 jobs in parallel. This CI jobs has a few other jobs as well as the matrix jobs, that's why I choose 10 as the limit here.