### PR TITLE
chore: pin hoverfly-java to 0.19

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -24,6 +24,8 @@ updates.pin  = [
   # jetty 10.+ requires Java 11 (only used in tests - via wiremock)
   { groupId = "org.eclipse.jetty", version = "9." }
   { groupId = "org.eclipse.jetty.http2", version = "9." }
+  # hoverfly-java 0.20.0 requires Java 11
+  { groupId = "io.specto", artifactId = "hoverfly-java", version = "0.19" }
   # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." },
   { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }


### PR DESCRIPTION
As 0.20 requires Java 11

Replaces https://github.com/apache/pekko-connectors/pull/978