### PR TITLE
FILE: Add size and date information to ZipArchiveMetadata

### DIFF
--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipReaderSource.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipReaderSource.scala
@@ -90,7 +90,7 @@ import java.util.zip.{ ZipEntry, ZipInputStream }
           override def onPull(): Unit = {
             val e = zis.getNextEntry
             if (e != null) {
-              val n = ZipArchiveMetadata(e.getName)
+              val n = new ZipArchiveMetadata(e.getName)(e.getSize(), e.getLastModifiedTime().toInstant())
               zis.closeEntry()
               push(out, n -> Source.fromGraph(new ZipEntrySource(n, f, chunkSize, fileCharset)))
             } else {

--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/model.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/model.scala
@@ -25,11 +25,16 @@ object ArchiveMetadata {
   def create(filePath: String): ArchiveMetadata = new ArchiveMetadata(filePath)
 }
 
-final case class ZipArchiveMetadata(name: String) {
+final case class ZipArchiveMetadata(name: String)(val size: Long, val lastModification: Instant) {
   def getName() = name
 }
 object ZipArchiveMetadata {
-  def create(name: String): ZipArchiveMetadata = ZipArchiveMetadata(name)
+  @deprecated("Use the variant with 3 arguments instead.", since = "pekko-connectors-file:1.1.0")
+  def apply(name: String): ZipArchiveMetadata = new ZipArchiveMetadata(name)(0, Instant.EPOCH)
+  @deprecated("Use the variant with 3 arguments instead.", since = "pekko-connectors-file:1.1.0")
+  def create(name: String): ZipArchiveMetadata = new ZipArchiveMetadata(name)(0, Instant.EPOCH)
+  def create(name: String, size: Long, lastModification: Instant): ZipArchiveMetadata =
+    new ZipArchiveMetadata(name)(size, lastModification)
 }
 
 final class TarArchiveMetadata private (


### PR DESCRIPTION
This brings the functionality closer to TarArchiveMetadata that already has these. Size and date information can be very valuable when unzipping files, to check if this entry has already been unzipped.