### PR TITLE
Re-enable github discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -22,6 +22,8 @@ github:
     issues: true
     # Enable projects for project management boards
     projects: true
+    # Enable github discussions
+    discussions: true
 
   enabled_merge_buttons:
     squash:  true


### PR DESCRIPTION
As per the https://lists.apache.org/thread/908mycqopxnm7cggqok3g0vmwt06m2v6 , github discussions now need to be explicitly enabled in other to be viewable.