### PR TITLE
Use GoogleSettings instead of GCStorageSettings

### DIFF
--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -27,10 +27,9 @@ import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.util.Random
-import pekko.stream.connectors.googlecloud.storage.GCStorageSettings
+import pekko.stream.connectors.google.GoogleSettings
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 
-import scala.annotation.nowarn
 import scala.concurrent.Future
 
 trait GCStorageStreamIntegrationSpec
@@ -48,14 +47,11 @@ trait GCStorageStreamIntegrationSpec
 
   def testFileName(file: String): String = folderName + file
 
-  @nowarn("msg=deprecated")
-  def settings: GCStorageSettings
+  def settings: GoogleSettings
 
   def bucket: String
   def rewriteBucket: String
   def projectId: String
-  def clientEmail: String
-  def privateKey: String
 
   before {
     folderName = classOf[GCStorageStreamIntegrationSpec].getSimpleName + UUID.randomUUID().toString + "/"

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GoogleGCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GoogleGCStorageStreamIntegrationSpec.scala
@@ -17,7 +17,7 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.storage.impl
 
-import org.apache.pekko.stream.connectors.googlecloud.storage.GCStorageSettings
+import org.apache.pekko.stream.connectors.google.GoogleSettings
 import org.scalatest.DoNotDiscover
 
 import scala.annotation.nowarn
@@ -44,12 +44,9 @@ import scala.annotation.nowarn
  */
 @DoNotDiscover
 class GoogleGCStorageStreamIntegrationSpec extends GCStorageStreamIntegrationSpec {
-  @nowarn("msg=deprecated")
-  def settings: GCStorageSettings = GCStorageSettings()
+  def settings: GoogleSettings = GoogleSettings()
 
   override def bucket = "connectors"
   override def rewriteBucket = "pekko-connectors-rewrite"
   override def projectId = settings.projectId
-  override def clientEmail = settings.clientEmail
-  override def privateKey = settings.privateKey
 }


### PR DESCRIPTION
In addition to getting rid of the depreciation message, this is necessary to add in [fake-gcs-server](https://github.com/fsouza/fake-gcs-server) testing as only `GoogleSettings` has the necessary `settings.withCredentials(NoCredentials(projectId, ""))` method (the deprecated `GCStorageSettings` has no such method and hence it forces official google authentication which won't work with gcs-storage-settings)

I have verified this hasn't caused any regressions by testing against a real google account. Another easy way to verify is to temporarily make `ServiceAccountCredentials` public, as well as the various constructor parameters and then you can do

```scala

val credentials = settings.credentials.asInstanceOf[org.apache.pekko.stream.connectors.google.auth.ServiceAccountCredentials]
println("credentials")
println(credentials.clientEmail)
println(credentials.project)
println(credentials.privateKey)
```

And it will match the settings at https://github.com/apache/pekko-connectors/blob/1fe3474d654bf48b0e81011d878e541a32409c93/google-cloud-storage/src/test/resources/application.conf#L38-L40

which means that everything is being loaded as expected