### PR TITLE
Rename none credentials to access-token and remove token from none

### DIFF
--- a/google-cloud-bigquery-storage/src/main/resources/reference.conf
+++ b/google-cloud-bigquery-storage/src/main/resources/reference.conf
@@ -8,7 +8,6 @@ pekko.connectors.google {
     provider = none
     none {
       project-id = "pekko-connectors-google-test"
-      token = "yyyy.c.an-access-token"
     }
   }
 

--- a/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryQueriesSpec.scala
+++ b/google-cloud-bigquery/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryQueriesSpec.scala
@@ -50,7 +50,7 @@ class BigQueryQueriesSpec
     jsonFormat10(QueryResponse[T])
   }
 
-  implicit val settings: GoogleSettings = GoogleSettings().copy(credentials = NoCredentials("", ""))
+  implicit val settings: GoogleSettings = GoogleSettings().copy(credentials = NoCredentials(""))
 
   val jobId = "jobId"
   val pageToken = "pageToken"

--- a/google-cloud-pub-sub/src/test/resources/application.conf
+++ b/google-cloud-pub-sub/src/test/resources/application.conf
@@ -29,7 +29,6 @@ pekko.connectors.google {
     provider = none
     none {
       project-id = "pekko-connectors"
-      token = "TESTTOKEN"
     }
   }
 }

--- a/google-cloud-pub-sub/src/test/scala/org/apache/pekko/stream/connectors/google/AuthorizationHeaderSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/org/apache/pekko/stream/connectors/google/AuthorizationHeaderSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.google
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.model.headers.OAuth2BearerToken
+import pekko.stream.connectors.googlecloud.pubsub.impl.TestCredentials
+import pekko.stream.connectors.googlecloud.pubsub.{ PubSubMockSpec, PublishMessage, PublishRequest }
+import pekko.stream.connectors.testkit.scaladsl.LogCapturing
+import pekko.stream.connectors.google.auth.{ Credentials, RetrievableCredentials }
+import pekko.stream.scaladsl.{ Keep, Sink, Source }
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.client.WireMock.{ aResponse, urlEqualTo }
+import com.typesafe.config.ConfigFactory
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{ when, withSettings }
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.mockito.MockitoSugar
+
+import java.util.Base64
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.collection.immutable.Seq
+import scala.concurrent.duration._
+
+class AuthorizationHeaderSpec extends AnyFlatSpec with BeforeAndAfterAll with ScalaFutures with Matchers
+    with LogCapturing
+    with PubSubMockSpec with MockitoSugar {
+
+  implicit val system: ActorSystem = ActorSystem(
+    "AuthorizationHeaderSpec",
+    ConfigFactory
+      .parseString(
+        s"pekko.connectors.google.credentials.none.project-id = ${TestCredentials.projectId}")
+      .withFallback(ConfigFactory.load()))
+
+  implicit val defaultPatience: PatienceConfig =
+    PatienceConfig(timeout = 5.seconds, interval = 100.millis)
+
+  it should "publish with auth header" in {
+
+    val accessToken = "yyyy.c.an-access-token"
+    val credentials =
+      mock[Credentials with RetrievableCredentials](withSettings().extraInterfaces(classOf[RetrievableCredentials]))
+
+    when(credentials.get()(any[ExecutionContext], any[RequestSettings])).thenReturn(
+      Future.successful(OAuth2BearerToken(accessToken))
+    )
+
+    val publishMessage =
+      PublishMessage(
+        data = new String(Base64.getEncoder.encode("Hello Google!".getBytes)),
+        attributes = Map("row_id" -> "7"))
+    val publishRequest = PublishRequest(Seq(publishMessage))
+
+    val expectedPublishRequest =
+      """{"messages":[{"data":"SGVsbG8gR29vZ2xlIQ==","attributes":{"row_id":"7"}}]}"""
+    val publishResponse = """{"messageIds":["1"]}"""
+
+    wireMock.register(
+      WireMock
+        .post(
+          urlEqualTo(s"/v1/projects/${TestCredentials.projectId}/topics/topic1:publish?prettyPrint=false"))
+        .withRequestBody(WireMock.equalToJson(expectedPublishRequest))
+        .withHeader("Authorization", WireMock.equalTo("Bearer " + accessToken))
+        .willReturn(
+          aResponse()
+            .withStatus(200)
+            .withBody(publishResponse)
+            .withHeader("Content-Type", "application/json")))
+    val flow = TestHttpApi.publish[Unit]("topic1", 1)
+    val result =
+      Source.single((publishRequest, ())).via(flow)
+        .withAttributes(GoogleAttributes.settings(GoogleSettings().copy(credentials = credentials)))
+        .toMat(Sink.head)(Keep.right).run()
+    result.futureValue._1.messageIds shouldBe Seq("1")
+    result.futureValue._2 shouldBe (())
+  }
+}

--- a/google-cloud-pub-sub/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/PubSubMockSpec.scala
+++ b/google-cloud-pub-sub/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/PubSubMockSpec.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.googlecloud.pubsub
+
+import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.{ ConnectionContext, Http }
+import pekko.stream.connectors.googlecloud.pubsub.impl.{ NoopTrustManager, PubSubApi }
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
+
+import javax.net.ssl.{ SSLContext, SSLEngine }
+import org.scalatest.{ BeforeAndAfterAll, Suite }
+
+trait PubSubMockSpec extends Suite with BeforeAndAfterAll {
+  implicit val system: ActorSystem
+
+  def createInsecureSslEngine(host: String, port: Int): SSLEngine = {
+    val sslContext: SSLContext = SSLContext.getInstance("TLS")
+    sslContext.init(null, Array(new NoopTrustManager()), null)
+
+    val engine = sslContext.createSSLEngine(host, port)
+    engine.setUseClientMode(true)
+
+    engine
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    Http().setDefaultClientHttpsContext(ConnectionContext.httpsClient(createInsecureSslEngine _))
+  }
+
+  val wiremockServer = new WireMockServer(
+    wireMockConfig().dynamicPort().dynamicHttpsPort().notifier(new ConsoleNotifier(false)))
+  wiremockServer.start()
+
+  val wireMock = new WireMock("localhost", wiremockServer.port())
+
+  object TestHttpApi extends PubSubApi {
+    val isEmulated = false
+    val PubSubGoogleApisHost = "localhost"
+    val PubSubGoogleApisPort = wiremockServer.httpsPort()
+  }
+
+  object TestEmulatorHttpApi extends PubSubApi {
+    override val isEmulated = true
+    val PubSubGoogleApisHost = "localhost"
+    val PubSubGoogleApisPort = wiremockServer.port()
+  }
+
+  val config = PubSubConfig()
+
+}

--- a/google-common/src/main/resources/reference.conf
+++ b/google-common/src/main/resources/reference.conf
@@ -8,8 +8,8 @@ pekko.connectors.google {
     # Override to specify custom scopes
     scopes = ${pekko.connectors.google.credentials.default-scopes}
 
-    # Options: application-default, service-account, compute-engine, none
-    # application-default first tries service-account then compute-engine
+    # Options: application-default, service-account, compute-engine, access-token, none
+    # application-default first tries service-account, compute-engine then access-token
     provider = application-default
 
     service-account {
@@ -48,9 +48,13 @@ pekko.connectors.google {
       path = ${?GOOGLE_APPLICATION_CREDENTIALS}
     }
 
+    access-token {
+      project-id = ""
+      token = ""
+    }
+
     none {
       project-id = "<no-project-id>"
-      token = "<no-token>"
     }
   }
 

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2Credentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2Credentials.scala
@@ -34,7 +34,8 @@ private[auth] object OAuth2Credentials {
 }
 
 @InternalApi
-private[auth] abstract class OAuth2Credentials(val projectId: String)(implicit mat: Materializer) extends Credentials {
+private[auth] abstract class OAuth2Credentials(val projectId: String)(implicit mat: Materializer) extends Credentials
+    with RetrievableCredentials {
 
   private val tokenStream = stream.run()
 

--- a/google-common/src/test/resources/application.conf
+++ b/google-common/src/test/resources/application.conf
@@ -3,8 +3,8 @@
 pekko.connectors.google {
 
   credentials {
-    provider = none
-    none {
+    provider = access-token
+    access-token {
       project-id = "pekko-connectors-google-test"
       token = "yyyy.c.an-access-token"
     }

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/http/GoogleHttpSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/http/GoogleHttpSpec.scala
@@ -25,13 +25,13 @@ import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.{ Authorization, OAuth2BearerToken }
 import pekko.http.scaladsl.settings.ConnectionPoolSettings
 import pekko.http.scaladsl.{ HttpExt, HttpsConnectionContext }
-import pekko.stream.connectors.google.auth.{ Credentials, GoogleOAuth2Exception }
+import pekko.stream.connectors.google.auth.{ Credentials, GoogleOAuth2Exception, RetrievableCredentials }
 import pekko.stream.connectors.google.implicits._
 import pekko.stream.connectors.google.{ GoogleHttpException, GoogleSettings, RequestSettings }
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import pekko.testkit.TestKit
 import org.mockito.ArgumentMatchers.{ any, anyInt, argThat }
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{ when, withSettings }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
@@ -160,7 +160,8 @@ class GoogleHttpSpec
 
       final class AnotherException extends RuntimeException
 
-      val credentials = mock[Credentials]
+      val credentials =
+        mock[Credentials with RetrievableCredentials](withSettings().extraInterfaces(classOf[RetrievableCredentials]))
       when(credentials.get()(any[ExecutionContext], any[RequestSettings])).thenReturn(
         Future.failed(GoogleOAuth2Exception(ErrorInfo())),
         Future.failed(new AnotherException))

--- a/google-fcm/src/test/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
+++ b/google-fcm/src/test/scala/org/apache/pekko/stream/connectors/google/firebase/fcm/v1/impl/FcmSenderSpec.scala
@@ -83,8 +83,6 @@ class FcmSenderSpec
       val request: HttpRequest = captor.getValue
       Unmarshal(request.entity).to[FcmSend].futureValue shouldBe FcmSend(false, FcmNotification.empty)
       request.uri.toString should startWith("https://fcm.googleapis.com/v1/projects/projectId/messages:send")
-      request.headers.size shouldBe 1
-      request.headers.head should matchPattern { case HttpHeader("authorization", "Bearer <no-token>") => }
     }
 
     "parse the success response correctly" in {


### PR DESCRIPTION
This PR modifies `NoCredentials` so that you aren't forced to provide it with a token and by consequence means that no `Authorization` header will be added when using `NoCredentials`. More specifically, the constructor for `NoCredentials` has been changed so that it doesn't have a `token` parameter and the `token` value from typesafe config is no longer retrieved.

In order to get this to work, I had to split out the `get()` method (which returns the token) from `Credentials` into a separate `RetrievableCredentials` trait and every subclass of `Credentials` aside from `NoCredentials` inherits this trait.

The main reason for this change is that `NoCredentials` shouldn't, by design, add token auth headers (the official analogue from Google's own sdk [doesn't do this](https://github.com/googleapis/sdk-platform-java/blob/main/java-core/google-cloud-core/src/main/java/com/google/cloud/NoCredentials.java)), it can even be argued that its a potential security risk as it may inadvertently force user to provide a token they shouldn't have. The change is also being done in context of adding support for [fake-gcs-server](https://github.com/fsouza/fake-gcs-server) where their own sample Java implementation also has [doesn't have to provide any token](https://github.com/fsouza/fake-gcs-server/blob/main/examples/java/src/test/java/com/fsouza/fakegcsserver/java/examples/FakeGcsServerTest.java#L25-L30)

Note that all of the touched code is dealing with internals that are marked with `DoNotInherit`/`private` so it doesn't break binary compatibility in any way. It could be argued that this is a behaviour change and so it should only land for pekko-connectors 1.2.x however an alternate view is that `NoCredentials` would have only be used for testing (I highly doubt anyone would be using in prod, but it is theoretically possible), this is ontop of the security concern mentioned earlier.