### PR TITLE
Actually use attributes in GCS tests

### DIFF
--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GoogleGCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GoogleGCStorageStreamIntegrationSpec.scala
@@ -18,6 +18,7 @@
 package org.apache.pekko.stream.connectors.googlecloud.storage.impl
 
 import org.apache.pekko.stream.connectors.google.GoogleSettings
+import org.apache.pekko.stream.connectors.googlecloud.storage.GCSSettings
 import org.scalatest.DoNotDiscover
 
 import scala.annotation.nowarn
@@ -44,7 +45,8 @@ import scala.annotation.nowarn
  */
 @DoNotDiscover
 class GoogleGCStorageStreamIntegrationSpec extends GCStorageStreamIntegrationSpec {
-  def settings: GoogleSettings = GoogleSettings()
+  override def settings: GoogleSettings = GoogleSettings()
+  override def gcsSettings: GCSSettings = GCSSettings()
 
   override def bucket = "connectors"
   override def rewriteBucket = "pekko-connectors-rewrite"


### PR DESCRIPTION
Currently the gcs tests don't even use the defined `GoogleSettings`, this PR fixes that. It also adds `GCSSettings` which is also used by google cloud storage tests.

This is a follow on from https://github.com/apache/pekko-connectors/pull/1020