### PR TITLE
Remove old leftover test settings

### DIFF
--- a/google-cloud-storage/src/test/resources/application.conf
+++ b/google-cloud-storage/src/test/resources/application.conf
@@ -43,15 +43,3 @@ pekko.connectors.google {
   }
 
 }
-
-//#settings
-
-pekko.connectors.google.cloud.storage {
-  project-id = "projectId"
-  client-email = "client@email.com"
-  private-key = ${privateKey}
-  base-url = "https://www.googleapis.com/" // default
-  base-path = "/storage/v1" // default
-  token-url = "https://www.googleapis.com/oauth2/v4/token" // default
-  token-scope = "https://www.googleapis.com/auth/devstorage.read_write" // default
-}


### PR DESCRIPTION
With the result of https://github.com/apache/pekko-connectors/pull/1020 and https://github.com/apache/pekko-connectors/pull/1022 these settings are no longer being used/loaded in the test code