### PR TITLE
Add fake-gcs-server

### DIFF
--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FakeGCSContainer.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FakeGCSContainer.scala
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.googlecloud.storage
+
+import com.dimafeng.testcontainers.GenericContainer
+import org.testcontainers.containers.wait.strategy.Wait
+
+import java.time.Duration
+
+class FakeGCSContainer(bucketsToCreate: List[String], location: Option[String]) extends GenericContainer(
+      "fsouza/fake-gcs-server:1.52",
+      exposedPorts = List(4443),
+      waitStrategy = Some(Wait.forHttp("/storage/v1/b").forPort(4443).withStartupTimeout(Duration.ofSeconds(10))),
+      command = List(
+        "-scheme", "http"
+      ) ++ location.map(List("-location", _)).getOrElse(Nil)
+    ) {
+  def getHostAddress: String =
+    s"http://${container.getHost}:${container.getMappedPort(4443)}"
+
+  override def start(): Unit = {
+    super.start()
+    if (bucketsToCreate.nonEmpty) {
+      container.execInContainer("mkdir", "data")
+      bucketsToCreate.foreach { bucket =>
+        container.execInContainer(s"mkdir", s"/data/$bucket")
+      }
+    }
+  }
+}

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FakeGCSServerTest.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/FakeGCSServerTest.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.googlecloud.storage
+
+import com.dimafeng.testcontainers.ForAllTestContainer
+import org.apache.pekko
+import org.apache.pekko.stream.connectors.google.auth.NoCredentials
+import org.apache.pekko.stream.connectors.google.{ GoogleSettings, RequestSettings, RetrySettings }
+import org.apache.pekko.testkit.TestKitBase
+import org.scalatest.Suite
+
+import java.time.Duration
+import java.time.temporal.ChronoUnit
+import java.util.Optional
+
+trait FakeGCSServerTest extends ForAllTestContainer with TestKitBase { self: Suite =>
+  override lazy val container: FakeGCSContainer =
+    new FakeGCSContainer(List("connectors", "pekko-connectors-rewrite"), Some("europe-west1"))
+
+  lazy val googleSettings =
+    GoogleSettings.create(
+      "test-project",
+      NoCredentials("", ""),
+      RequestSettings.create(
+        Optional.empty(),
+        Optional.empty(),
+        prettyPrint = false,
+        15728640, // 15 MiB
+        RetrySettings.create(
+          6,
+          Duration.of(1, ChronoUnit.SECONDS),
+          Duration.of(1, ChronoUnit.MINUTES),
+          0.2d
+        ),
+        Optional.empty()
+      )
+    )
+
+  lazy val gCSSettings =
+    GCSSettings(container.getHostAddress, GCSSettings().basePath)
+}

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/FakeGCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/FakeGCStorageStreamIntegrationSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.googlecloud.storage.impl
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.connectors.google.GoogleSettings
+import org.apache.pekko.stream.connectors.googlecloud.storage.scaladsl.GCStorage
+import org.apache.pekko.stream.connectors.googlecloud.storage.{ FakeGCSServerTest, GCSSettings, GCStorageSettings }
+
+class FakeGCStorageStreamIntegrationSpec extends GCStorageStreamIntegrationSpec with FakeGCSServerTest {
+  override def settings: GoogleSettings = googleSettings
+  override def gcsSettings: GCSSettings = gCSSettings
+
+  override implicit def system: ActorSystem = actorSystem
+
+  override def bucket = "connectors"
+  override def rewriteBucket = "pekko-connectors-rewrite"
+  override def projectId = settings.projectId
+
+}


### PR DESCRIPTION
This PR adds the ability to run google cloud storage tests against fake-gcs-server. PR is currently in draft since its blocked by https://github.com/fsouza/fake-gcs-server/issues/1943