### PR TITLE
Fix metadata not working with GCStorage

### DIFF
--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStream.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStream.scala
@@ -154,7 +154,8 @@ import scala.concurrent.{ ExecutionContext, Future }
           .withQuery(("uploadType" -> "resumable") +: ("name" -> objectName) +: Query.Empty)
         val headers = List(`X-Upload-Content-Type`(contentType))
         val entity =
-          metadata.fold(HttpEntity.Empty)(m => HttpEntity(ContentTypes.`application/json`, m.toJson.toString))
+          metadata.fold(HttpEntity.Empty)(m =>
+            HttpEntity(ContentTypes.`application/json`, JsObject(("metadata", m.toJson)).toString))
         val request = HttpRequest(POST, uri, headers, entity)
 
         implicit val um: Unmarshaller[HttpResponse, StorageObject] = Unmarshaller.withMaterializer {

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/scaladsl/GCStorageWiremockBase.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/scaladsl/GCStorageWiremockBase.scala
@@ -25,7 +25,7 @@ import io.specto.hoverfly.junit.core.{ Hoverfly, HoverflyConfig, HoverflyMode, S
 import io.specto.hoverfly.junit.dsl.HoverflyDsl.{ response, service }
 import io.specto.hoverfly.junit.dsl.matchers.HoverflyMatchers.equalsToJson
 import spray.json.DefaultJsonProtocol.{ mapFormat, StringJsonFormat }
-import spray.json.enrichAny
+import spray.json.{ enrichAny, JsObject }
 
 import scala.annotation.nowarn
 import scala.util.Random
@@ -639,7 +639,7 @@ abstract class GCStorageWiremockBase(_system: ActorSystem, _wireMockServer: Hove
     dsl(
       metadata
         .fold(noMeta) { m =>
-          noMeta.body(equalsToJson(m.toJson.toString))
+          noMeta.body(equalsToJson(JsObject(("metadata", m.toJson)).toString))
         }
         .willReturn(
           response()


### PR DESCRIPTION
Resolves https://github.com/apache/pekko-connectors/issues/656 .

Underlying issue is that metadata needs to be nested inside of its own "metadata" object, see https://cloud.google.com/storage/docs/json_api/v1/objects/insert#request-body

With this test, running `sbt "google-cloud-storage/Test/runMain org.scalatest.tools.Runner -o -s org.apache.pekko.stream.connectors.googlecloud.storage.impl.GoogleGCStorageStreamIntegrationSpec"` against an actual  google cloud account works.