### PR TITLE
log4j 2.24.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
 
   val GoogleAuthVersion = "1.34.0"
   val JwtScalaVersion = "10.0.4"
-  val Log4jVersion = "2.23.1"
+  val Log4jVersion = "2.24.3"
 
   // Releases https://github.com/FasterXML/jackson-databind/releases
   // CVE issues https://github.com/FasterXML/jackson-databind/issues?utf8=%E2%9C%93&q=+label%3ACVE


### PR DESCRIPTION
scala-steward seems not to be creating PRs to upgrade this lib. We don't seem to have anything in the .scala-steward.conf for log4j.
