### PR TITLE
Make GCS resumableUpload work with empty byte payload

### DIFF
--- a/google-common/src/main/mima-filters/1.1.x.backwards.excludes/private-zero-chunk-change.backwards.excludes
+++ b/google-common/src/main/mima-filters/1.1.x.backwards.excludes/private-zero-chunk-change.backwards.excludes
@@ -1,0 +1,1 @@
+ProblemFilters.exclude[MissingTypesProblem]("org.apache.pekko.stream.connectors.google.ResumableUpload$Chunk$")

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/util/AnnotateLastSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/util/AnnotateLastSpec.scala
@@ -50,6 +50,18 @@ class AnnotateLastSpec
       val probe = Source.empty[Nothing].via(AnnotateLast[Nothing]).runWith(TestSink.probe)
       probe.expectSubscriptionAndComplete()
     }
+
+    "return zero value when stream is empty using zero apply" in {
+      val probe = Source.empty[Null].via(AnnotateLast[Null](null)).runWith(TestSink.probe)
+      probe.requestNext(Last(null))
+      probe.expectComplete()
+    }
+
+    "don't return zero value if stream is non empty using zero apply" in {
+      val probe = Source.single(1).via(AnnotateLast[Int](0)).runWith(TestSink.probe)
+      probe.requestNext(Last(1))
+      probe.expectComplete()
+    }
   }
 
 }


### PR DESCRIPTION
Resolves: https://github.com/apache/pekko-connectors/issues/1054

This PR solves resumable upload for gcs when uploading an empty payload (i.e. zero bytes).  Comments have been added explaining how the solution works, but in short a special sentinel value gets inserted in the `onComplete` of `statefulMap` where the chunks get calculated on the specific case that the state is empty (which means nothing is being processed, hence empty payload) and this sentinel value gets used/detected later when calculating the Content-Range header.

A test has been added to confirm that this works, without this change the newly added test fails. I also rerun the entire test suite against a real GCS account to make sure there are no additional regressions.

@He-Pin Would be good if you check this PR as you originally wrote some of the code being touched