### PR TITLE
Manage Pekko upgrades explicitly

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -42,6 +42,8 @@ updates.pin  = [
 ]
 
 updates.ignore = [
+  # Manage Pekko upgrades explicitly
+  { groupId = "org.apache.pekko" }
   # https://github.com/apache/pekko-connectors/issues/61
   { groupId = "org.apache.hbase" }
   { groupId = "org.apache.hadoop" }


### PR DESCRIPTION
Failures in CI because we can't have Scala Steward upgrade CI actions (due to how ASF configure our repos)
  https://github.com/apache/pekko-connectors/actions/runs/15950739121

Easier at the moment to manage pekko upgrades using manual PRs.
The Scala Steward failures are blocking us from getting PRs for some other libs that are already out of date.