### PR TITLE
protect 1.2.x branch

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -66,7 +66,19 @@ github:
       required_pull_request_reviews:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
-        required_approving_review_count: 1                
+        required_approving_review_count: 1
+    1.2.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
 
 notifications:
   commits:              commits@pekko.apache.org


### PR DESCRIPTION
* 1.2.0 is not released and not yet planned but there is nothing being actively developed there
* we can release 1.2.0 at some stage in the future and can use the 1.2.x branch to do that
* it would be good to allow 2.0.0 dev work to start on main branch with changes like making Java 17 the min version and removing deprecated code (matching what we are doing in other Pekko repos)