### PR TITLE
tidy up mima and deprecations

### DIFF
--- a/s3/src/main/mima-filters/1.0.x.backwards.excludes/chunkUploadSink-type-param-change.backwards.excludes
+++ b/s3/src/main/mima-filters/1.0.x.backwards.excludes/chunkUploadSink-type-param-change.backwards.excludes
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # These filters are here because a type argument in the chunkUploadSink parameter was changed from
 # NotUsed to _ which has zero effect on runtime
 ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.stream.connectors.s3.javadsl.S3.resumeMultipartUploadWithContext")

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
@@ -348,7 +348,7 @@ object S3 {
    * @param key the s3 object key
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(bucket: String,
       key: String): Source[Optional[JPair[Source[ByteString, NotUsed], ObjectMetadata]], NotUsed] =
     toJava(S3Stream.download(S3Location(bucket, key), None, None, S3Headers.empty))
@@ -361,7 +361,7 @@ object S3 {
    * @param sse the server side encryption to use
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -376,7 +376,7 @@ object S3 {
    * @param range the [[pekko.http.javadsl.model.headers.ByteRange ByteRange]] you want to download
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(bucket: String,
       key: String,
       range: ByteRange): Source[Optional[JPair[Source[ByteString, NotUsed], ObjectMetadata]], NotUsed] = {
@@ -393,7 +393,7 @@ object S3 {
    * @param sse the server side encryption to use
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -411,7 +411,7 @@ object S3 {
    * @param sse the server side encryption to use
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -428,7 +428,7 @@ object S3 {
    * @param s3Headers any headers you want to add
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -445,7 +445,7 @@ object S3 {
    * @param s3Headers any headers you want to add
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -466,7 +466,7 @@ object S3 {
    * @param s3Headers any headers you want to add
    * @return A [[pekko.japi.Pair]] with a [[pekko.stream.javadsl.Source Source]] of [[pekko.util.ByteString ByteString]], and a [[pekko.stream.javadsl.Source Source]] containing the [[ObjectMetadata]]
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3.scala
@@ -204,7 +204,7 @@ object S3 {
    * @return The source will emit an empty [[scala.Option Option]] if an object can not be found.
    *         Otherwise [[scala.Option Option]] will contain a tuple of object's data and metadata.
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,
@@ -224,7 +224,7 @@ object S3 {
    * @return The source will emit an empty [[scala.Option Option]] if an object can not be found.
    *         Otherwise [[scala.Option Option]] will contain a tuple of object's data and metadata.
    */
-  @deprecated("Use S3.getObject instead", "4.0.0")
+  @deprecated("Use S3.getObject instead", "Alpakka 4.0.0")
   def download(
       bucket: String,
       key: String,


### PR DESCRIPTION
Tidy up of 1.2.x code based on changes in #1187 

* Some deprecation warnings say "4.0.0" which is an Alpakka version and we normally differentiate those
* One mima filter file has no license header