### PR TITLE
test with pekko 1.2.x

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -33,13 +33,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -65,13 +65,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17
@@ -153,13 +153,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'apache/pekko-connectors'    
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install sbt
         uses: sbt/setup-sbt@26ab4b0fa1c47fa62fc1f6e51823a658fb6c760c # v1.1.7      
       - uses: scalacenter/sbt-dependency-submission@64084844d2b0a9b6c3765f33acde2fbe3f5ae7d3 # v3.1.0

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -19,13 +19,13 @@ jobs:
     if: github.repository == 'apache/pekko-connectors'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -37,13 +37,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
 
       - name: Setup Java ${{ matrix.JDK }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.JDK }}
@@ -63,12 +63,12 @@ jobs:
     if: github.repository == 'apache/pekko-connectors'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/nightly-pekko-1.0-builds.yaml
+++ b/.github/workflows/nightly-pekko-1.0-builds.yaml
@@ -15,18 +15,16 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Nightly Pekko 1.0 Builds
+name: Nightly Pekko 1.0 Builds (on 1.2.x branch)
 
 on:
-  schedule:
-    - cron: "0 3 * * *"
   workflow_dispatch:
 
 permissions: {}
 
 concurrency:
   # Only run once for latest commit per ref and cancel other (previous) runs.
-  group: pekko-1.1-${{ github.ref }}
+  group: pekko-1.0-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -43,13 +41,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
+          ref: 1.2.x
 
       - name: Setup Java ${{ matrix.JDK }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.JDK }}

--- a/.github/workflows/nightly-pekko-1.2-builds.yaml
+++ b/.github/workflows/nightly-pekko-1.2-builds.yaml
@@ -15,29 +15,45 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Headers
+name: Nightly Pekko 1.2 Builds (on 1.2.x branch)
 
 on:
-  pull_request:
+  schedule:
+    - cron: "0 3 * * *"
+  workflow_dispatch:
 
 permissions: {}
 
+concurrency:
+  # Only run once for latest commit per ref and cancel other (previous) runs.
+  group: pekko-1.2-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  check-headers:
-    name: Check headers
+  test-compile:
+    name: Compile
     runs-on: ubuntu-22.04
+    if: github.repository == 'apache/pekko-connectors'
+    strategy:
+      fail-fast: false
+      matrix:
+        JDK: [ 8, 11, 17, 21 ]
+    env:
+      JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
+
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
+          ref: 1.2.x
 
-      - name: Setup Java 17
+      - name: Setup Java ${{ matrix.JDK }}
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: ${{ matrix.JDK }}
 
       - name: Install sbt
         uses: sbt/setup-sbt@26ab4b0fa1c47fa62fc1f6e51823a658fb6c760c # v1.1.7
@@ -45,9 +61,5 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
 
-      - name: Check headers
-        run: |-
-          sbt \
-          -Dsbt.override.build.repos=false \
-          -Dsbt.log.noformat=false \
-          +headerCheckAll
+      - name: "compile, including  tests. Run locally with: sbt -Dpekko.build.pekko.version=1.2.x -Dpekko.build.pekko.http.version=1.3.x +Test/compile"
+        run: sbt -Dpekko.build.pekko.version=1.2.x -Dpekko.build.pekko.http.version=1.3.x +Test/compile

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -30,14 +30,14 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
           ref: 1.0.x
 
       - name: Setup Java 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -30,14 +30,14 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
           ref: 1.1.x
 
       - name: Setup Java 8
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -36,14 +36,14 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-tags: true
           fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || matrix.branch }}
 
       - name: Setup Java 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
* we've seen at least 1 bin compat issue with Pekko 1.2.0
* we don't really need to test pekko 1.0.x nightly
* update action versions
* change the nightly tests to test the 1.2.x branch as we need a 1.2.0 release but little point testing main branch yet because we are making breaking changes