### PR TITLE
remove final modifier for objects

### DIFF
--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2Credentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2Credentials.scala
@@ -29,7 +29,7 @@ import scala.concurrent.{ ExecutionContext, Future, Promise }
 private[auth] object OAuth2Credentials {
   sealed abstract class Command
   final case class TokenRequest(promise: Promise[OAuth2BearerToken], settings: RequestSettings) extends Command
-  final case object ForceRefresh extends Command
+  case object ForceRefresh extends Command
 }
 
 @InternalApi

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2CredentialsSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/OAuth2CredentialsSpec.scala
@@ -47,7 +47,7 @@ class OAuth2CredentialsSpec
   implicit val settings: RequestSettings = GoogleSettings().requestSettings
   implicit val clock: Clock = Clock.systemUTC()
 
-  final object AccessTokenProvider {
+  object AccessTokenProvider {
     @volatile var accessTokenPromise: Promise[AccessToken] = Promise.failed(new RuntimeException)
   }
 

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSchedulerSourceStage.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSchedulerSourceStage.scala
@@ -37,8 +37,8 @@ private[kinesis] object KinesisSchedulerSourceStage {
 
   sealed trait Command
   final case class NewRecord(cr: CommittableRecord) extends Command
-  final case object Pump extends Command
-  final case object Complete extends Command
+  case object Pump extends Command
+  case object Complete extends Command
   final case class SchedulerShutdown(result: Try[_]) extends Command
 
 }

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
@@ -43,9 +43,9 @@ private[kinesis] object KinesisSourceStage {
 
   private[kinesis] final case class GetRecordsFailure(ex: Throwable)
 
-  private[kinesis] final case object Pump
+  private[kinesis] case object Pump
 
-  private[kinesis] final case object GetRecords
+  private[kinesis] case object GetRecords
 
 }
 

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/ClientState.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/ClientState.scala
@@ -629,7 +629,7 @@ import scala.util.{ Either, Failure, Success }
 
   sealed abstract class Event
   final case class AcquiredPacketId(packetId: PacketId) extends Event
-  final case object UnobtainablePacketId extends Event
+  case object UnobtainablePacketId extends Event
   final case class SubAckReceivedFromRemote(local: Promise[ForwardSubAck]) extends Event
   case object ReceiveSubAckTimeout extends Event
 
@@ -712,7 +712,7 @@ import scala.util.{ Either, Failure, Success }
 
   sealed abstract class Event
   final case class AcquiredPacketId(packetId: PacketId) extends Event
-  final case object UnobtainablePacketId extends Event
+  case object UnobtainablePacketId extends Event
   final case class UnsubAckReceivedFromRemote(local: Promise[ForwardUnsubAck]) extends Event
   case object ReceiveUnsubAckTimeout extends Event
 

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/RequestState.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/RequestState.scala
@@ -85,7 +85,7 @@ import scala.util.{ Either, Failure, Success }
 
   sealed abstract class Event
   final case class AcquiredPacketId(packetId: PacketId) extends Event
-  final case object UnacquiredPacketId extends Event
+  case object UnacquiredPacketId extends Event
   case object ReceivePubAckRecTimeout extends Event
   final case class PubAckReceivedFromRemote(local: Promise[ForwardPubAck]) extends Event
   final case class PubRecReceivedFromRemote(local: Promise[ForwardPubRec]) extends Event
@@ -268,8 +268,8 @@ import scala.util.{ Either, Failure, Success }
       extends Data(publish, clientId, packetId, packetRouter, settings)
 
   sealed abstract class Event
-  final case object RegisteredPacketId extends Event
-  final case object UnobtainablePacketId extends Event
+  case object RegisteredPacketId extends Event
+  case object UnobtainablePacketId extends Event
   final case class PubAckReceivedLocally(remote: Promise[ForwardPubAck.type]) extends Event
   final case class PubRecReceivedLocally(remote: Promise[ForwardPubRec.type]) extends Event
   case object ReceivePubAckRecTimeout extends Event
@@ -540,7 +540,7 @@ import scala.util.{ Either, Failure, Success }
   // Replies
 
   sealed abstract class Reply
-  final case object Registered extends Reply
+  case object Registered extends Reply
 
   /*
    * Construct with the starting state

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/ServerState.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/impl/ServerState.scala
@@ -811,8 +811,8 @@ import scala.util.{ Failure, Success }
       extends Data(clientId, packetId, subscribed, packetRouter, settings)
 
   sealed abstract class Event
-  final case object RegisteredPacketId extends Event
-  final case object UnobtainablePacketId extends Event
+  case object RegisteredPacketId extends Event
+  case object UnobtainablePacketId extends Event
   final case class SubAckReceivedLocally(remote: Promise[ForwardSubAck.type]) extends Event
   case object ReceiveSubAckTimeout extends Event
 
@@ -905,8 +905,8 @@ import scala.util.{ Failure, Success }
       extends Data(clientId, packetId, unsubscribed, packetRouter, settings)
 
   sealed abstract class Event
-  final case object RegisteredPacketId extends Event
-  final case object UnobtainablePacketId extends Event
+  case object RegisteredPacketId extends Event
+  case object UnobtainablePacketId extends Event
   final case class UnsubAckReceivedLocally(remote: Promise[ForwardUnsubAck.type]) extends Event
   case object ReceiveUnsubAckTimeout extends Event
 

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
@@ -493,7 +493,7 @@ object MqttCodec {
   /**
    * Not enough bytes in the byte iterator
    */
-  final case object BufferUnderflow extends DecodeError
+  case object BufferUnderflow extends DecodeError
 
   /**
    * Cannot determine the type/flags combination of the control packet
@@ -516,7 +516,7 @@ object MqttCodec {
   /**
    * Bit 0 of the connect flag was set - which it should not be as it is reserved.
    */
-  final case object ConnectFlagReservedSet extends DecodeError
+  case object ConnectFlagReservedSet extends DecodeError
 
   /**
    * Something is wrong with the connect message

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsModel.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsModel.scala
@@ -45,7 +45,7 @@ object MessageAction {
     override def hashCode(): Int = java.util.Objects.hash(message)
   }
 
-  final object Delete {
+  object Delete {
     def apply(message: Message): Delete = new Delete(message)
   }
 
@@ -63,7 +63,7 @@ object MessageAction {
     override def hashCode(): Int = java.util.Objects.hash(message)
   }
 
-  final object Ignore {
+  object Ignore {
     def apply(message: Message): Ignore = new Ignore(message)
   }
 

--- a/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
+++ b/sse/src/test/scala/docs/scaladsl/EventSourceSpec.scala
@@ -46,10 +46,10 @@ import org.scalatest.wordspec.AsyncWordSpec
 
 object EventSourceSpec {
 
-  final object Server {
+  object Server {
 
-    private final case object Bind
-    private final case object Unbind
+    private case object Bind
+    private case object Unbind
 
     private def route(size: Int, setEventId: Boolean): Route = {
       import Directives._


### PR DESCRIPTION
Scala 3 gives compiler warnings like
```
[warn] -- [E147] Syntax Warning: /Users/pj.fanning/code/pekko-connectors/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/SqsModel.scala:48:2 
[warn] 48 |  final object Delete {
[warn]    |  ^^^^^
[warn]    |  Modifier final is redundant for this definition
```