### PR TITLE
rework nightly publish job

### DIFF
--- a/.github/workflows/publish-nightly-1.2.yml
+++ b/.github/workflows/publish-nightly-1.2.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Publish Nightly
+name: Publish Nightly (1.2.x)
 
 on:
   workflow_dispatch:
@@ -36,12 +36,13 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          ref: 1.2.x
 
-      - name: Setup Java 17
+      - name: Setup Java 8
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
 
       - name: Install sbt
         uses: sbt/setup-sbt@26ab4b0fa1c47fa62fc1f6e51823a658fb6c760c # v1.1.7

--- a/.github/workflows/publish-on-demand.yml
+++ b/.github/workflows/publish-on-demand.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Publish Nightly
+name: Publish On Demand (1.x)
 
 on:
   workflow_dispatch:
@@ -36,12 +36,13 @@ jobs:
         with:
           fetch-tags: true
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.branch || '1.1.x' }}
 
-      - name: Setup Java 17
+      - name: Setup Java 8
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
 
       - name: Install sbt
         uses: sbt/setup-sbt@26ab4b0fa1c47fa62fc1f6e51823a658fb6c760c # v1.1.7


### PR DESCRIPTION
* the job tries to work for 3 branches to publish snapshots for different versions but the Java version is hardcoded
* we don't have a setup to publish 1.2.x
* we don't really need nightly 1.0.x or 1.1.x builds
* it's easier to manage this with separate scripts for main and 1.2x and the a special on-demand job that can publish for 1.0.x or 1.1.x on demand