### PR TITLE
Avoid silently swallowing the error when SSE stream fails/retries

### DIFF
--- a/sse/src/main/scala/org/apache/pekko/stream/connectors/sse/scaladsl/EventSource.scala
+++ b/sse/src/main/scala/org/apache/pekko/stream/connectors/sse/scaladsl/EventSource.scala
@@ -113,11 +113,12 @@ object EventSource {
           .flatMap(Unmarshal(_).to[EventSource])
           .fallbackTo(Future.successful(noEvents))
       }
-      def recover(eventSource: EventSource) = eventSource.recoverWithRetries(1, { 
-        case e =>
-          log.error(e, "SSE Connector is retrying failed stream for: {} ", uri)
-          noEvents
-      })
+      def recover(eventSource: EventSource) = eventSource.recoverWithRetries(1,
+        {
+          case e =>
+            log.error(e, "SSE Connector is retrying failed stream for: {} ", uri)
+            noEvents
+        })
       def delimit(eventSource: EventSource) = eventSource.concat(singleDelimiter)
       Flow[Option[String]]
         .mapAsync(1)(getEventSource)


### PR DESCRIPTION
# Problem

The current pekko-http SSE (Server-Sent Events) client implementation fails its stream every time a message arrives over the size limits. When a Pekko SSE client connects to a Pekko SSE server who serves a message larger than the client's size limit, the pekko-http client fails the stream, then the SSE Connector tries to reconnect and resume at the same (oversized) message which fails again. The SSE Connector client falls into a silent infinite connection retry loop. The oversized message error is swallowed by the SSE Connector, so the user never knows what is happening. The observed behavior appears as if the stream is still active and just gets stuck at the message that preceded the oversized message. Meanwhile the SSE connector is infinitely retrying… silently.

# Solution
This simple PR just avoids silently swallowing the failure message, and instead logs an error. The existing retry logic is left untouched (but really should be designed better for useful error handling).

Another PR to the pekko-http library has been submitted to add additional options beyond just failing stream when either an SSE line or event exceeds the size limit. https://github.com/apache/pekko-http/pull/744  Some of the new options in that PR can avoid the stream failing in the first place (example: `log-and-skip`). So this PR is meant to stay as small as possible, with related key new functionality added to the core pekko-http library.