### PR TITLE
Update scala-library, scala-reflect to 2.13.17 (#1238)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,8 +16,8 @@ object Dependencies {
 
   val CronBuild = sys.env.get("GITHUB_EVENT_NAME").contains("schedule")
 
-  val Scala213 = "2.13.16" // update even in link-validator.conf
   val Scala212 = "2.12.20"
+  val Scala213 = "2.13.17" // update even in link-validator.conf
   val Scala3 = "3.3.6"
   val ScalaVersions = Seq(Scala213, Scala212, Scala3)
 


### PR DESCRIPTION
cherry pick d90dfdf56a04329a76ddfc1fab04b23c5ac43636 #1238 

we are seeing build issues because some jars that we test with need scala 2.13.17

eg https://github.com/apache/pekko-connectors/actions/runs/18364430514/job/52314504015