### PR TITLE
getIssuerDN deprecated in favour of getIssuerX500Principal

### DIFF
--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
@@ -29,7 +29,7 @@ private[google] object ForwardProxyHttpsContext {
     val certificate = x509Certificate(trustPemPath: String)
     val sslContext = SSLContext.getInstance("SSL")
 
-    val alias = certificate.getIssuerDN.getName
+    val alias = certificate.getIssuerX500Principal.getName
     val trustStore = KeyStore.getInstance(KeyStore.getDefaultType)
     trustStore.load(null, null)
     trustStore.setCertificateEntry(alias, certificate)

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
@@ -46,7 +46,7 @@ private[pushkit] object ForwardProxyHttpsContext {
     val certificate = x509Certificate(trustPem)
     val sslContext = SSLContext.getInstance(SSL)
 
-    val alias = certificate.getIssuerDN.getName
+    val alias = certificate.getIssuerX500Principal.getName
     val trustStore = KeyStore.getInstance(KeyStore.getDefaultType)
     trustStore.load(null, null)
     trustStore.setCertificateEntry(alias, certificate)


### PR DESCRIPTION
fixes #1201

https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/security/cert/X509Certificate.html#getIssuerDN()