### PR TITLE
remove unnecessary conversion

### DIFF
--- a/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSession.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraSession.scala
@@ -272,7 +272,6 @@ final class CassandraSession(system: pekko.actor.ActorSystem,
   def selectAll(stmt: Statement[_]): Future[immutable.Seq[Row]] = {
     select(stmt)
       .runWith(Sink.seq)
-      .map(_.toVector) // Sink.seq returns Seq, not immutable.Seq (compilation issue in Eclipse)
   }
 
   /**


### PR DESCRIPTION
might have been needed with Scala 2.12 but we don't support that in main branch any more