### PR TITLE
use latest version of circe

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -345,7 +345,8 @@ object Dependencies {
     libraryDependencies ++= Seq(
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "org.mdedetrich" %% "pekko-stream-circe" % PekkoStreamsCirceVersion,
-      "org.mdedetrich" %% "pekko-http-circe" % PekkoStreamsCirceVersion))
+      "org.mdedetrich" %% "pekko-http-circe" % PekkoStreamsCirceVersion,
+      "io.circe" %% "circe-jawn" % "0.14.15"))
 
   val JakartaMs = {
     val artemisVersion = "2.42.0"


### PR DESCRIPTION
we get circe as a transitive dependency but it would be good not rely on the upstream pekko-stream-circe lib to ensure we use latest circe