### PR TITLE
Remove deprecated Apache StringUtils

### DIFF
--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -13,7 +13,7 @@
 
 import sbtheader.HeaderPlugin.autoImport._
 import sbtheader.{ CommentCreator, HeaderPlugin, NewLine }
-import org.apache.commons.lang3.StringUtils
+import org.apache.commons.lang3.Strings
 import sbt.Keys._
 import sbt._
 
@@ -113,16 +113,16 @@ trait CopyrightHeader extends AutoPlugin {
   })
 
   private def isGenerated(text: String): Boolean =
-    StringUtils.contains(text, "DO NOT EDIT DIRECTLY")
+    Strings.CS.contains(text, "DO NOT EDIT DIRECTLY")
 
   private def isApacheCopyrighted(text: String): Boolean =
-    StringUtils.containsIgnoreCase(text, "licensed to the apache software foundation (asf)") ||
-    StringUtils.containsIgnoreCase(text, "www.apache.org/licenses/license-2.0") ||
-    StringUtils.contains(text, "Apache License, Version 2.0") ||
-    StringUtils.contains(text, "Apache-2.0")
+    Strings.CI.contains(text, "licensed to the apache software foundation (asf)") ||
+    Strings.CI.contains(text, "www.apache.org/licenses/license-2.0") ||
+    Strings.CS.contains(text, "Apache License, Version 2.0") ||
+    Strings.CS.contains(text, "Apache-2.0")
 
   private def isLightbendCopyrighted(text: String): Boolean =
-    StringUtils.containsIgnoreCase(text, "lightbend inc.")
+    Strings.CI.contains(text, "lightbend inc.")
 
   private def isOnlyLightbendCopyrightAnnotated(text: String): Boolean = {
     isLightbendCopyrighted(text) && !isApacheCopyrighted(text)


### PR DESCRIPTION
Note that `Strings.CS` means case sensitive where as `Strings.CI` means case insensitive