### PR TITLE
Update sbt-pekko-build plugin version to 0.4.7

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
 addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.5")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 // discipline


### PR DESCRIPTION
upgrade sbt plugin so that we can use 1.x to indicate latest pekko 1 release instead needing to be more specific