### PR TITLE
update java format

### DIFF
--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -36,17 +44,7 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-
 import org.junit.*;
-
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
 
 /** Needs a local running AMQP server on the default port with no password. */
 public class AmqpDocsTest {

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -15,19 +15,18 @@ package org.apache.pekko.stream.connectors.amqp.javadsl;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import org.apache.pekko.stream.connectors.amqp.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
+import java.net.ConnectException;
+import org.apache.pekko.stream.connectors.amqp.*;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.net.ConnectException;
 
 public class AmqpConnectionProvidersTest {
 

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
@@ -13,6 +13,18 @@
 
 package org.apache.pekko.stream.connectors.amqp.javadsl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import com.rabbitmq.client.AuthenticationFailureException;
+import java.net.ConnectException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -31,22 +43,9 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import com.rabbitmq.client.AuthenticationFailureException;
 import org.junit.*;
 import scala.collection.JavaConverters;
 import scala.concurrent.duration.Duration;
-
-import java.net.ConnectException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 
 /** Needs a local running AMQP server on the default port with no password. */
 public class AmqpConnectorsTest {

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
@@ -18,17 +18,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
-
-import scala.collection.JavaConverters;
-
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
-
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -45,6 +34,14 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.util.ByteString;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import scala.collection.JavaConverters;
 
 /** Needs a local running AMQP server on the default port with no password. */
 @RunWith(Parameterized.class)
@@ -55,11 +52,8 @@ public class AmqpFlowTest {
     return Arrays.asList(false, true);
   }
 
-  /**
-   * This value is initialized with values from data() array
-   */
-  @Parameter
-  public boolean reuseByteArray;
+  /** This value is initialized with values from data() array */
+  @Parameter public boolean reuseByteArray;
 
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 

--- a/aws-spi-pekko-http/src/test/java/org/apache/pekko/stream/connectors/awsspi/s3/S3Test.java
+++ b/aws-spi-pekko-http/src/test/java/org/apache/pekko/stream/connectors/awsspi/s3/S3Test.java
@@ -17,6 +17,15 @@
 
 package org.apache.pekko.stream.connectors.awsspi.s3;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpAsyncHttpService;
 import org.junit.jupiter.api.Test;
@@ -33,16 +42,6 @@ import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Testcontainers
 public class S3Test {

--- a/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
+++ b/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awslambda.javadsl.AwsLambdaFlow;
@@ -26,16 +35,6 @@ import org.junit.*;
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class AwsLambdaFlowTest {
 
@@ -57,7 +56,8 @@ public class AwsLambdaFlowTest {
 
   @After
   public void checkForStageLeaks() {
-    StreamTestKit.assertAllStagesStopped(org.apache.pekko.stream.Materializer.matFromSystem(system));
+    StreamTestKit.assertAllStagesStopped(
+        org.apache.pekko.stream.Materializer.matFromSystem(system));
   }
 
   @Test

--- a/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
+++ b/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import com.microsoft.azure.storage.*;
+import com.microsoft.azure.storage.queue.*;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -30,17 +39,6 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.microsoft.azure.storage.*;
-import com.microsoft.azure.storage.queue.*;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
-
 import org.junit.*;
 
 public class JavaDslTest {
@@ -90,7 +88,8 @@ public class JavaDslTest {
 
   @After
   public void checkForStageLeaks() {
-    StreamTestKit.assertAllStagesStopped(org.apache.pekko.stream.Materializer.matFromSystem(system));
+    StreamTestKit.assertAllStagesStopped(
+        org.apache.pekko.stream.Materializer.matFromSystem(system));
   }
 
   @Test

--- a/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
@@ -13,6 +13,11 @@
 
 package docs.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.cassandra.CassandraSessionSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
@@ -22,12 +27,6 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
-
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class CassandraTestHelper {
   final ActorSystem system;

--- a/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
@@ -13,12 +13,11 @@
 
 package org.apache.pekko.stream.connectors.couchbase.javadsl;
 
+import com.typesafe.config.Config;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
-import com.typesafe.config.Config;
-
-import java.util.concurrent.CompletionStage;
 
 /**
  * Utility to delegate Couchbase node address lookup to
@@ -26,8 +25,8 @@ import java.util.concurrent.CompletionStage;
  */
 public final class DiscoverySupport {
 
-  private static final org.apache.pekko.stream.connectors.couchbase.scaladsl.DiscoverySupport SUPPORT =
-      org.apache.pekko.stream.connectors.couchbase.scaladsl.DiscoverySupport.INSTANCE();
+  private static final org.apache.pekko.stream.connectors.couchbase.scaladsl.DiscoverySupport
+      SUPPORT = org.apache.pekko.stream.connectors.couchbase.scaladsl.DiscoverySupport.INSTANCE();
 
   /**
    * Expects a `service` section in the given Config and reads the given service name's address to

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/ByteOrderMark.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/ByteOrderMark.java
@@ -38,5 +38,6 @@ public class ByteOrderMark {
       org.apache.pekko.stream.connectors.csv.scaladsl.ByteOrderMark.UTF_32_LE();
 
   /** Byte Order Mark for UTF-8 */
-  public static final ByteString UTF_8 = org.apache.pekko.stream.connectors.csv.scaladsl.ByteOrderMark.UTF_8();
+  public static final ByteString UTF_8 =
+      org.apache.pekko.stream.connectors.csv.scaladsl.ByteOrderMark.UTF_8();
 }

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvFormatting.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvFormatting.java
@@ -13,6 +13,10 @@
 
 package org.apache.pekko.stream.connectors.csv.javadsl;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Optional;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.csv.scaladsl.CsvQuotingStyle$;
 import org.apache.pekko.stream.javadsl.Flow;
@@ -21,11 +25,6 @@ import scala.Option;
 import scala.Some;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.List;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Optional;
 
 /**
  * Provides CSV formatting flows that convert a sequence of String into their CSV representation in

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvParsing.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvParsing.java
@@ -13,12 +13,11 @@
 
 package org.apache.pekko.stream.connectors.csv.javadsl;
 
+import java.util.Collection;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.util.ByteString;
 import scala.collection.JavaConverters;
-
-import java.util.Collection;
 
 public class CsvParsing {
 

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvToMap.java
@@ -13,17 +13,16 @@
 
 package org.apache.pekko.stream.connectors.csv.javadsl;
 
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.connectors.csv.impl.CsvToMapAsStringsJavaStage;
-import org.apache.pekko.stream.connectors.csv.impl.CsvToMapJavaStage;
-import org.apache.pekko.util.ByteString;
-
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.pekko.stream.connectors.csv.impl.CsvToMapAsStringsJavaStage;
+import org.apache.pekko.stream.connectors.csv.impl.CsvToMapJavaStage;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.util.ByteString;
 
 public class CsvToMap {
 

--- a/doc-examples/src/test/java/org/apache/pekko/stream/connectors/eip/javadsl/PassThroughExamples.java
+++ b/doc-examples/src/test/java/org/apache/pekko/stream/connectors/eip/javadsl/PassThroughExamples.java
@@ -13,6 +13,12 @@
 
 package org.apache.pekko.stream.connectors.eip.javadsl;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -27,16 +33,9 @@ import org.apache.pekko.kafka.javadsl.Consumer;
 import org.apache.pekko.stream.*;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 public class PassThroughExamples {
   private static ActorSystem system;
@@ -112,6 +111,7 @@ class PassThroughFlow {
             }));
   }
 }
+
 // #PassThrough
 
 class PassThroughFlowKafkaCommitExample {

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
@@ -13,26 +13,25 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.connectors.elasticsearch.*;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.connectors.elasticsearch.*;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
 public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -13,6 +13,9 @@
 
 package docs.javadsl;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.model.ContentTypes;
@@ -28,10 +31,6 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 public class ElasticsearchTestBase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -50,6 +49,7 @@ public class ElasticsearchTestBase {
       this.title = title;
     }
   }
+
   // #define-class
 
   @BeforeClass
@@ -64,7 +64,8 @@ public class ElasticsearchTestBase {
   }
 
   protected static void prepareIndex(
-      int port, org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase version) throws IOException {
+      int port, org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase version)
+      throws IOException {
     connectionSettings =
         ElasticsearchConnectionSettings.create(String.format("http://localhost:%d", port));
 
@@ -120,6 +121,7 @@ public class ElasticsearchTestBase {
     }
     // #custom-search-params
   }
+
   // #custom-search-params
 
   static class KafkaCommitter {

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.elasticsearch.*;
@@ -21,19 +30,9 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSin
 import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class ElasticsearchV5Test extends ElasticsearchTestBase {
   @BeforeClass

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.elasticsearch.*;
@@ -21,18 +29,9 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSin
 import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
 
 public class ElasticsearchV7Test extends ElasticsearchTestBase {
   @BeforeClass

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
@@ -13,26 +13,25 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.connectors.elasticsearch.*;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.connectors.elasticsearch.*;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 @RunWith(value = Parameterized.class)
 public class OpensearchParameterizedTest extends ElasticsearchTestBase {

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.elasticsearch.*;
@@ -21,18 +29,9 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSin
 import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
 
 public class OpensearchV1Test extends ElasticsearchTestBase {
   @BeforeClass

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
@@ -13,6 +13,14 @@
 
 package org.apache.pekko.stream.connectors.file.impl;
 
+import static java.nio.file.StandardWatchEventKinds.*;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.function.BiFunction;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.annotation.InternalApi;
 import org.apache.pekko.japi.Pair;
@@ -25,16 +33,7 @@ import org.apache.pekko.stream.stage.AbstractOutHandler;
 import org.apache.pekko.stream.stage.GraphStage;
 import org.apache.pekko.stream.stage.GraphStageLogic;
 import org.apache.pekko.stream.stage.TimerGraphStageLogic;
-import com.sun.nio.file.SensitivityWatchEventModifier;
 import scala.concurrent.duration.FiniteDuration;
-
-import java.io.IOException;
-import java.nio.file.*;
-import java.util.ArrayDeque;
-import java.util.Queue;
-import java.util.function.BiFunction;
-
-import static java.nio.file.StandardWatchEventKinds.*;
 
 /**
  * INTERNAL API

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/FileTailSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/FileTailSource.java
@@ -13,6 +13,13 @@
 
 package org.apache.pekko.stream.connectors.file.impl;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import org.apache.pekko.annotation.InternalApi;
 import org.apache.pekko.stream.Attributes;
 import org.apache.pekko.stream.Outlet;
@@ -23,14 +30,6 @@ import scala.concurrent.duration.FiniteDuration;
 import scala.util.Failure;
 import scala.util.Success;
 import scala.util.Try;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.AsynchronousFileChannel;
-import java.nio.channels.CompletionHandler;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 /**
  * INTERNAL API

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/Directory.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/Directory.java
@@ -13,15 +13,14 @@
 
 package org.apache.pekko.stream.connectors.file.javadsl;
 
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.StreamConverters;
-
-import java.nio.file.FileVisitOption;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 public final class Directory {
 

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/DirectoryChangesSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/DirectoryChangesSource.java
@@ -13,13 +13,11 @@
 
 package org.apache.pekko.stream.connectors.file.javadsl;
 
+import java.nio.file.Path;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.file.DirectoryChange;
 import org.apache.pekko.stream.javadsl.Source;
-
-import java.nio.file.Path;
-
 import scala.jdk.javaapi.DurationConverters;
 
 /**
@@ -40,9 +38,6 @@ public final class DirectoryChangesSource {
       Path directoryPath, java.time.Duration pollInterval, int maxBufferSize) {
     return Source.fromGraph(
         new org.apache.pekko.stream.connectors.file.impl.DirectoryChangesSource<>(
-            directoryPath,
-            DurationConverters.toScala(pollInterval),
-            maxBufferSize,
-            Pair::apply));
+            directoryPath, DurationConverters.toScala(pollInterval), maxBufferSize, Pair::apply));
   }
 }

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
@@ -13,15 +13,13 @@
 
 package org.apache.pekko.stream.connectors.file.javadsl;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Framing;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-
 import scala.jdk.javaapi.DurationConverters;
 
 /**
@@ -54,10 +52,7 @@ public final class FileTailSource {
       Path path, int maxChunkSize, long startingPosition, java.time.Duration pollingInterval) {
     return Source.fromGraph(
         new org.apache.pekko.stream.connectors.file.impl.FileTailSource(
-            path,
-            maxChunkSize,
-            startingPosition,
-            DurationConverters.toScala(pollingInterval)));
+            path, maxChunkSize, startingPosition, DurationConverters.toScala(pollingInterval)));
   }
 
   /**

--- a/file/src/test/java/docs/javadsl/ArchiveHelper.java
+++ b/file/src/test/java/docs/javadsl/ArchiveHelper.java
@@ -13,13 +13,12 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.util.ByteString;
-
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.apache.pekko.util.ByteString;
 
 public class ArchiveHelper {
 

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -13,6 +13,21 @@
 
 package docs.javadsl;
 
+import static org.apache.pekko.util.ByteString.emptyByteString;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -32,23 +47,6 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.*;
-
-import static org.apache.pekko.util.ByteString.emptyByteString;
-
-import java.io.File;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
 
 public class ArchiveTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/file/src/test/java/docs/javadsl/FileTailSourceTest.java
+++ b/file/src/test/java/docs/javadsl/FileTailSourceTest.java
@@ -13,6 +13,22 @@
 
 package docs.javadsl;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.io.FileNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.concurrent.TimeoutException;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.pf.PFBuilder;
@@ -28,24 +44,7 @@ import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 import org.junit.*;
-
-import java.io.FileNotFoundException;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.concurrent.TimeoutException;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.StandardOpenOption.APPEND;
-import static java.nio.file.StandardOpenOption.WRITE;
-import static org.junit.Assert.assertEquals;
 
 public class FileTailSourceTest {
 

--- a/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
+++ b/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
@@ -13,6 +13,17 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -26,18 +37,6 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.*;
-
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
 
 public class LogRotatorSinkTest {
 

--- a/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
+++ b/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
@@ -13,6 +13,17 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.ClassicActorSystemProvider;
@@ -23,23 +34,12 @@ import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.CoreMatchers.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class NestedTarReaderTest {
   private static final Logger logger = LoggerFactory.getLogger(NestedTarReaderTest.class);

--- a/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
@@ -15,10 +15,10 @@ package docs.javadsl;
 
 // #configure-custom-ssh-client
 
-import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.ftp.javadsl.SftpApi;
 import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
+import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
+import org.apache.pekko.stream.connectors.ftp.javadsl.SftpApi;
 
 public class ConfigureCustomSSHClient {
 

--- a/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
@@ -14,13 +14,13 @@
 package docs.javadsl;
 
 // #moving
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.FtpFile;
 import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.Sink;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class FtpMovingExample {
 

--- a/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
@@ -14,6 +14,8 @@
 package docs.javadsl;
 
 // #processAndMove
+import java.nio.file.Files;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.ftp.FtpFile;
@@ -21,9 +23,6 @@ import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.FileIO;
 import org.apache.pekko.stream.javadsl.RunnableGraph;
-
-import java.nio.file.Files;
-import java.util.function.Function;
 
 public class FtpProcessAndMoveExample {
 

--- a/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
@@ -14,12 +14,12 @@
 package docs.javadsl;
 
 // #removing
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.FtpFile;
 import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.Sink;
-import java.util.concurrent.CompletionStage;
 
 public class FtpRemovingExample {
 

--- a/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
@@ -14,12 +14,12 @@
 package docs.javadsl;
 
 // #retrieving
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import java.util.concurrent.CompletionStage;
 
 public class FtpRetrievingExample {
 

--- a/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
@@ -15,13 +15,12 @@ package docs.javadsl;
 
 // #retrieving-with-unconfirmed-reads
 
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.SftpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-
-import java.util.concurrent.CompletionStage;
 
 public class SftpRetrievingExample {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/BaseSupportImpl.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/BaseSupportImpl.java
@@ -13,14 +13,13 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.Materializer;
-import org.junit.After;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.Materializer;
+import org.junit.After;
 
 public abstract class BaseSupportImpl implements BaseSupport, PekkoSupport {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
@@ -13,11 +13,19 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.time.Instant;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.IOResult;
-import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
@@ -25,15 +33,6 @@ import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.util.ByteString;
 import org.junit.Assert;
-
-import java.time.Instant;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 interface CommonFtpStageTest extends BaseSupport, PekkoSupport {
 
@@ -49,7 +48,8 @@ interface CommonFtpStageTest extends BaseSupport, PekkoSupport {
       throws Exception;
 
   default <T> T await(CompletionStage<T> result)
-      throws InterruptedException, java.util.concurrent.ExecutionException,
+      throws InterruptedException,
+          java.util.concurrent.ExecutionException,
           java.util.concurrent.TimeoutException {
     return result.toCompletableFuture().get(10, TimeUnit.SECONDS);
   }

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpStageTest.java
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
@@ -23,9 +26,6 @@ import org.apache.pekko.util.ByteString;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class FtpStageTest extends BaseFtpSupport implements CommonFtpStageTest {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpWithProxyStageTest.java
@@ -13,6 +13,11 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
@@ -23,12 +28,6 @@ import org.apache.pekko.util.ByteString;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class FtpWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsStageTest.java
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftps;
@@ -20,13 +23,8 @@ import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class FtpsStageTest extends BaseFtpSupport implements CommonFtpStageTest {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsWithProxyStageTest.java
@@ -13,6 +13,11 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftps;
@@ -24,17 +29,11 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-
 public class FtpsWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
 
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
-  private final static int PROXYPORT = 3128;
+  private static final int PROXYPORT = 3128;
   private final Proxy PROXY =
       new Proxy(Proxy.Type.HTTP, new InetSocketAddress(HOSTNAME, PROXYPORT));
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/KeyFileSftpSourceTest.java
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
@@ -22,9 +25,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.Rule;
 import org.junit.Test;
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class KeyFileSftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/RawKeySftpSourceTest.java
@@ -13,6 +13,11 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
@@ -22,11 +27,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.Rule;
 import org.junit.Test;
-import java.net.InetAddress;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class RawKeySftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpStageTest.java
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
@@ -23,10 +26,6 @@ import org.apache.pekko.util.ByteString;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class SftpStageTest extends BaseSftpSupport implements CommonFtpStageTest {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpWithProxyStageTest.java
@@ -13,6 +13,11 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
@@ -23,12 +28,6 @@ import org.apache.pekko.util.ByteString;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.net.InetAddress;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class SftpWithProxyStageTest extends BaseSftpSupport implements CommonFtpStageTest {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/StrictHostCheckingSftpSourceTest.java
@@ -13,6 +13,9 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
@@ -22,9 +25,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.Rule;
 import org.junit.Test;
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class StrictHostCheckingSftpSourceTest extends BaseSftpSupport
     implements CommonFtpStageTest {

--- a/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/Geode.java
+++ b/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/Geode.java
@@ -13,23 +13,20 @@
 
 package org.apache.pekko.stream.connectors.geode.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
 import org.apache.pekko.stream.connectors.geode.GeodeSettings;
+import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
 import org.apache.pekko.stream.connectors.geode.RegionSettings;
 import org.apache.pekko.stream.connectors.geode.impl.GeodeCache;
-
 import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeFiniteSourceStage;
 import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeFlowStage;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.apache.geode.cache.client.ClientCacheFactory;
-
-import java.util.concurrent.CompletionStage;
-
 import scala.jdk.javaapi.FutureConverters;
 
 /** Java API: Geode client without server event subscription. */
@@ -47,7 +44,8 @@ public class Geode extends GeodeCache {
     return factory.addPoolLocator(geodeSettings.hostname(), geodeSettings.port());
   }
 
-  public <V> Source<V, CompletionStage<Done>> query(String query, PekkoPdxSerializer<V> serializer) {
+  public <V> Source<V, CompletionStage<Done>> query(
+      String query, PekkoPdxSerializer<V> serializer) {
 
     registerPDXSerializer(serializer, serializer.clazz());
     return Source.fromGraph(new GeodeFiniteSourceStage<V>(cache(), query))
@@ -55,7 +53,7 @@ public class Geode extends GeodeCache {
   }
 
   public <K, V> Flow<V, V, NotUsed> flow(
-          RegionSettings<K, V> regionSettings, PekkoPdxSerializer<V> serializer) {
+      RegionSettings<K, V> regionSettings, PekkoPdxSerializer<V> serializer) {
 
     registerPDXSerializer(serializer, serializer.clazz());
 
@@ -63,7 +61,7 @@ public class Geode extends GeodeCache {
   }
 
   public <K, V> Sink<V, CompletionStage<Done>> sink(
-          RegionSettings<K, V> regionSettings, PekkoPdxSerializer<V> serializer) {
+      RegionSettings<K, V> regionSettings, PekkoPdxSerializer<V> serializer) {
     return flow(regionSettings, serializer).toMat(Sink.ignore(), Keep.right());
   }
 

--- a/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/GeodeWithPoolSubscription.java
+++ b/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/GeodeWithPoolSubscription.java
@@ -13,18 +13,16 @@
 
 package org.apache.pekko.stream.connectors.geode.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
-import org.apache.pekko.stream.connectors.geode.GeodeSettings;
-import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeContinuousSourceStage;
-import org.apache.pekko.stream.javadsl.Source;
+import java.util.concurrent.CompletionStage;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.query.CqException;
 import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.query.QueryService;
-
-import java.util.concurrent.CompletionStage;
-
+import org.apache.pekko.Done;
+import org.apache.pekko.stream.connectors.geode.GeodeSettings;
+import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
+import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeContinuousSourceStage;
+import org.apache.pekko.stream.javadsl.Source;
 import scala.jdk.javaapi.FutureConverters;
 
 /** Java API: Geode client with server event subscription. Can build continuous sources. */
@@ -44,7 +42,7 @@ public class GeodeWithPoolSubscription extends Geode {
   }
 
   public <V> Source<V, CompletionStage<Done>> continuousQuery(
-          String queryName, String query, PekkoPdxSerializer<V> serializer) {
+      String queryName, String query, PekkoPdxSerializer<V> serializer) {
     registerPDXSerializer(serializer, serializer.clazz());
     return Source.fromGraph(new GeodeContinuousSourceStage<V>(cache(), queryName, query))
         .mapMaterializedValue(FutureConverters::<Done>asJava);

--- a/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
@@ -13,6 +13,8 @@
 
 package docs.javadsl;
 
+import java.util.Arrays;
+import java.util.Date;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.geode.GeodeSettings;
@@ -24,13 +26,9 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-
 import org.junit.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.Date;
 
 public class GeodeBaseTestCase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -50,6 +48,7 @@ public class GeodeBaseTestCase {
       RegionSettings.create("persons", Person::getId);
   protected final RegionSettings<Integer, Animal> animalRegionSettings =
       RegionSettings.create("animals", Animal::getId);
+
   // #region
 
   @BeforeClass

--- a/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
@@ -13,6 +13,11 @@
 
 package docs.javadsl;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
@@ -24,12 +29,6 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 public class GeodeContinuousSourceTestCase extends GeodeBaseTestCase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
@@ -13,14 +13,13 @@
 
 package docs.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.Done;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 public class GeodeFiniteSourceTestCase extends GeodeBaseTestCase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
@@ -13,6 +13,9 @@
 
 package docs.javadsl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
@@ -22,10 +25,6 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 public class GeodeFlowTestCase extends GeodeBaseTestCase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
@@ -13,6 +13,8 @@
 
 package docs.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
@@ -23,9 +25,6 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 public class GeodeSinkTestCase extends GeodeBaseTestCase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
+++ b/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
@@ -13,6 +13,15 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.javadsl;
 
+import static org.junit.Assert.*;
+
+import com.google.cloud.bigquery.storage.v1.DataFormat;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pekko.stream.Attributes;
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryRecord;
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryStorageSettings;
@@ -21,19 +30,7 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.scaladsl.
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.scaladsl.GrpcBigQueryStorageReader;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.Sink;
-
-import com.google.cloud.bigquery.storage.v1.DataFormat;
-import com.google.cloud.bigquery.storage.v1.ReadSession;
-
 import org.junit.*;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static org.junit.Assert.*;
 
 public class BigQueryStorageSpec extends BigQueryStorageSpecBase {
 

--- a/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
+++ b/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
@@ -15,6 +15,23 @@ package docs.javadsl;
 
 // #imports
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+// #imports
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.http.javadsl.marshallers.jackson.Jackson;
@@ -43,24 +60,6 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableSchema
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-// #imports
 
 public class BigQueryDoc {
 
@@ -146,6 +145,7 @@ public class BigQueryDoc {
       }
     }
   }
+
   // #setup
 
   String datasetId;

--- a/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -13,6 +13,26 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.e2e.javadsl;
 
+import static org.junit.Assert.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.specto.hoverfly.junit.core.Hoverfly;
+import io.specto.hoverfly.junit.core.HoverflyMode;
+import io.specto.hoverfly.junit.core.SimulationSource;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.marshallers.jackson.Jackson;
@@ -36,30 +56,9 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableFieldS
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableSchema;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.specto.hoverfly.junit.core.Hoverfly;
-import io.specto.hoverfly.junit.core.HoverflyMode;
-import io.specto.hoverfly.junit.core.SimulationSource;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.*;
 
 public class BigQueryEndToEndTest extends EndToEndHelper {
 

--- a/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
+++ b/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import com.google.common.collect.Lists;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -22,16 +31,6 @@ import org.apache.pekko.stream.RestartSettings;
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.*;
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.javadsl.GooglePubSub;
 import org.apache.pekko.stream.javadsl.*;
-import com.google.common.collect.Lists;
-
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-import java.time.Duration;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
 
 public class ExampleUsageJava {
 

--- a/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
+++ b/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
@@ -13,6 +13,13 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -32,14 +39,6 @@ import org.apache.pekko.util.ByteString;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.*;
 
 public class GCStorageTest extends GCStorageWiremockBase {
 
@@ -799,7 +798,8 @@ public class GCStorageTest extends GCStorageWiremockBase {
       source.runWith(sink, system()).toCompletableFuture().get(5, TimeUnit.SECONDS);
     } catch (Exception e) {
       assertEquals(
-          "org.apache.pekko.stream.connectors.googlecloud.storage.FailedUpload: Uploading part failed with status 400 Bad Request: Chunk upload failed",
+          "org.apache.pekko.stream.connectors.googlecloud.storage.FailedUpload: Uploading part"
+              + " failed with status 400 Bad Request: Chunk upload failed",
           e.getMessage());
     }
   }

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -13,6 +13,20 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.*;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -25,25 +39,10 @@ import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.*;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-
-import static org.junit.Assert.assertEquals;
 
 public class HBaseStageTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -147,6 +146,7 @@ public class HBaseStageTest {
           return Collections.emptyList();
         }
       };
+
   // #create-converter-complex
 
   @Test
@@ -197,7 +197,9 @@ public class HBaseStageTest {
 
   @Test
   public void readFromSource()
-      throws InterruptedException, TimeoutException, ExecutionException,
+      throws InterruptedException,
+          TimeoutException,
+          ExecutionException,
           UnsupportedEncodingException {
 
     HTableSettings<Person> tableSettings =

--- a/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
@@ -13,6 +13,19 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertArrayEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -27,21 +40,7 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.compress.DefaultCodec;
 import org.junit.*;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertArrayEquals;
 
 public class HdfsReaderTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbCpu.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbCpu.java
@@ -14,7 +14,6 @@
 package docs.javadsl;
 
 import java.time.Instant;
-
 import org.influxdb.annotation.Measurement;
 
 // #define-class

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceCpu.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceCpu.java
@@ -14,7 +14,6 @@
 package docs.javadsl;
 
 import java.time.Instant;
-
 import org.influxdb.annotation.Measurement;
 
 @Measurement(name = "cpu", database = "InfluxDbSourceTest")

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
@@ -13,26 +13,25 @@
 
 package docs.javadsl;
 
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
-import org.influxdb.InfluxDB;
-import org.influxdb.dto.Query;
-import org.influxdb.dto.QueryResult;
-import org.junit.*;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.stream.connectors.influxdb.InfluxDbReadSettings;
-import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSource;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import org.apache.pekko.testkit.javadsl.TestKit;
 import static docs.javadsl.TestUtils.cleanDatabase;
 import static docs.javadsl.TestUtils.dropDatabase;
 import static docs.javadsl.TestUtils.populateDatabase;
 import static docs.javadsl.TestUtils.setupConnection;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.Materializer;
+import org.apache.pekko.stream.connectors.influxdb.InfluxDbReadSettings;
+import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSource;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.*;
 
 public class InfluxDbSourceTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
@@ -13,6 +13,13 @@
 
 package docs.javadsl;
 
+import static docs.javadsl.TestUtils.cleanDatabase;
+import static docs.javadsl.TestUtils.dropDatabase;
+import static docs.javadsl.TestUtils.populateDatabase;
+import static docs.javadsl.TestUtils.resultToPoint;
+import static docs.javadsl.TestUtils.setupConnection;
+import static org.junit.Assert.assertEquals;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -25,14 +32,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
-import org.influxdb.InfluxDB;
-import org.influxdb.dto.Point;
-import org.influxdb.dto.Query;
-import org.influxdb.dto.QueryResult;
-import org.junit.*;
-
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -43,16 +42,16 @@ import org.apache.pekko.stream.connectors.influxdb.InfluxDbWriteResult;
 import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbFlow;
 import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSink;
 import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSource;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import static docs.javadsl.TestUtils.cleanDatabase;
-import static docs.javadsl.TestUtils.dropDatabase;
-import static docs.javadsl.TestUtils.populateDatabase;
-import static docs.javadsl.TestUtils.resultToPoint;
-import static docs.javadsl.TestUtils.setupConnection;
-import static org.junit.Assert.assertEquals;
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.*;
 
 public class InfluxDbTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
+++ b/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
@@ -13,24 +13,23 @@
 
 package org.apache.pekko.stream.connectors.ironmq;
 
+import static scala.collection.JavaConverters.*;
+import static scala.jdk.javaapi.FutureConverters.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.ironmq.impl.IronMqClient;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
-
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static scala.jdk.javaapi.FutureConverters.*;
-import static scala.collection.JavaConverters.*;
 
 public abstract class UnitTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/javadsl/IronMqConsumerTest.java
+++ b/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/javadsl/IronMqConsumerTest.java
@@ -13,6 +13,10 @@
 
 package org.apache.pekko.stream.connectors.ironmq.javadsl;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.stream.connectors.ironmq.IronMqSettings;
 import org.apache.pekko.stream.connectors.ironmq.PushMessage;
 import org.apache.pekko.stream.connectors.ironmq.UnitTest;
@@ -21,11 +25,6 @@ import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class IronMqConsumerTest extends UnitTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -13,11 +13,22 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
 import com.typesafe.config.Config;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
@@ -37,356 +48,341 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-
 public class JmsBufferedAckConnectorsTest {
 
-    @Rule
-    public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
-    private static ActorSystem system;
-    private static Config consumerConfig;
-    private static Config producerConfig;
+  private static ActorSystem system;
+  private static Config consumerConfig;
+  private static Config producerConfig;
 
-    @BeforeClass
-    public static void setup() {
-        system = ActorSystem.create();
-        consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
-        producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
+  @BeforeClass
+  public static void setup() {
+    system = ActorSystem.create();
+    consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
+    producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
+  }
+
+  @AfterClass
+  public static void teardown() {
+    TestKit.shutdownActorSystem(system);
+  }
+
+  private List<JmsTextMessage> createTestMessageList() {
+    List<Integer> intsIn = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    List<JmsTextMessage> msgsIn = new ArrayList<>();
+    for (Integer n : intsIn) {
+      msgsIn.add(
+          JmsTextMessage.create(n.toString())
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0));
     }
 
-    @AfterClass
-    public static void teardown() {
-        TestKit.shutdownActorSystem(system);
+    return msgsIn;
+  }
+
+  @Test
+  public void publishAndConsume() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<String, CompletionStage<Done>> jmsSink =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
+          Source.from(in).runWith(jmsSink, system);
+
+          Source<AckEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withBufferSize(5)
+                      .withQueue("test"));
+
+          CompletionStage<List<String>> result =
+              jmsSource
+                  .take(in.size())
+                  .map(env -> new Pair<>(env, ((TextMessage) env.message()).getText()))
+                  .map(
+                      pair -> {
+                        pair.first().acknowledge();
+                        return pair.second();
+                      })
+                  .runWith(Sink.seq(), system);
+          List<String> out = new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          Collections.sort(out);
+          assertEquals(in, out);
+        });
+  }
+
+  @Test
+  public void publishAndConsumeJmsTextMessagesWithProperties() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          // #source
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn = createTestMessageList();
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          // #source
+          Source<org.apache.pekko.stream.connectors.jakartams.AckEnvelope, JmsConsumerControl>
+              jmsSource =
+                  JmsConsumer.ackSource(
+                      JmsConsumerSettings.create(system, connectionFactory)
+                          .withSessionCount(5)
+                          .withQueue("test"));
+
+          CompletionStage<List<jakarta.jms.Message>> result =
+              jmsSource
+                  .take(msgsIn.size())
+                  .map(
+                      envelope -> {
+                        envelope.acknowledge();
+                        return envelope.message();
+                      })
+                  .runWith(Sink.seq(), system);
+          // #source
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                msgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                msgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishAndConsumeJmsTextMessagesWithHeaders() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn =
+              createTestMessageList().stream()
+                  .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsType.create("type")))
+                  .map(
+                      jmsTextMessage ->
+                          jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
+                  .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
+                  .collect(Collectors.toList());
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          Source<AckEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withQueue("test"));
+
+          CompletionStage<List<Message>> result =
+              jmsSource
+                  .take(msgsIn.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return env.message();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                msgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                msgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
+            assertEquals(outMsg.getJMSType(), "type");
+            assertEquals(outMsg.getJMSCorrelationID(), "correlationId");
+            assertEquals(((ActiveMQQueue) outMsg.getJMSReplyTo()).getQueueName(), "test-reply");
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishJmsTextMessagesWithPropertiesAndConsumeThemWithASelector() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn = createTestMessageList();
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          Source<AckEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withBufferSize(5)
+                      .withQueue("test")
+                      .withSelector("IsOdd = TRUE"));
+
+          List<JmsTextMessage> oddMsgsIn =
+              msgsIn.stream()
+                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
+                  .collect(Collectors.toList());
+          assertEquals(5, oddMsgsIn.size());
+
+          CompletionStage<List<Message>> result =
+              jmsSource
+                  .take(oddMsgsIn.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return env.message();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                oddMsgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                oddMsgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (oddMsgsIn.get(msgIdx).properties().get("IsEven").get()));
+            assertEquals(1, outMsg.getIntProperty("Number") % 2);
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishAndConsumeTopic() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
+          List<String> inNumbers =
+              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+
+          Sink<String, CompletionStage<Done>> jmsTopicSink =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
+          Sink<String, CompletionStage<Done>> jmsTopicSink2 =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
+
+          Source<AckEnvelope, JmsConsumerControl> jmsTopicSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(1)
+                      .withBufferSize(5)
+                      .withTopic("topic"));
+          Source<AckEnvelope, JmsConsumerControl> jmsTopicSource2 =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(1)
+                      .withBufferSize(5)
+                      .withTopic("topic"));
+
+          CompletionStage<List<String>> result =
+              jmsTopicSource
+                  .take(in.size() + inNumbers.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return ((TextMessage) env.message()).getText();
+                      })
+                  .runWith(Sink.seq(), system)
+                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+          CompletionStage<List<String>> result2 =
+              jmsTopicSource2
+                  .take(in.size() + inNumbers.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return ((TextMessage) env.message()).getText();
+                      })
+                  .runWith(Sink.seq(), system)
+                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+
+          Thread.sleep(500);
+
+          Source.from(in).runWith(jmsTopicSink, system);
+          Source.from(inNumbers).runWith(jmsTopicSink2, system);
+
+          assertEquals(
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              result.toCompletableFuture().get(5, TimeUnit.SECONDS));
+          assertEquals(
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
+        });
+  }
+
+  private void withServer(ConsumerChecked<EmbeddedActiveMQResource> test) throws Exception {
+    EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
+    try {
+      server.start();
+      test.accept(server);
+      Thread.sleep(500);
+    } finally {
+      server.stop();
     }
+  }
 
-    private List<JmsTextMessage> createTestMessageList() {
-        List<Integer> intsIn = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        List<JmsTextMessage> msgsIn = new ArrayList<>();
-        for (Integer n : intsIn) {
-            msgsIn.add(
-                    JmsTextMessage.create(n.toString())
-                            .withProperty("Number", n)
-                            .withProperty("IsOdd", n % 2 == 1)
-                            .withProperty("IsEven", n % 2 == 0));
-        }
+  private void withConnectionFactory(ConsumerChecked<ConnectionFactory> test) throws Exception {
+    withServer(server -> test.accept(new ActiveMQConnectionFactory(server.getVmURL())));
+  }
 
-        return msgsIn;
-    }
-
-    @Test
-    public void publishAndConsume() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-
-                    Sink<String, CompletionStage<Done>> jmsSink =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-                    Source.from(in).runWith(jmsSink, system);
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withBufferSize(5)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<String>> result =
-                            jmsSource
-                                    .take(in.size())
-                                    .map(env -> new Pair<>(env, ((TextMessage) env.message()).getText()))
-                                    .map(
-                                            pair -> {
-                                                pair.first().acknowledge();
-                                                return pair.second();
-                                            })
-                                    .runWith(Sink.seq(), system);
-                    List<String> out = new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    Collections.sort(out);
-                    assertEquals(in, out);
-                });
-    }
-
-    @Test
-    public void publishAndConsumeJmsTextMessagesWithProperties() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    // #source
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn = createTestMessageList();
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    // #source
-                    Source<org.apache.pekko.stream.connectors.jakartams.AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(system, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<jakarta.jms.Message>> result =
-                            jmsSource
-                                    .take(msgsIn.size())
-                                    .map(
-                                            envelope -> {
-                                                envelope.acknowledge();
-                                                return envelope.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-                    // #source
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                msgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                msgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishAndConsumeJmsTextMessagesWithHeaders() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn =
-                            createTestMessageList().stream()
-                                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsType.create("type")))
-                                    .map(
-                                            jmsTextMessage ->
-                                                    jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
-                                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                                    .collect(Collectors.toList());
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<Message>> result =
-                            jmsSource
-                                    .take(msgsIn.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return env.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                msgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                msgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        assertEquals(outMsg.getJMSType(), "type");
-                        assertEquals(outMsg.getJMSCorrelationID(), "correlationId");
-                        assertEquals(((ActiveMQQueue) outMsg.getJMSReplyTo()).getQueueName(), "test-reply");
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishJmsTextMessagesWithPropertiesAndConsumeThemWithASelector() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn = createTestMessageList();
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withBufferSize(5)
-                                            .withQueue("test")
-                                            .withSelector("IsOdd = TRUE"));
-
-                    List<JmsTextMessage> oddMsgsIn =
-                            msgsIn.stream()
-                                    .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                                    .collect(Collectors.toList());
-                    assertEquals(5, oddMsgsIn.size());
-
-                    CompletionStage<List<Message>> result =
-                            jmsSource
-                                    .take(oddMsgsIn.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return env.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                oddMsgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                oddMsgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (oddMsgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        assertEquals(1, outMsg.getIntProperty("Number") % 2);
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishAndConsumeTopic() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-                    List<String> inNumbers =
-                            IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
-
-                    Sink<String, CompletionStage<Done>> jmsTopicSink =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
-                    Sink<String, CompletionStage<Done>> jmsTopicSink2 =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsTopicSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(1)
-                                            .withBufferSize(5)
-                                            .withTopic("topic"));
-                    Source<AckEnvelope, JmsConsumerControl> jmsTopicSource2 =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(1)
-                                            .withBufferSize(5)
-                                            .withTopic("topic"));
-
-                    CompletionStage<List<String>> result =
-                            jmsTopicSource
-                                    .take(in.size() + inNumbers.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return ((TextMessage) env.message()).getText();
-                                            })
-                                    .runWith(Sink.seq(), system)
-                                    .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
-                    CompletionStage<List<String>> result2 =
-                            jmsTopicSource2
-                                    .take(in.size() + inNumbers.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return ((TextMessage) env.message()).getText();
-                                            })
-                                    .runWith(Sink.seq(), system)
-                                    .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
-
-                    Thread.sleep(500);
-
-                    Source.from(in).runWith(jmsTopicSink, system);
-                    Source.from(inNumbers).runWith(jmsTopicSink2, system);
-
-                    assertEquals(
-                            Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
-                            result.toCompletableFuture().get(5, TimeUnit.SECONDS));
-                    assertEquals(
-                            Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
-                            result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
-                });
-    }
-
-    private void withServer(ConsumerChecked<EmbeddedActiveMQResource> test) throws Exception {
-        EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
-        try {
-            server.start();
-            test.accept(server);
-            Thread.sleep(500);
-        } finally {
-            server.stop();
-        }
-    }
-
-    private void withConnectionFactory(ConsumerChecked<ConnectionFactory> test) throws Exception {
-        withServer(
-                server -> test.accept(new ActiveMQConnectionFactory(server.getVmURL()))
-        );
-    }
-
-    @FunctionalInterface
-    private interface ConsumerChecked<T> {
-        void accept(T elt) throws Exception;
-    }
+  @FunctionalInterface
+  private interface ConsumerChecked<T> {
+    void accept(T elt) throws Exception;
+  }
 }

--- a/jakartams/src/test/java/docs/javadsl/JmsSettingsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsSettingsTest.java
@@ -13,8 +13,13 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.time.Duration;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.apache.pekko.stream.connectors.jakartams.*;
@@ -23,83 +28,76 @@ import org.junit.Rule;
 import org.junit.Test;
 import scala.Option;
 
-import java.time.Duration;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-
 // #retry-settings #send-retry-settings
 
 public class JmsSettingsTest {
 
-    @Rule
-    public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
-    @Test
-    public void producerSettings() throws Exception {
+  @Test
+  public void producerSettings() throws Exception {
 
-        Config config = ConfigFactory.load();
-        // #retry-settings
-        Config connectionRetryConfig = config.getConfig("pekko.connectors.jakartams.connection-retry");
-        // reiterating the values from reference.conf
-        ConnectionRetrySettings retrySettings =
-                ConnectionRetrySettings.create(connectionRetryConfig)
-                        .withConnectTimeout(Duration.ofSeconds(10))
-                        .withInitialRetry(Duration.ofMillis(100))
-                        .withBackoffFactor(2.0)
-                        .withMaxBackoff(Duration.ofMinutes(1))
-                        .withMaxRetries(10);
-        // #retry-settings
+    Config config = ConfigFactory.load();
+    // #retry-settings
+    Config connectionRetryConfig = config.getConfig("pekko.connectors.jakartams.connection-retry");
+    // reiterating the values from reference.conf
+    ConnectionRetrySettings retrySettings =
+        ConnectionRetrySettings.create(connectionRetryConfig)
+            .withConnectTimeout(Duration.ofSeconds(10))
+            .withInitialRetry(Duration.ofMillis(100))
+            .withBackoffFactor(2.0)
+            .withMaxBackoff(Duration.ofMinutes(1))
+            .withMaxRetries(10);
+    // #retry-settings
 
-        ConnectionRetrySettings retrySettings2 = ConnectionRetrySettings.create(connectionRetryConfig);
-        assertEquals(retrySettings.toString(), retrySettings2.toString());
+    ConnectionRetrySettings retrySettings2 = ConnectionRetrySettings.create(connectionRetryConfig);
+    assertEquals(retrySettings.toString(), retrySettings2.toString());
 
-        // #send-retry-settings
-        Config sendRetryConfig = config.getConfig("pekko.connectors.jakartams.send-retry");
-        // reiterating the values from reference.conf
-        SendRetrySettings sendRetrySettings =
-                SendRetrySettings.create(sendRetryConfig)
-                        .withInitialRetry(Duration.ofMillis(20))
-                        .withBackoffFactor(1.5d)
-                        .withMaxBackoff(Duration.ofMillis(500))
-                        .withMaxRetries(10);
-        // #send-retry-settings
-        SendRetrySettings sendRetrySettings2 = SendRetrySettings.create(sendRetryConfig);
-        assertEquals(sendRetrySettings.toString(), sendRetrySettings2.toString());
-        EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
-        // #producer-settings
-        Config producerConfig = config.getConfig(JmsProducerSettings.configPath());
-        JmsProducerSettings settings =
-                JmsProducerSettings.create(producerConfig, new ActiveMQConnectionFactory(server.getVmURL()))
-                        .withTopic("target-topic")
-                        .withCredentials(Credentials.create("username", "password"))
-                        .withConnectionRetrySettings(retrySettings)
-                        .withSendRetrySettings(sendRetrySettings)
-                        .withSessionCount(10)
-                        .withTimeToLive(Duration.ofHours(1));
-        // #producer-settings
-    }
+    // #send-retry-settings
+    Config sendRetryConfig = config.getConfig("pekko.connectors.jakartams.send-retry");
+    // reiterating the values from reference.conf
+    SendRetrySettings sendRetrySettings =
+        SendRetrySettings.create(sendRetryConfig)
+            .withInitialRetry(Duration.ofMillis(20))
+            .withBackoffFactor(1.5d)
+            .withMaxBackoff(Duration.ofMillis(500))
+            .withMaxRetries(10);
+    // #send-retry-settings
+    SendRetrySettings sendRetrySettings2 = SendRetrySettings.create(sendRetryConfig);
+    assertEquals(sendRetrySettings.toString(), sendRetrySettings2.toString());
+    EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
+    // #producer-settings
+    Config producerConfig = config.getConfig(JmsProducerSettings.configPath());
+    JmsProducerSettings settings =
+        JmsProducerSettings.create(producerConfig, new ActiveMQConnectionFactory(server.getVmURL()))
+            .withTopic("target-topic")
+            .withCredentials(Credentials.create("username", "password"))
+            .withConnectionRetrySettings(retrySettings)
+            .withSendRetrySettings(sendRetrySettings)
+            .withSessionCount(10)
+            .withTimeToLive(Duration.ofHours(1));
+    // #producer-settings
+  }
 
-    @Test
-    public void consumerSettings() throws Exception {
-        Config config = ConfigFactory.load();
-        Config connectionRetryConfig = config.getConfig("pekko.connectors.jakartams.connection-retry");
-        ConnectionRetrySettings retrySettings = ConnectionRetrySettings.create(connectionRetryConfig);
-        EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
+  @Test
+  public void consumerSettings() throws Exception {
+    Config config = ConfigFactory.load();
+    Config connectionRetryConfig = config.getConfig("pekko.connectors.jakartams.connection-retry");
+    ConnectionRetrySettings retrySettings = ConnectionRetrySettings.create(connectionRetryConfig);
+    EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
 
-        // #consumer-settings
-        Config consumerConfig = config.getConfig(JmsConsumerSettings.configPath());
-        JmsConsumerSettings settings =
-                JmsConsumerSettings.create(consumerConfig, new ActiveMQConnectionFactory(server.getVmURL()))
-                        .withTopic("message-topic")
-                        .withCredentials(Credentials.create("username", "password"))
-                        .withConnectionRetrySettings(retrySettings)
-                        .withSessionCount(10)
-                        .withAcknowledgeMode(AcknowledgeMode.AutoAcknowledge())
-                        .withSelector("Important = TRUE");
-        // #consumer-settings
-        assertThat(settings.sessionCount(), is(10));
-        assertThat(settings.acknowledgeMode(), is(Option.apply(AcknowledgeMode.AutoAcknowledge())));
-    }
+    // #consumer-settings
+    Config consumerConfig = config.getConfig(JmsConsumerSettings.configPath());
+    JmsConsumerSettings settings =
+        JmsConsumerSettings.create(consumerConfig, new ActiveMQConnectionFactory(server.getVmURL()))
+            .withTopic("message-topic")
+            .withCredentials(Credentials.create("username", "password"))
+            .withConnectionRetrySettings(retrySettings)
+            .withSessionCount(10)
+            .withAcknowledgeMode(AcknowledgeMode.AutoAcknowledge())
+            .withSelector("Important = TRUE");
+    // #consumer-settings
+    assertThat(settings.sessionCount(), is(10));
+    assertThat(settings.acknowledgeMode(), is(Option.apply(AcknowledgeMode.AutoAcknowledge())));
+  }
 }

--- a/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -13,11 +13,23 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
 import com.typesafe.config.Config;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
@@ -37,358 +49,343 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-
 public class JmsTxConnectorsTest {
 
-    @Rule
-    public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
-    private static ActorSystem system;
-    private static Config consumerConfig;
-    private static Config producerConfig;
+  private static ActorSystem system;
+  private static Config consumerConfig;
+  private static Config producerConfig;
 
-    @BeforeClass
-    public static void setup() {
-        system = ActorSystem.create();
-        consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
-        producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
+  @BeforeClass
+  public static void setup() {
+    system = ActorSystem.create();
+    consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
+    producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
+  }
+
+  @AfterClass
+  public static void teardown() {
+    TestKit.shutdownActorSystem(system);
+  }
+
+  private List<JmsTextMessage> createTestMessageList() {
+    List<Integer> intsIn = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    List<JmsTextMessage> msgsIn = new ArrayList<>();
+    for (Integer n : intsIn) {
+      msgsIn.add(
+          JmsTextMessage.create(n.toString())
+              .withProperty("Number", n)
+              .withProperty("IsOdd", n % 2 == 1)
+              .withProperty("IsEven", n % 2 == 0));
     }
 
-    @AfterClass
-    public static void teardown() {
-        TestKit.shutdownActorSystem(system);
+    return msgsIn;
+  }
+
+  @Test
+  public void publishAndConsume() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<String, CompletionStage<Done>> jmsSink =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
+          Source.from(in).runWith(jmsSink, system);
+
+          Source<TxEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.txSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withQueue("test"));
+
+          CompletionStage<List<String>> result =
+              jmsSource
+                  .take(in.size())
+                  .map(env -> new Pair<>(env, ((TextMessage) env.message()).getText()))
+                  .map(
+                      pair -> {
+                        pair.first().commit();
+                        return pair.second();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<String> out = new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          Collections.sort(out);
+          assertEquals(in, out);
+        });
+  }
+
+  @Test
+  public void publishAndConsumeJmsTextMessagesWithProperties() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn = createTestMessageList();
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          // #source
+          Source<org.apache.pekko.stream.connectors.jakartams.TxEnvelope, JmsConsumerControl>
+              jmsSource =
+                  JmsConsumer.txSource(
+                      JmsConsumerSettings.create(system, connectionFactory)
+                          .withSessionCount(5)
+                          .withAckTimeout(Duration.ofSeconds(1))
+                          .withQueue("test"));
+
+          CompletionStage<List<jakarta.jms.Message>> result =
+              jmsSource
+                  .take(msgsIn.size())
+                  .map(
+                      txEnvelope -> {
+                        txEnvelope.commit();
+                        return txEnvelope.message();
+                      })
+                  .runWith(Sink.seq(), system);
+          // #source
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                msgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                msgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishAndConsumeJmsTextMessagesWithHeaders() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn =
+              createTestMessageList().stream()
+                  .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsType.create("type")))
+                  .map(
+                      jmsTextMessage ->
+                          jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
+                  .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
+                  .collect(Collectors.toList());
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          Source<TxEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.txSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withQueue("test"));
+
+          CompletionStage<List<Message>> result =
+              jmsSource
+                  .take(msgsIn.size())
+                  .map(
+                      env -> {
+                        env.commit();
+                        return env.message();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                msgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                msgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
+            assertEquals(outMsg.getJMSType(), "type");
+            assertEquals(outMsg.getJMSCorrelationID(), "correlationId");
+            assertEquals(((ActiveMQQueue) outMsg.getJMSReplyTo()).getQueueName(), "test-reply");
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishJmsTextMessagesWithPropertiesAndConsumeThemWithASelector() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn = createTestMessageList();
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          Source<TxEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.txSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withQueue("test")
+                      .withSelector("IsOdd = TRUE"));
+
+          List<JmsTextMessage> oddMsgsIn =
+              msgsIn.stream()
+                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
+                  .collect(Collectors.toList());
+          assertEquals(5, oddMsgsIn.size());
+
+          CompletionStage<List<Message>> result =
+              jmsSource
+                  .take(oddMsgsIn.size())
+                  .map(
+                      env -> {
+                        env.commit();
+                        return env.message();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                oddMsgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                oddMsgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (oddMsgsIn.get(msgIdx).properties().get("IsEven").get()));
+            assertEquals(1, outMsg.getIntProperty("Number") % 2);
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishAndConsumeTopic() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
+          List<String> inNumbers =
+              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+
+          Sink<String, CompletionStage<Done>> jmsTopicSink =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
+
+          Sink<String, CompletionStage<Done>> jmsTopicSink2 =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
+
+          Source<TxEnvelope, JmsConsumerControl> jmsTopicSource =
+              JmsConsumer.txSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(1)
+                      .withTopic("topic"));
+
+          Source<TxEnvelope, JmsConsumerControl> jmsTopicSource2 =
+              JmsConsumer.txSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(1)
+                      .withTopic("topic"));
+
+          CompletionStage<List<String>> result =
+              jmsTopicSource
+                  .take(in.size() + inNumbers.size())
+                  .map(
+                      env -> {
+                        env.commit();
+                        return ((TextMessage) env.message()).getText();
+                      })
+                  .runWith(Sink.seq(), system)
+                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+
+          CompletionStage<List<String>> result2 =
+              jmsTopicSource2
+                  .take(in.size() + inNumbers.size())
+                  .map(
+                      env -> {
+                        env.commit();
+                        return ((TextMessage) env.message()).getText();
+                      })
+                  .runWith(Sink.seq(), system)
+                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+
+          Thread.sleep(500);
+
+          Source.from(in).runWith(jmsTopicSink, system);
+
+          Source.from(inNumbers).runWith(jmsTopicSink2, system);
+
+          assertEquals(
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              result.toCompletableFuture().get(5, TimeUnit.SECONDS));
+          assertEquals(
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
+        });
+  }
+
+  private void withServer(ConsumerChecked<EmbeddedActiveMQResource> test) throws Exception {
+    EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
+    try {
+      server.start();
+      test.accept(server);
+      Thread.sleep(500);
+    } finally {
+      if (server.getServer().getActiveMQServer().isStarted()) {
+        server.stop();
+      }
     }
+  }
 
-    private List<JmsTextMessage> createTestMessageList() {
-        List<Integer> intsIn = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        List<JmsTextMessage> msgsIn = new ArrayList<>();
-        for (Integer n : intsIn) {
-            msgsIn.add(
-                    JmsTextMessage.create(n.toString())
-                            .withProperty("Number", n)
-                            .withProperty("IsOdd", n % 2 == 1)
-                            .withProperty("IsEven", n % 2 == 0));
-        }
+  private void withConnectionFactory(ConsumerChecked<ConnectionFactory> test) throws Exception {
+    withServer(server -> test.accept(new ActiveMQConnectionFactory(server.getVmURL())));
+  }
 
-        return msgsIn;
-    }
-
-    @Test
-    public void publishAndConsume() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<String, CompletionStage<Done>> jmsSink =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-                    Source.from(in).runWith(jmsSink, system);
-
-                    Source<TxEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.txSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<String>> result =
-                            jmsSource
-                                    .take(in.size())
-                                    .map(env -> new Pair<>(env, ((TextMessage) env.message()).getText()))
-                                    .map(
-                                            pair -> {
-                                                pair.first().commit();
-                                                return pair.second();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<String> out = new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    Collections.sort(out);
-                    assertEquals(in, out);
-                });
-    }
-
-    @Test
-    public void publishAndConsumeJmsTextMessagesWithProperties() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn = createTestMessageList();
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    // #source
-                    Source<org.apache.pekko.stream.connectors.jakartams.TxEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.txSource(
-                                    JmsConsumerSettings.create(system, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withAckTimeout(Duration.ofSeconds(1))
-                                            .withQueue("test"));
-
-                    CompletionStage<List<jakarta.jms.Message>> result =
-                            jmsSource
-                                    .take(msgsIn.size())
-                                    .map(
-                                            txEnvelope -> {
-                                                txEnvelope.commit();
-                                                return txEnvelope.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-                    // #source
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                msgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                msgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishAndConsumeJmsTextMessagesWithHeaders() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn =
-                            createTestMessageList().stream()
-                                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsType.create("type")))
-                                    .map(
-                                            jmsTextMessage ->
-                                                    jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
-                                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                                    .collect(Collectors.toList());
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    Source<TxEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.txSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<Message>> result =
-                            jmsSource
-                                    .take(msgsIn.size())
-                                    .map(
-                                            env -> {
-                                                env.commit();
-                                                return env.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                msgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                msgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        assertEquals(outMsg.getJMSType(), "type");
-                        assertEquals(outMsg.getJMSCorrelationID(), "correlationId");
-                        assertEquals(((ActiveMQQueue) outMsg.getJMSReplyTo()).getQueueName(), "test-reply");
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishJmsTextMessagesWithPropertiesAndConsumeThemWithASelector() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn = createTestMessageList();
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    Source<TxEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.txSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withQueue("test")
-                                            .withSelector("IsOdd = TRUE"));
-
-                    List<JmsTextMessage> oddMsgsIn =
-                            msgsIn.stream()
-                                    .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                                    .collect(Collectors.toList());
-                    assertEquals(5, oddMsgsIn.size());
-
-                    CompletionStage<List<Message>> result =
-                            jmsSource
-                                    .take(oddMsgsIn.size())
-                                    .map(
-                                            env -> {
-                                                env.commit();
-                                                return env.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                oddMsgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                oddMsgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (oddMsgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        assertEquals(1, outMsg.getIntProperty("Number") % 2);
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishAndConsumeTopic() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-                    List<String> inNumbers =
-                            IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
-
-                    Sink<String, CompletionStage<Done>> jmsTopicSink =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
-
-                    Sink<String, CompletionStage<Done>> jmsTopicSink2 =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
-
-                    Source<TxEnvelope, JmsConsumerControl> jmsTopicSource =
-                            JmsConsumer.txSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(1)
-                                            .withTopic("topic"));
-
-                    Source<TxEnvelope, JmsConsumerControl> jmsTopicSource2 =
-                            JmsConsumer.txSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(1)
-                                            .withTopic("topic"));
-
-                    CompletionStage<List<String>> result =
-                            jmsTopicSource
-                                    .take(in.size() + inNumbers.size())
-                                    .map(
-                                            env -> {
-                                                env.commit();
-                                                return ((TextMessage) env.message()).getText();
-                                            })
-                                    .runWith(Sink.seq(), system)
-                                    .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
-
-                    CompletionStage<List<String>> result2 =
-                            jmsTopicSource2
-                                    .take(in.size() + inNumbers.size())
-                                    .map(
-                                            env -> {
-                                                env.commit();
-                                                return ((TextMessage) env.message()).getText();
-                                            })
-                                    .runWith(Sink.seq(), system)
-                                    .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
-
-                    Thread.sleep(500);
-
-                    Source.from(in).runWith(jmsTopicSink, system);
-
-                    Source.from(inNumbers).runWith(jmsTopicSink2, system);
-
-                    assertEquals(
-                            Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
-                            result.toCompletableFuture().get(5, TimeUnit.SECONDS));
-                    assertEquals(
-                            Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
-                            result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
-                });
-    }
-
-    private void withServer(ConsumerChecked<EmbeddedActiveMQResource> test) throws Exception {
-        EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
-        try {
-            server.start();
-            test.accept(server);
-            Thread.sleep(500);
-        } finally {
-            if (server.getServer().getActiveMQServer().isStarted()) {
-                server.stop();
-            }
-        }
-    }
-
-    private void withConnectionFactory(ConsumerChecked<ConnectionFactory> test) throws Exception {
-        withServer(
-                server -> test.accept(new ActiveMQConnectionFactory(server.getVmURL()))
-        );
-    }
-
-    @FunctionalInterface
-    private interface ConsumerChecked<T> {
-        void accept(T elt) throws Exception;
-    }
+  @FunctionalInterface
+  private interface ConsumerChecked<T> {
+    void accept(T elt) throws Exception;
+  }
 }

--- a/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
+++ b/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
@@ -13,11 +13,19 @@
 
 package org.apache.pekko.stream.connectors.jakartams.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
 import com.typesafe.config.Config;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
@@ -34,354 +42,342 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-
 public class JmsAckConnectorsTest {
 
-    @Rule
-    public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
-    private static ActorSystem system;
-    private static Config consumerConfig;
-    private static Config producerConfig;
+  private static ActorSystem system;
+  private static Config consumerConfig;
+  private static Config producerConfig;
 
-    @BeforeClass
-    public static void setup() {
-        system = ActorSystem.create();
-        consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
-        producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
+  @BeforeClass
+  public static void setup() {
+    system = ActorSystem.create();
+    consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
+    producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
+  }
+
+  @AfterClass
+  public static void teardown() {
+    TestKit.shutdownActorSystem(system);
+  }
+
+  private List<JmsTextMessage> createTestMessageList() {
+    List<Integer> intsIn = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    List<JmsTextMessage> msgsIn = new ArrayList<>();
+    for (Integer n : intsIn) {
+      final Map<String, Object> map = new HashMap<>();
+      map.put("Number", n);
+      map.put("IsOdd", n % 2 == 1);
+      map.put("IsEven", n % 2 == 0);
+
+      msgsIn.add(JmsTextMessage.create(n.toString()).withProperties(map));
     }
 
-    @AfterClass
-    public static void teardown() {
-        TestKit.shutdownActorSystem(system);
+    return msgsIn;
+  }
+
+  @Test
+  public void publishAndConsume() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<String, CompletionStage<Done>> jmsSink =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
+          Source.from(in).runWith(jmsSink, system);
+
+          Source<AckEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withBufferSize(0)
+                      .withQueue("test"));
+
+          CompletionStage<List<String>> result =
+              jmsSource
+                  .take(in.size())
+                  .map(env -> new Pair<>(env, ((TextMessage) env.message()).getText()))
+                  .map(
+                      pair -> {
+                        pair.first().acknowledge();
+                        return pair.second();
+                      })
+                  .runWith(Sink.seq(), system);
+          List<String> out = new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          Collections.sort(out);
+          assertEquals(in, out);
+        });
+  }
+
+  @Test
+  public void publishAndConsumeJmsTextMessagesWithProperties() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn = createTestMessageList();
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          Source<AckEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withBufferSize(0)
+                      .withQueue("test"));
+
+          CompletionStage<List<Message>> result =
+              jmsSource
+                  .take(msgsIn.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return env.message();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                msgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                msgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishAndConsumeJmsTextMessagesWithHeaders() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn =
+              createTestMessageList().stream()
+                  .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsType.create("type")))
+                  .map(
+                      jmsTextMessage ->
+                          jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
+                  .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
+                  .collect(Collectors.toList());
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          Source<AckEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withBufferSize(0)
+                      .withQueue("test"));
+
+          CompletionStage<List<Message>> result =
+              jmsSource
+                  .take(msgsIn.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return env.message();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                msgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                msgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
+            assertEquals(outMsg.getJMSType(), "type");
+            assertEquals(outMsg.getJMSCorrelationID(), "correlationId");
+            assertEquals(((ActiveMQQueue) outMsg.getJMSReplyTo()).getQueueName(), "test-reply");
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishJmsTextMessagesWithPropertiesAndConsumeThemWithASelector() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
+              JmsProducer.sink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
+
+          List<JmsTextMessage> msgsIn = createTestMessageList();
+
+          Source.from(msgsIn).runWith(jmsSink, system);
+
+          Source<AckEnvelope, JmsConsumerControl> jmsSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(5)
+                      .withBufferSize(0)
+                      .withQueue("test")
+                      .withSelector("IsOdd = TRUE"));
+
+          List<JmsTextMessage> oddMsgsIn =
+              msgsIn.stream()
+                  .filter(msg -> Integer.parseInt(msg.body()) % 2 == 1)
+                  .collect(Collectors.toList());
+          assertEquals(5, oddMsgsIn.size());
+
+          CompletionStage<List<Message>> result =
+              jmsSource
+                  .take(oddMsgsIn.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return env.message();
+                      })
+                  .runWith(Sink.seq(), system);
+
+          List<Message> outMessages =
+              new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
+          outMessages.sort(
+              (a, b) -> {
+                try {
+                  return a.getIntProperty("Number") - b.getIntProperty("Number");
+                } catch (JMSException e) {
+                  throw new RuntimeException(e);
+                }
+              });
+
+          int msgIdx = 0;
+          for (Message outMsg : outMessages) {
+            assertEquals(
+                outMsg.getIntProperty("Number"),
+                oddMsgsIn.get(msgIdx).properties().get("Number").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsOdd"),
+                oddMsgsIn.get(msgIdx).properties().get("IsOdd").get());
+            assertEquals(
+                outMsg.getBooleanProperty("IsEven"),
+                (oddMsgsIn.get(msgIdx).properties().get("IsEven").get()));
+            assertEquals(1, outMsg.getIntProperty("Number") % 2);
+            msgIdx++;
+          }
+        });
+  }
+
+  @Test
+  public void publishAndConsumeTopic() throws Exception {
+    withConnectionFactory(
+        connectionFactory -> {
+          List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
+          List<String> inNumbers =
+              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+
+          Sink<String, CompletionStage<Done>> jmsTopicSink =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
+          Sink<String, CompletionStage<Done>> jmsTopicSink2 =
+              JmsProducer.textSink(
+                  JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
+
+          Source<AckEnvelope, JmsConsumerControl> jmsTopicSource =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(1)
+                      .withBufferSize(0)
+                      .withTopic("topic"));
+          Source<AckEnvelope, JmsConsumerControl> jmsTopicSource2 =
+              JmsConsumer.ackSource(
+                  JmsConsumerSettings.create(consumerConfig, connectionFactory)
+                      .withSessionCount(1)
+                      .withBufferSize(0)
+                      .withTopic("topic"));
+
+          CompletionStage<List<String>> result =
+              jmsTopicSource
+                  .take(in.size() + inNumbers.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return ((TextMessage) env.message()).getText();
+                      })
+                  .runWith(Sink.seq(), system)
+                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+          CompletionStage<List<String>> result2 =
+              jmsTopicSource2
+                  .take(in.size() + inNumbers.size())
+                  .map(
+                      env -> {
+                        env.acknowledge();
+                        return ((TextMessage) env.message()).getText();
+                      })
+                  .runWith(Sink.seq(), system)
+                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+
+          Thread.sleep(500);
+
+          Source.from(in).runWith(jmsTopicSink, system);
+          Source.from(inNumbers).runWith(jmsTopicSink2, system);
+
+          assertEquals(
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              result.toCompletableFuture().get(5, TimeUnit.SECONDS));
+          assertEquals(
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
+        });
+  }
+
+  private void withServer(ConsumerChecked<EmbeddedActiveMQResource> test) throws Exception {
+    EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
+    try {
+      server.start();
+      test.accept(server);
+      Thread.sleep(500);
+    } finally {
+      if (server.getServer().getActiveMQServer().isStarted()) {
+        server.stop();
+      }
     }
+  }
 
-    private List<JmsTextMessage> createTestMessageList() {
-        List<Integer> intsIn = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
-        List<JmsTextMessage> msgsIn = new ArrayList<>();
-        for (Integer n : intsIn) {
-            final Map<String, Object> map = new HashMap<>();
-            map.put("Number", n);
-            map.put("IsOdd", n % 2 == 1);
-            map.put("IsEven", n % 2 == 0);
+  private void withConnectionFactory(ConsumerChecked<ConnectionFactory> test) throws Exception {
+    withServer(server -> test.accept(new ActiveMQConnectionFactory(server.getVmURL())));
+  }
 
-            msgsIn.add(JmsTextMessage.create(n.toString()).withProperties(map));
-        }
-
-        return msgsIn;
-    }
-
-    @Test
-    public void publishAndConsume() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<String, CompletionStage<Done>> jmsSink =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-                    Source.from(in).runWith(jmsSink, system);
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withBufferSize(0)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<String>> result =
-                            jmsSource
-                                    .take(in.size())
-                                    .map(env -> new Pair<>(env, ((TextMessage) env.message()).getText()))
-                                    .map(
-                                            pair -> {
-                                                pair.first().acknowledge();
-                                                return pair.second();
-                                            })
-                                    .runWith(Sink.seq(), system);
-                    List<String> out = new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    Collections.sort(out);
-                    assertEquals(in, out);
-                });
-    }
-
-    @Test
-    public void publishAndConsumeJmsTextMessagesWithProperties() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn = createTestMessageList();
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withBufferSize(0)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<Message>> result =
-                            jmsSource
-                                    .take(msgsIn.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return env.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                msgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                msgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishAndConsumeJmsTextMessagesWithHeaders() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn =
-                            createTestMessageList().stream()
-                                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsType.create("type")))
-                                    .map(
-                                            jmsTextMessage ->
-                                                    jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
-                                    .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                                    .collect(Collectors.toList());
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withBufferSize(0)
-                                            .withQueue("test"));
-
-                    CompletionStage<List<Message>> result =
-                            jmsSource
-                                    .take(msgsIn.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return env.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                msgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                msgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (msgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        assertEquals(outMsg.getJMSType(), "type");
-                        assertEquals(outMsg.getJMSCorrelationID(), "correlationId");
-                        assertEquals(((ActiveMQQueue) outMsg.getJMSReplyTo()).getQueueName(), "test-reply");
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishJmsTextMessagesWithPropertiesAndConsumeThemWithASelector() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    Sink<JmsTextMessage, CompletionStage<Done>> jmsSink =
-                            JmsProducer.sink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withQueue("test"));
-
-                    List<JmsTextMessage> msgsIn = createTestMessageList();
-
-                    Source.from(msgsIn).runWith(jmsSink, system);
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(5)
-                                            .withBufferSize(0)
-                                            .withQueue("test")
-                                            .withSelector("IsOdd = TRUE"));
-
-                    List<JmsTextMessage> oddMsgsIn =
-                            msgsIn.stream()
-                                    .filter(msg -> Integer.parseInt(msg.body()) % 2 == 1)
-                                    .collect(Collectors.toList());
-                    assertEquals(5, oddMsgsIn.size());
-
-                    CompletionStage<List<Message>> result =
-                            jmsSource
-                                    .take(oddMsgsIn.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return env.message();
-                                            })
-                                    .runWith(Sink.seq(), system);
-
-                    List<Message> outMessages =
-                            new ArrayList<>(result.toCompletableFuture().get(3, TimeUnit.SECONDS));
-                    outMessages.sort(
-                            (a, b) -> {
-                                try {
-                                    return a.getIntProperty("Number") - b.getIntProperty("Number");
-                                } catch (JMSException e) {
-                                    throw new RuntimeException(e);
-                                }
-                            });
-
-                    int msgIdx = 0;
-                    for (Message outMsg : outMessages) {
-                        assertEquals(
-                                outMsg.getIntProperty("Number"),
-                                oddMsgsIn.get(msgIdx).properties().get("Number").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsOdd"),
-                                oddMsgsIn.get(msgIdx).properties().get("IsOdd").get());
-                        assertEquals(
-                                outMsg.getBooleanProperty("IsEven"),
-                                (oddMsgsIn.get(msgIdx).properties().get("IsEven").get()));
-                        assertEquals(1, outMsg.getIntProperty("Number") % 2);
-                        msgIdx++;
-                    }
-                });
-    }
-
-    @Test
-    public void publishAndConsumeTopic() throws Exception {
-        withConnectionFactory(
-                connectionFactory -> {
-                    List<String> in = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-                    List<String> inNumbers =
-                            IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
-
-                    Sink<String, CompletionStage<Done>> jmsTopicSink =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
-                    Sink<String, CompletionStage<Done>> jmsTopicSink2 =
-                            JmsProducer.textSink(
-                                    JmsProducerSettings.create(producerConfig, connectionFactory).withTopic("topic"));
-
-                    Source<AckEnvelope, JmsConsumerControl> jmsTopicSource =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(1)
-                                            .withBufferSize(0)
-                                            .withTopic("topic"));
-                    Source<AckEnvelope, JmsConsumerControl> jmsTopicSource2 =
-                            JmsConsumer.ackSource(
-                                    JmsConsumerSettings.create(consumerConfig, connectionFactory)
-                                            .withSessionCount(1)
-                                            .withBufferSize(0)
-                                            .withTopic("topic"));
-
-                    CompletionStage<List<String>> result =
-                            jmsTopicSource
-                                    .take(in.size() + inNumbers.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return ((TextMessage) env.message()).getText();
-                                            })
-                                    .runWith(Sink.seq(), system)
-                                    .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
-                    CompletionStage<List<String>> result2 =
-                            jmsTopicSource2
-                                    .take(in.size() + inNumbers.size())
-                                    .map(
-                                            env -> {
-                                                env.acknowledge();
-                                                return ((TextMessage) env.message()).getText();
-                                            })
-                                    .runWith(Sink.seq(), system)
-                                    .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
-
-                    Thread.sleep(500);
-
-                    Source.from(in).runWith(jmsTopicSink, system);
-                    Source.from(inNumbers).runWith(jmsTopicSink2, system);
-
-                    assertEquals(
-                            Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
-                            result.toCompletableFuture().get(5, TimeUnit.SECONDS));
-                    assertEquals(
-                            Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
-                            result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
-                });
-    }
-
-    private void withServer(ConsumerChecked<EmbeddedActiveMQResource> test) throws Exception {
-        EmbeddedActiveMQResource server = new EmbeddedActiveMQResource();
-        try {
-            server.start();
-            test.accept(server);
-            Thread.sleep(500);
-        } finally {
-            if (server.getServer().getActiveMQServer().isStarted()) {
-                server.stop();
-            }
-        }
-    }
-
-    private void withConnectionFactory(ConsumerChecked<ConnectionFactory> test) throws Exception {
-        withServer(
-                server -> test.accept(new ActiveMQConnectionFactory(server.getVmURL()))
-        );
-    }
-
-    @FunctionalInterface
-    private interface ConsumerChecked<T> {
-        void accept(T elt) throws Exception;
-    }
+  @FunctionalInterface
+  private interface ConsumerChecked<T> {
+    void accept(T elt) throws Exception;
+  }
 }

--- a/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -13,6 +13,21 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import com.typesafe.config.Config;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import jmstestkit.JmsBroker;
+import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -24,26 +39,10 @@ import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import jmstestkit.JmsBroker;
-import com.typesafe.config.Config;
-import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
 
 public class JmsBufferedAckConnectorsTest {
 

--- a/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -13,6 +13,22 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import com.typesafe.config.Config;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import jmstestkit.JmsBroker;
+import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -24,27 +40,10 @@ import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import jmstestkit.JmsBroker;
-import com.typesafe.config.Config;
-import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
 
 public class JmsTxConnectorsTest {
 

--- a/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
@@ -13,6 +13,21 @@
 
 package org.apache.pekko.stream.connectors.jms.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import com.typesafe.config.Config;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import jmstestkit.JmsBroker;
+import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -21,26 +36,10 @@ import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.typesafe.config.Config;
-import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import jmstestkit.JmsBroker;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
 
 public class JmsAckConnectorsTest {
 

--- a/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
+++ b/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.json.javadsl.JsonReader;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
@@ -23,15 +31,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 public class JsonReaderUsageTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/kinesis/src/test/java/docs/javadsl/KclSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KclSnippets.java
@@ -13,6 +13,9 @@
 
 package docs.javadsl;
 
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.kinesis.CommittableRecord;
 import org.apache.pekko.stream.connectors.kinesis.KinesisSchedulerCheckpointSettings;
@@ -23,10 +26,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import software.amazon.kinesis.coordinator.Scheduler;
 import software.amazon.kinesis.processor.ShardRecordProcessorFactory;
 import software.amazon.kinesis.retrieval.KinesisClientRecord;
-
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
-import java.util.concurrent.CompletionStage;
 
 public class KclSnippets {
 

--- a/kinesis/src/test/java/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisTest.java
@@ -13,6 +13,12 @@
 
 package org.apache.pekko.stream.connectors.kinesis.javadsl;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.kinesis.ShardSettings;
@@ -27,13 +33,6 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.*;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.*;
 
 public class KinesisTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -85,15 +84,17 @@ public class KinesisTest {
                 invocation ->
                     CompletableFuture.completedFuture(
                         GetRecordsResponse.builder()
-                            .records(software.amazon.awssdk.services.kinesis.model.Record
-                                    .builder().sequenceNumber("1").build())
+                            .records(
+                                software.amazon.awssdk.services.kinesis.model.Record.builder()
+                                    .sequenceNumber("1")
+                                    .build())
                             .nextShardIterator("iter")
                             .build()));
 
     final Source<software.amazon.awssdk.services.kinesis.model.Record, NotUsed> source =
-            KinesisSource.basic(settings, amazonKinesisAsync);
+        KinesisSource.basic(settings, amazonKinesisAsync);
     final CompletionStage<software.amazon.awssdk.services.kinesis.model.Record> record =
-            source.runWith(Sink.head(), system);
+        source.runWith(Sink.head(), system);
 
     assertEquals("1", record.toCompletableFuture().get(10, TimeUnit.SECONDS).sequenceNumber());
   }

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -13,6 +13,22 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.CreateTableOptions;
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.PartialRow;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -25,26 +41,10 @@ import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.kudu.ColumnSchema;
-import org.apache.kudu.Schema;
-import org.apache.kudu.Type;
-import org.apache.kudu.client.CreateTableOptions;
-import org.apache.kudu.client.KuduClient;
-import org.apache.kudu.client.KuduException;
-import org.apache.kudu.client.PartialRow;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
 
 public class KuduTableTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -13,6 +13,24 @@
 
 package docs.javadsl;
 
+import static java.util.stream.Collectors.toList;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.model.Updates;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -25,31 +43,12 @@ import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.InsertManyOptions;
-import com.mongodb.client.model.Updates;
-import com.mongodb.reactivestreams.client.MongoClient;
-import com.mongodb.reactivestreams.client.MongoClients;
-import com.mongodb.reactivestreams.client.MongoCollection;
-import com.mongodb.reactivestreams.client.MongoDatabase;
 import org.bson.Document;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.bson.conversions.Bson;
 import org.junit.*;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-
-import static java.util.stream.Collectors.toList;
-import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
-import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class MongoSinkTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
@@ -13,30 +13,29 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import com.mongodb.client.result.InsertManyResult;
+import com.mongodb.reactivestreams.client.*;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.mongodb.javadsl.MongoSource;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
-import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import com.mongodb.client.result.InsertManyResult;
-import com.mongodb.reactivestreams.client.*;
 import org.bson.Document;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.junit.*;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
 
 public class MongoSourceTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertFalse;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -38,13 +44,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
-import static org.junit.Assert.assertFalse;
 
 public class MqttFlowTest {
 

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -13,6 +13,20 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLContext;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -36,23 +50,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLContext;
-
-import static org.hamcrest.CoreMatchers.*;
-
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.Assert.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
 
 public class MqttSourceTest {
 

--- a/mqttv5/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertFalse;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -38,13 +44,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
-import static org.junit.Assert.assertFalse;
 
 public class MqttFlowTest {
 

--- a/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -13,6 +13,21 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLContext;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -40,302 +55,286 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.net.ssl.SSLContext;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
 public class MqttSourceTest {
 
-    @Rule
-    public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
-    private static final Logger log = LoggerFactory.getLogger(MqttSourceTest.class);
+  private static final Logger log = LoggerFactory.getLogger(MqttSourceTest.class);
 
-    private static ActorSystem system;
+  private static ActorSystem system;
 
-    private static final int bufferSize = 8;
+  private static final int bufferSize = 8;
 
-    @BeforeClass
-    public static void setup() throws Exception {
-        system = ActorSystem.create("MqttSourceTest");
-    }
+  @BeforeClass
+  public static void setup() throws Exception {
+    system = ActorSystem.create("MqttSourceTest");
+  }
 
-    @AfterClass
-    public static void teardown() {
-        TestKit.shutdownActorSystem(system);
-    }
+  @AfterClass
+  public static void teardown() {
+    TestKit.shutdownActorSystem(system);
+  }
 
-    @Test
-    public void connectionSettings() {
-        // #create-connection-settings
-        MqttConnectionSettings connectionSettings =
-                MqttConnectionSettings.create(
-                        "tcp://localhost:1883", // (1)
-                        "test-java-client", // (2)
-                        new MemoryPersistence() // (3)
-                );
-        // #create-connection-settings
-        assertThat(connectionSettings.toString(), containsString("tcp://localhost:1883"));
-    }
+  @Test
+  public void connectionSettings() {
+    // #create-connection-settings
+    MqttConnectionSettings connectionSettings =
+        MqttConnectionSettings.create(
+            "tcp://localhost:1883", // (1)
+            "test-java-client", // (2)
+            new MemoryPersistence() // (3)
+            );
+    // #create-connection-settings
+    assertThat(connectionSettings.toString(), containsString("tcp://localhost:1883"));
+  }
 
-    @Test
-    public void connectionSettingsForSsl() throws Exception {
-        // #ssl-settings
-        MqttConnectionSettings connectionSettings =
-                MqttConnectionSettings.create("ssl://localhost:1885", "ssl-client", new MemoryPersistence())
-                        .withAuth("mqttUser", "mqttPassword")
-                        .withSocketFactory(SSLContext.getDefault().getSocketFactory());
-        // #ssl-settings
-        assertThat(connectionSettings.toString(), containsString("ssl://localhost:1885"));
-        assertThat(connectionSettings.asMqttConnectionOptions().getUserName(), is("mqttUser"));
-    }
+  @Test
+  public void connectionSettingsForSsl() throws Exception {
+    // #ssl-settings
+    MqttConnectionSettings connectionSettings =
+        MqttConnectionSettings.create("ssl://localhost:1885", "ssl-client", new MemoryPersistence())
+            .withAuth("mqttUser", "mqttPassword")
+            .withSocketFactory(SSLContext.getDefault().getSocketFactory());
+    // #ssl-settings
+    assertThat(connectionSettings.toString(), containsString("ssl://localhost:1885"));
+    assertThat(connectionSettings.asMqttConnectionOptions().getUserName(), is("mqttUser"));
+  }
 
-    @Test
-    public void publishAndConsumeWithoutAutoAck() throws Exception {
-        final String topic = "v5/source-test/manualacks";
-        final MqttConnectionSettings baseConnectionSettings =
-                MqttConnectionSettings.create(
-                        "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
+  @Test
+  public void publishAndConsumeWithoutAutoAck() throws Exception {
+    final String topic = "v5/source-test/manualacks";
+    final MqttConnectionSettings baseConnectionSettings =
+        MqttConnectionSettings.create(
+            "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
 
-        MqttConnectionSettings connectionSettings = baseConnectionSettings;
+    MqttConnectionSettings connectionSettings = baseConnectionSettings;
 
-        final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
+    final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
 
-        // #create-source-with-manualacks
-        Source<MqttMessageWithAck, CompletionStage<Done>> mqttSource =
-                MqttSource.atLeastOnce(
-                        connectionSettings
-                                .withClientId("source-test/source-withoutAutoAck")
-                                .withCleanStart(false),
-                        MqttSubscriptions.create(topic, MqttQoS.atLeastOnce()),
-                        bufferSize);
-        // #create-source-with-manualacks
+    // #create-source-with-manualacks
+    Source<MqttMessageWithAck, CompletionStage<Done>> mqttSource =
+        MqttSource.atLeastOnce(
+            connectionSettings
+                .withClientId("source-test/source-withoutAutoAck")
+                .withCleanStart(false),
+            MqttSubscriptions.create(topic, MqttQoS.atLeastOnce()),
+            bufferSize);
+    // #create-source-with-manualacks
 
-        final Pair<CompletionStage<Done>, CompletionStage<List<MqttMessageWithAck>>> unackedResult =
-                mqttSource.take(input.size()).toMat(Sink.seq(), Keep.both()).run(system);
+    final Pair<CompletionStage<Done>, CompletionStage<List<MqttMessageWithAck>>> unackedResult =
+        mqttSource.take(input.size()).toMat(Sink.seq(), Keep.both()).run(system);
 
-        unackedResult.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    unackedResult.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-        final Sink<MqttMessage, CompletionStage<Done>> mqttSink =
-                MqttSink.create(
-                        baseConnectionSettings.withClientId("source-test/sink-withoutAutoAck"),
-                        MqttQoS.atLeastOnce());
-        Source.from(input)
-                .map(s -> MqttMessage.create(topic, ByteString.fromString(s)))
-                .runWith(mqttSink, system);
+    final Sink<MqttMessage, CompletionStage<Done>> mqttSink =
+        MqttSink.create(
+            baseConnectionSettings.withClientId("source-test/sink-withoutAutoAck"),
+            MqttQoS.atLeastOnce());
+    Source.from(input)
+        .map(s -> MqttMessage.create(topic, ByteString.fromString(s)))
+        .runWith(mqttSink, system);
 
-        assertEquals(
-                input,
-                unackedResult.second().toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
-                        .map(m -> m.message().payload().utf8String())
-                        .collect(Collectors.toList()));
+    assertEquals(
+        input,
+        unackedResult.second().toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
+            .map(m -> m.message().payload().utf8String())
+            .collect(Collectors.toList()));
 
-        Flow<MqttMessageWithAck, MqttMessageWithAck, NotUsed> businessLogic = Flow.create();
+    Flow<MqttMessageWithAck, MqttMessageWithAck, NotUsed> businessLogic = Flow.create();
 
-        // #run-source-with-manualacks
-        final CompletionStage<List<MqttMessage>> result =
-                mqttSource
-                        .via(businessLogic)
-                        .mapAsync(
-                                1,
-                                messageWithAck ->
-                                        messageWithAck.ack().thenApply(unused2 -> messageWithAck.message()))
-                        .take(input.size())
-                        .runWith(Sink.seq(), system);
-        // #run-source-with-manualacks
+    // #run-source-with-manualacks
+    final CompletionStage<List<MqttMessage>> result =
+        mqttSource
+            .via(businessLogic)
+            .mapAsync(
+                1,
+                messageWithAck ->
+                    messageWithAck.ack().thenApply(unused2 -> messageWithAck.message()))
+            .take(input.size())
+            .runWith(Sink.seq(), system);
+    // #run-source-with-manualacks
 
-        assertEquals(
-                input,
-                result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream()
-                        .map(m -> m.payload().utf8String())
-                        .collect(Collectors.toList()));
-    }
+    assertEquals(
+        input,
+        result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream()
+            .map(m -> m.payload().utf8String())
+            .collect(Collectors.toList()));
+  }
 
-    @Test
-    public void keepConnectionOpenIfDownstreamClosesAndThereArePendingAcks() throws Exception {
-        final String topic = "v5/source-test/pendingacks";
-        final MqttConnectionSettings baseConnectionSettings =
-                MqttConnectionSettings.create(
-                        "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
+  @Test
+  public void keepConnectionOpenIfDownstreamClosesAndThereArePendingAcks() throws Exception {
+    final String topic = "v5/source-test/pendingacks";
+    final MqttConnectionSettings baseConnectionSettings =
+        MqttConnectionSettings.create(
+            "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
 
-        MqttConnectionSettings sourceSettings =
-                baseConnectionSettings.withClientId("source-test/source-pending");
-        MqttConnectionSettings sinkSettings =
-                baseConnectionSettings.withClientId("source-test/sink-pending");
+    MqttConnectionSettings sourceSettings =
+        baseConnectionSettings.withClientId("source-test/source-pending");
+    MqttConnectionSettings sinkSettings =
+        baseConnectionSettings.withClientId("source-test/sink-pending");
 
-        final Sink<MqttMessage, CompletionStage<Done>> mqttSink =
-                MqttSink.create(sinkSettings, MqttQoS.atLeastOnce());
-        final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
+    final Sink<MqttMessage, CompletionStage<Done>> mqttSink =
+        MqttSink.create(sinkSettings, MqttQoS.atLeastOnce());
+    final List<String> input = Arrays.asList("one", "two", "three", "four", "five");
 
-        MqttConnectionSettings connectionSettings = sourceSettings.withCleanStart(false);
-        MqttSubscriptions subscriptions = MqttSubscriptions.create(topic, MqttQoS.atLeastOnce());
-        final Source<MqttMessageWithAck, CompletionStage<Done>> mqttSource =
-                MqttSource.atLeastOnce(connectionSettings, subscriptions, bufferSize);
+    MqttConnectionSettings connectionSettings = sourceSettings.withCleanStart(false);
+    MqttSubscriptions subscriptions = MqttSubscriptions.create(topic, MqttQoS.atLeastOnce());
+    final Source<MqttMessageWithAck, CompletionStage<Done>> mqttSource =
+        MqttSource.atLeastOnce(connectionSettings, subscriptions, bufferSize);
 
-        final Pair<CompletionStage<Done>, CompletionStage<List<MqttMessageWithAck>>> unackedResult =
-                mqttSource.take(input.size()).toMat(Sink.seq(), Keep.both()).run(system);
+    final Pair<CompletionStage<Done>, CompletionStage<List<MqttMessageWithAck>>> unackedResult =
+        mqttSource.take(input.size()).toMat(Sink.seq(), Keep.both()).run(system);
 
-        unackedResult.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    unackedResult.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-        Source.from(input)
-                .map(s -> MqttMessage.create(topic, ByteString.fromString(s)))
-                .runWith(mqttSink, system)
-                .toCompletableFuture()
-                .get(3, TimeUnit.SECONDS);
+    Source.from(input)
+        .map(s -> MqttMessage.create(topic, ByteString.fromString(s)))
+        .runWith(mqttSink, system)
+        .toCompletableFuture()
+        .get(3, TimeUnit.SECONDS);
 
-        unackedResult
-                .second()
-                .toCompletableFuture()
-                .get(5, TimeUnit.SECONDS)
-                .forEach(
-                        m -> {
-                            try {
-                                m.ack().toCompletableFuture().get(3, TimeUnit.SECONDS);
-                            } catch (Exception e) {
-                                assertFalse("Error acking message manually", false);
-                            }
-                        });
-    }
+    unackedResult
+        .second()
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS)
+        .forEach(
+            m -> {
+              try {
+                m.ack().toCompletableFuture().get(3, TimeUnit.SECONDS);
+              } catch (Exception e) {
+                assertFalse("Error acking message manually", false);
+              }
+            });
+  }
 
-    @Test
-    public void receiveFromMultipleTopics() throws Exception {
-        final String topic1 = "v5/source-test/topic1";
-        final String topic2 = "v5/source-test/topic2";
+  @Test
+  public void receiveFromMultipleTopics() throws Exception {
+    final String topic1 = "v5/source-test/topic1";
+    final String topic2 = "v5/source-test/topic2";
 
-        MqttConnectionSettings connectionSettings =
-                MqttConnectionSettings.create(
-                        "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
+    MqttConnectionSettings connectionSettings =
+        MqttConnectionSettings.create(
+            "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
 
-        final Integer messageCount = 7;
+    final Integer messageCount = 7;
 
-        // #create-source
-        MqttSubscriptions subscriptions =
-                MqttSubscriptions.create(topic1, MqttQoS.atMostOnce())
-                        .addSubscription(topic2, MqttQoS.atMostOnce());
+    // #create-source
+    MqttSubscriptions subscriptions =
+        MqttSubscriptions.create(topic1, MqttQoS.atMostOnce())
+            .addSubscription(topic2, MqttQoS.atMostOnce());
 
-        Source<MqttMessage, CompletionStage<Done>> mqttSource =
-                MqttSource.atMostOnce(
-                        connectionSettings.withClientId("source-test/source"), subscriptions, bufferSize);
+    Source<MqttMessage, CompletionStage<Done>> mqttSource =
+        MqttSource.atMostOnce(
+            connectionSettings.withClientId("source-test/source"), subscriptions, bufferSize);
 
-        Pair<CompletionStage<Done>, CompletionStage<List<String>>> materialized =
-                mqttSource
-                        .map(m -> m.topic() + "-" + m.payload().utf8String())
-                        .take(messageCount * 2)
-                        .toMat(Sink.seq(), Keep.both())
-                        .run(system);
+    Pair<CompletionStage<Done>, CompletionStage<List<String>>> materialized =
+        mqttSource
+            .map(m -> m.topic() + "-" + m.payload().utf8String())
+            .take(messageCount * 2)
+            .toMat(Sink.seq(), Keep.both())
+            .run(system);
 
-        CompletionStage<Done> subscribed = materialized.first();
-        CompletionStage<List<String>> streamResult = materialized.second();
-        // #create-source
+    CompletionStage<Done> subscribed = materialized.first();
+    CompletionStage<List<String>> streamResult = materialized.second();
+    // #create-source
 
-        subscribed.toCompletableFuture().get(3, TimeUnit.SECONDS);
+    subscribed.toCompletableFuture().get(3, TimeUnit.SECONDS);
 
-        List<MqttMessage> messages =
-                IntStream.range(0, messageCount)
-                        .boxed()
-                        .flatMap(
-                                i ->
-                                        Stream.of(
-                                                MqttMessage.create(topic1, ByteString.fromString("msg" + i.toString())),
-                                                MqttMessage.create(topic2, ByteString.fromString("msg" + i.toString()))))
-                        .collect(Collectors.toList());
+    List<MqttMessage> messages =
+        IntStream.range(0, messageCount)
+            .boxed()
+            .flatMap(
+                i ->
+                    Stream.of(
+                        MqttMessage.create(topic1, ByteString.fromString("msg" + i.toString())),
+                        MqttMessage.create(topic2, ByteString.fromString("msg" + i.toString()))))
+            .collect(Collectors.toList());
 
-        // #run-sink
-        Sink<MqttMessage, CompletionStage<Done>> mqttSink =
-                MqttSink.create(connectionSettings.withClientId("source-test/sink"), MqttQoS.atLeastOnce());
-        Source.from(messages).runWith(mqttSink, system);
-        // #run-sink
+    // #run-sink
+    Sink<MqttMessage, CompletionStage<Done>> mqttSink =
+        MqttSink.create(connectionSettings.withClientId("source-test/sink"), MqttQoS.atLeastOnce());
+    Source.from(messages).runWith(mqttSink, system);
+    // #run-sink
 
-        assertEquals(
-                IntStream.range(0, messageCount)
-                        .boxed()
-                        .flatMap(i -> Stream.of("v5/source-test/topic1-msg" + i, "v5/source-test/topic2-msg" + i))
-                        .collect(Collectors.toSet()),
-                new HashSet<>(streamResult.toCompletableFuture().get(3, TimeUnit.SECONDS)));
-    }
+    assertEquals(
+        IntStream.range(0, messageCount)
+            .boxed()
+            .flatMap(
+                i -> Stream.of("v5/source-test/topic1-msg" + i, "v5/source-test/topic2-msg" + i))
+            .collect(Collectors.toSet()),
+        new HashSet<>(streamResult.toCompletableFuture().get(3, TimeUnit.SECONDS)));
+  }
 
-    @Test
-    public void supportWillMessage() throws Exception {
-        String topic1 = "v5/source-test/topic1";
-        String willTopic = "v5/source-test/will";
-        final MqttConnectionSettings baseConnectionSettings =
-                MqttConnectionSettings.create(
-                        "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
-        MqttConnectionSettings sourceSettings =
-                baseConnectionSettings.withClientId("source-test/source-withoutAutoAck");
-        MqttConnectionSettings sinkSettings =
-                baseConnectionSettings.withClientId("source-test/sink-withoutAutoAck");
+  @Test
+  public void supportWillMessage() throws Exception {
+    String topic1 = "v5/source-test/topic1";
+    String willTopic = "v5/source-test/will";
+    final MqttConnectionSettings baseConnectionSettings =
+        MqttConnectionSettings.create(
+            "tcp://localhost:1883", "test-java-client", new MemoryPersistence());
+    MqttConnectionSettings sourceSettings =
+        baseConnectionSettings.withClientId("source-test/source-withoutAutoAck");
+    MqttConnectionSettings sinkSettings =
+        baseConnectionSettings.withClientId("source-test/sink-withoutAutoAck");
 
-        MqttMessage msg = MqttMessage.create(topic1, ByteString.fromString("ohi"));
+    MqttMessage msg = MqttMessage.create(topic1, ByteString.fromString("ohi"));
 
-        // #will-message
-        MqttMessage lastWill =
-                MqttMessage.create(willTopic, ByteString.fromString("ohi"))
-                        .withQos(MqttQoS.atLeastOnce())
-                        .withRetained(true);
-        // #will-message
+    // #will-message
+    MqttMessage lastWill =
+        MqttMessage.create(willTopic, ByteString.fromString("ohi"))
+            .withQos(MqttQoS.atLeastOnce())
+            .withRetained(true);
+    // #will-message
 
-        // Create a proxy to RabbitMQ so it can be shutdown
-        int proxyPort = 1347; // make sure to keep it separate from ports used by other tests
-        Pair<CompletionStage<Tcp.ServerBinding>, CompletionStage<Tcp.IncomingConnection>> result1 =
-                Tcp.get(system).bind("localhost", proxyPort).toMat(Sink.head(), Keep.both()).run(system);
+    // Create a proxy to RabbitMQ so it can be shutdown
+    int proxyPort = 1347; // make sure to keep it separate from ports used by other tests
+    Pair<CompletionStage<Tcp.ServerBinding>, CompletionStage<Tcp.IncomingConnection>> result1 =
+        Tcp.get(system).bind("localhost", proxyPort).toMat(Sink.head(), Keep.both()).run(system);
 
-        CompletionStage<UniqueKillSwitch> proxyKs =
-                result1
-                        .second()
-                        .toCompletableFuture()
-                        .thenApply(
-                                conn ->
-                                        conn.handleWith(
-                                                Tcp.get(system)
-                                                        .outgoingConnection("localhost", 1883)
-                                                        .viaMat(KillSwitches.single(), Keep.right()),
-                                                system));
+    CompletionStage<UniqueKillSwitch> proxyKs =
+        result1
+            .second()
+            .toCompletableFuture()
+            .thenApply(
+                conn ->
+                    conn.handleWith(
+                        Tcp.get(system)
+                            .outgoingConnection("localhost", 1883)
+                            .viaMat(KillSwitches.single(), Keep.right()),
+                        system));
 
-        result1.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    result1.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-        MqttConnectionSettings settings1 =
-                sourceSettings
-                        .withClientId("source-test/testator")
-                        .withBroker("tcp://localhost:" + proxyPort)
-                        .withWill(lastWill);
-        MqttSubscriptions subscriptions = MqttSubscriptions.create(topic1, MqttQoS.atLeastOnce());
+    MqttConnectionSettings settings1 =
+        sourceSettings
+            .withClientId("source-test/testator")
+            .withBroker("tcp://localhost:" + proxyPort)
+            .withWill(lastWill);
+    MqttSubscriptions subscriptions = MqttSubscriptions.create(topic1, MqttQoS.atLeastOnce());
 
-        Source<MqttMessage, CompletionStage<Done>> source1 =
-                MqttSource.atMostOnce(settings1, subscriptions, bufferSize);
+    Source<MqttMessage, CompletionStage<Done>> source1 =
+        MqttSource.atMostOnce(settings1, subscriptions, bufferSize);
 
-        Pair<CompletionStage<Done>, TestSubscriber.Probe<MqttMessage>> result2 =
-                source1.toMat(TestSink.create(system), Keep.both()).run(system);
+    Pair<CompletionStage<Done>, TestSubscriber.Probe<MqttMessage>> result2 =
+        source1.toMat(TestSink.create(system), Keep.both()).run(system);
 
-        // Ensure that the connection made it all the way to the server by waiting until it receives a
-        // message
-        result2.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
-        Source.single(msg).runWith(MqttSink.create(sinkSettings, MqttQoS.atLeastOnce()), system);
-        result2.second().requestNext();
+    // Ensure that the connection made it all the way to the server by waiting until it receives a
+    // message
+    result2.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
+    Source.single(msg).runWith(MqttSink.create(sinkSettings, MqttQoS.atLeastOnce()), system);
+    result2.second().requestNext();
 
-        // Kill the proxy, producing an unexpected disconnection of the client
-        proxyKs.toCompletableFuture().get(5, TimeUnit.SECONDS).shutdown();
+    // Kill the proxy, producing an unexpected disconnection of the client
+    proxyKs.toCompletableFuture().get(5, TimeUnit.SECONDS).shutdown();
 
-        MqttConnectionSettings settings2 = sourceSettings.withClientId("source-test/executor");
-        MqttSubscriptions subscriptions2 = MqttSubscriptions.create(willTopic, MqttQoS.atLeastOnce());
-        Source<MqttMessage, CompletionStage<Done>> source2 =
-                MqttSource.atMostOnce(settings2, subscriptions2, bufferSize);
+    MqttConnectionSettings settings2 = sourceSettings.withClientId("source-test/executor");
+    MqttSubscriptions subscriptions2 = MqttSubscriptions.create(willTopic, MqttQoS.atLeastOnce());
+    Source<MqttMessage, CompletionStage<Done>> source2 =
+        MqttSource.atMostOnce(settings2, subscriptions2, bufferSize);
 
-        CompletionStage<MqttMessage> elem = source2.runWith(Sink.head(), system);
-        assertEquals(
-                MqttMessage.create(willTopic, ByteString.fromString("ohi")),
-                elem.toCompletableFuture().get(3, TimeUnit.SECONDS));
-    }
+    CompletionStage<MqttMessage> elem = source2.runWith(Sink.head(), system);
+    assertEquals(
+        MqttMessage.create(willTopic, ByteString.fromString("ohi")),
+        elem.toCompletableFuture().get(3, TimeUnit.SECONDS));
+  }
 }

--- a/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/Pravega.java
+++ b/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/Pravega.java
@@ -13,10 +13,12 @@
 
 package org.apache.pekko.stream.connectors.pravega.javadsl;
 
+import io.pravega.client.ClientConfig;
+import io.pravega.client.stream.ReaderGroup;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.annotation.ApiMayChange;
-
 import org.apache.pekko.stream.connectors.pravega.*;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaFlow;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaSource;
@@ -24,14 +26,7 @@ import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
-import io.pravega.client.ClientConfig;
-import io.pravega.client.stream.ReaderGroup;
-
-import java.util.concurrent.CompletionStage;
-
 import scala.jdk.javaapi.FutureConverters;
-
 
 @ApiMayChange
 public class Pravega {
@@ -40,6 +35,7 @@ public class Pravega {
 
     return new PravegaReaderGroupManager(scope, clientConfig);
   }
+
   /**
    * Messages are read from a Pravega stream.
    *
@@ -56,6 +52,7 @@ public class Pravega {
       String scope, String streamName, WriterSettings<V> writerSettings) {
     return Flow.fromGraph(new PravegaFlow<>(scope, streamName, writerSettings));
   }
+
   /** Incoming messages are written to Pravega. */
   public static <V> Sink<V, CompletionStage<Done>> sink(
       String scope, String streamName, WriterSettings<V> writerSettings) {

--- a/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
+++ b/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
@@ -13,27 +13,20 @@
 
 package org.apache.pekko.stream.connectors.pravega.javadsl;
 
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.annotation.ApiMayChange;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.pravega.*;
+import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableReadFlow;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableSource;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableWriteFlow;
-import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableReadFlow;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
-import io.pravega.client.tables.TableKey;
-
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-import java.nio.ByteBuffer;
-
-import scala.Option;
 import scala.jdk.javaapi.FutureConverters;
 import scala.jdk.javaapi.OptionConverters;
 
@@ -68,6 +61,7 @@ public class PravegaTable {
     return Source.fromGraph(new PravegaTableSource<K, V>(scope, tableName, tableReaderSettings))
         .mapMaterializedValue(FutureConverters::asJava);
   }
+
   /** A flow from key to and Option[value]. */
   public static <K, V> Flow<K, Optional<V>, NotUsed> readFlow(
       String scope, String tableName, TableSettings<K, V> tableSettings) {

--- a/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
@@ -13,18 +13,15 @@
 
 package docs.javadsl;
 
-import java.net.URI;
-import java.util.UUID;
-
-import org.apache.pekko.stream.connectors.pravega.PravegaPekkoTestCaseSupport;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-
-import org.apache.pekko.testkit.javadsl.TestKit;
-
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
+import java.net.URI;
+import java.util.UUID;
+import org.apache.pekko.stream.connectors.pravega.PravegaPekkoTestCaseSupport;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 
 public abstract class PravegaBaseTestCase extends PravegaPekkoTestCaseSupport {
 

--- a/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.client.tables.TableKey;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.pravega.*;
@@ -22,16 +31,6 @@ import org.apache.pekko.stream.connectors.pravega.javadsl.PravegaTable;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import io.pravega.client.stream.ReaderGroup;
-import io.pravega.client.stream.Serializer;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.client.stream.impl.UTF8StringSerializer;
-import io.pravega.client.tables.TableKey;
-
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 public class PravegaReadWriteDocs extends PravegaPekkoTestCaseSupport {
 

--- a/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
@@ -13,21 +13,18 @@
 
 package docs.javadsl;
 
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.client.tables.TableKey;
+import java.nio.ByteBuffer;
+import java.time.Duration;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.pravega.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
-
-import io.pravega.client.stream.impl.UTF8StringSerializer;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.nio.ByteBuffer;
-import java.time.Duration;
-
-import io.pravega.client.tables.TableKey;
-import io.pravega.client.stream.Serializer;
 
 public class PravegaSettingsTestCase {
 

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaGraphTestCase.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaGraphTestCase.java
@@ -13,30 +13,23 @@
 
 package org.apache.pekko.stream.connectors.pravega;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.stream.connectors.pravega.PravegaReaderGroupManager;
-import org.apache.pekko.stream.javadsl.Source;
-
 import com.typesafe.config.ConfigFactory;
 import docs.javadsl.PravegaBaseTestCase;
-
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.impl.JavaSerializer;
-import org.junit.Assert;
-import org.junit.Test;
-
-import org.apache.pekko.japi.Pair;
-
-import org.apache.pekko.stream.UniqueKillSwitch;
-import org.apache.pekko.stream.KillSwitches;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.connectors.pravega.javadsl.Pravega;
-
 import java.util.Arrays;
-
 import java.util.List;
 import java.util.concurrent.*;
+import org.apache.pekko.Done;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.KillSwitches;
+import org.apache.pekko.stream.UniqueKillSwitch;
+import org.apache.pekko.stream.connectors.pravega.javadsl.Pravega;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.junit.Assert;
+import org.junit.Test;
 
 public class PravegaGraphTestCase extends PravegaBaseTestCase {
 

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
@@ -13,34 +13,30 @@
 
 package org.apache.pekko.stream.connectors.pravega;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.japi.Pair;
-
-import org.apache.pekko.stream.connectors.pravega.javadsl.PravegaTable;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
 import docs.javadsl.PravegaBaseTestCase;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.KeyValueTableManager;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.UTF8StringSerializer;
-
 import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.client.tables.TableKey;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.*;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.pravega.javadsl.PravegaTable;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-import java.util.concurrent.*;
 
 public class PravegaKVTableTestCase extends PravegaBaseTestCase {
 

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaPekkoTestCaseSupport.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaPekkoTestCaseSupport.java
@@ -13,8 +13,8 @@
 
 package org.apache.pekko.stream.connectors.pravega;
 
-import org.apache.pekko.actor.ActorSystem;
 import docs.javadsl.PravegaBaseTestCase;
+import org.apache.pekko.actor.ActorSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,6 +18,9 @@ addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.6")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
+// use newer version of guava so that we can better control formats generated
+// by sbt-java-formatter
+libraryDependencies += "com.google.guava" % "guava" % "33.5.0-android"
 addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.10.0")
 
 // docs

--- a/reference/src/test/java/docs/javadsl/ReferenceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceTest.java
@@ -17,6 +17,12 @@
  */
 package docs.javadsl;
 
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -29,13 +35,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.*;
-
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /** Append "Test" to every Java test suite. */
 public class ReferenceTest {

--- a/s3/src/test/java/docs/javadsl/S3Test.java
+++ b/s3/src/test/java/docs/javadsl/S3Test.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -35,20 +44,10 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class S3Test extends S3WireMockBase {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
+++ b/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.recordio.javadsl.RecordIOFraming;
@@ -24,14 +32,6 @@ import org.apache.pekko.util.ByteString;
 import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class RecordIOFramingTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -47,7 +47,8 @@ public class RecordIOFramingTest {
   public void parseStream() throws InterruptedException, ExecutionException, TimeoutException {
     // #run-via-scanner
     String firstRecordData =
-        "{\"type\": \"SUBSCRIBED\",\"subscribed\": {\"framework_id\": {\"value\":\"12220-3440-12532-2345\"},\"heartbeat_interval_seconds\":15.0}";
+        "{\"type\": \"SUBSCRIBED\",\"subscribed\": {\"framework_id\":"
+            + " {\"value\":\"12220-3440-12532-2345\"},\"heartbeat_interval_seconds\":15.0}";
     String secondRecordData = "{\"type\":\"HEARTBEAT\"}";
 
     String firstRecordWithPrefix = "121\n" + firstRecordData;

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
@@ -13,18 +13,17 @@
 
 package docs.javadsl;
 
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
 import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
-import java.sql.PreparedStatement;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class DocSnippetFlow {
   public static void main(String[] args) throws Exception {
@@ -51,7 +50,8 @@ public class DocSnippetFlow {
                     (user, connection) -> {
                       PreparedStatement statement =
                           connection.prepareStatement(
-                              "INSERT INTO PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)");
+                              "INSERT INTO PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS VALUES (?,"
+                                  + " ?)");
                       statement.setInt(1, user.id);
                       statement.setString(2, user.name);
                       return statement;

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
@@ -13,14 +13,6 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
-import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-
 import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -28,6 +20,13 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.pekko.Done;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
+import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
 
 // We're going to pretend we got messages from kafka.
 // After we've written them to a db with Slick, we want
@@ -89,7 +88,8 @@ public class DocSnippetFlowWithPassThrough {
                     (kafkaMessage, connection) -> {
                       PreparedStatement statement =
                           connection.prepareStatement(
-                              "INSERT INTO PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)");
+                              "INSERT INTO PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS VALUES (?,"
+                                  + " ?)");
                       statement.setInt(1, kafkaMessage.msg.id);
                       statement.setString(2, kafkaMessage.msg.name);
                       return statement;

--- a/slick/src/test/java/docs/javadsl/DocSnippetSink.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetSink.java
@@ -13,17 +13,16 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
-import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
-import org.apache.pekko.stream.javadsl.Source;
-
 import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.apache.pekko.Done;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
+import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
+import org.apache.pekko.stream.javadsl.Source;
 
 public class DocSnippetSink {
   public static void main(String[] args) throws Exception {
@@ -48,7 +47,8 @@ public class DocSnippetSink {
                     (user, connection) -> {
                       PreparedStatement statement =
                           connection.prepareStatement(
-                              "INSERT INTO PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS VALUES (?, ?)");
+                              "INSERT INTO PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS VALUES (?,"
+                                  + " ?)");
                       statement.setInt(1, user.id);
                       statement.setString(2, user.name);
                       return statement;

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -13,6 +13,23 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -31,27 +48,9 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
-
 /**
- * This unit test is run using a local H2 database using `/tmp/pekko-connectors-slick-h2-test` for temporary
- * storage.
+ * This unit test is run using a local H2 database using `/tmp/pekko-connectors-slick-h2-test` for
+ * temporary storage.
  */
 public class SlickTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/PekkoStreamsRegistrar.java
+++ b/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/PekkoStreamsRegistrar.java
@@ -13,14 +13,14 @@
 
 package org.apache.pekko.stream.connectors.spring.web;
 
+import static org.springframework.core.ReactiveTypeDescriptor.multiValue;
+
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.javadsl.AsPublisher;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.util.Assert;
-
-import static org.springframework.core.ReactiveTypeDescriptor.multiValue;
 
 public class PekkoStreamsRegistrar {
 
@@ -33,14 +33,20 @@ public class PekkoStreamsRegistrar {
   public void registerAdapters(ReactiveAdapterRegistry registry) {
     Assert.notNull(registry, "registry must not be null");
     registry.registerReactiveType(
-        multiValue(org.apache.pekko.stream.javadsl.Source.class, org.apache.pekko.stream.javadsl.Source::empty),
+        multiValue(
+            org.apache.pekko.stream.javadsl.Source.class,
+            org.apache.pekko.stream.javadsl.Source::empty),
         source ->
             ((org.apache.pekko.stream.javadsl.Source<?, ?>) source)
-                .runWith(org.apache.pekko.stream.javadsl.Sink.asPublisher(AsPublisher.WITH_FANOUT), system),
+                .runWith(
+                    org.apache.pekko.stream.javadsl.Sink.asPublisher(AsPublisher.WITH_FANOUT),
+                    system),
         org.apache.pekko.stream.javadsl.Source::fromPublisher);
 
     registry.registerReactiveType(
-        multiValue(org.apache.pekko.stream.scaladsl.Source.class, org.apache.pekko.stream.scaladsl.Source::empty),
+        multiValue(
+            org.apache.pekko.stream.scaladsl.Source.class,
+            org.apache.pekko.stream.scaladsl.Source::empty),
         source ->
             ((org.apache.pekko.stream.scaladsl.Source<?, ?>) source)
                 .runWith(

--- a/spring-web/src/test/java/docs/javadsl/SampleController.java
+++ b/spring-web/src/test/java/docs/javadsl/SampleController.java
@@ -15,16 +15,15 @@ package docs.javadsl;
 
 // #use
 import jakarta.annotation.PostConstruct;
-
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.event.LoggingAdapter;
 import org.apache.pekko.stream.javadsl.Source;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.util.Assert;
 
 @RestController
 public class SampleController {

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -13,6 +13,18 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.sqs.MessageAction;
@@ -24,24 +36,11 @@ import org.apache.pekko.stream.connectors.sqs.SqsAckSettings;
 import org.apache.pekko.stream.connectors.sqs.javadsl.BaseSqsTest;
 import org.apache.pekko.stream.connectors.sqs.javadsl.SqsAckFlow;
 import org.apache.pekko.stream.connectors.sqs.javadsl.SqsAckSink;
-import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
 import org.junit.Test;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.*;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.junit.Assert.assertEquals;
 
 public class SqsAckTest extends BaseSqsTest {
 

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.stream.connectors.sqs.SqsPublishBatchSettings;
 import org.apache.pekko.stream.connectors.sqs.SqsPublishGroupedSettings;
@@ -26,16 +35,6 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.junit.Test;
 import software.amazon.awssdk.services.sqs.model.*;
-
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
 
 public class SqsPublishTest extends BaseSqsTest {
 
@@ -170,7 +169,10 @@ public class SqsPublishTest extends BaseSqsTest {
         // #flow
         // for dynamic SQS queues
         Source.single(
-                SendMessageRequest.builder().messageBody("pekko-connectors-flow").queueUrl(queueUrl).build())
+                SendMessageRequest.builder()
+                    .messageBody("pekko-connectors-flow")
+                    .queueUrl(queueUrl)
+                    .build())
             .via(SqsPublishFlow.create(SqsPublishSettings.create(), sqsClient))
             .runWith(Sink.head(), system);
     // #flow

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.connectors.sqs.MessageAttributeName;
@@ -32,16 +41,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
-
-import java.net.URI;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-
-import static org.junit.Assert.assertEquals;
 
 public class SqsSourceTest extends BaseSqsTest {
 
@@ -122,7 +121,8 @@ public class SqsSourceTest extends BaseSqsTest {
     // #init-custom-client
 
     customSqsClient
-        .sendMessage(SendMessageRequest.builder().queueUrl(queueUrl).messageBody("connectors").build())
+        .sendMessage(
+            SendMessageRequest.builder().queueUrl(queueUrl).messageBody("connectors").build())
         .get(2, TimeUnit.SECONDS);
 
     final CompletionStage<String> cs =

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import java.net.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.io.Inet;
 import org.apache.pekko.io.UdpSO;
@@ -33,13 +39,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.net.*;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 public class UdpTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.nio.file.Files;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -35,13 +41,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.file.Files;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
 
 public class UnixDomainSocketTest {
 

--- a/xml/src/test/java/docs/javadsl/XmlHelper.java
+++ b/xml/src/test/java/docs/javadsl/XmlHelper.java
@@ -13,13 +13,12 @@
 
 package docs.javadsl;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-
+import java.io.StringWriter;
 import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.StringWriter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 public class XmlHelper {
 

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -13,6 +13,21 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.fasterxml.aalto.AsyncXMLInputFactory;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
@@ -27,229 +42,215 @@ import org.apache.pekko.stream.connectors.xml.javadsl.XmlParsing;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import com.fasterxml.aalto.AsyncXMLInputFactory;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.w3c.dom.Element;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 @SuppressWarnings("deprecation")
 public class XmlParsingTest {
-    @Rule
-    public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
+  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
-    private static ActorSystem system;
+  private static ActorSystem system;
 
-    @Test
-    public void xmlParser() throws InterruptedException, ExecutionException, TimeoutException {
+  @Test
+  public void xmlParser() throws InterruptedException, ExecutionException, TimeoutException {
 
-        // #parser
-        final Sink<String, CompletionStage<List<ParseEvent>>> parse =
-            Flow.<String>create()
-                .map(ByteString::fromString)
-                .via(XmlParsing.parser())
-                .toMat(Sink.seq(), Keep.right());
-        // #parser
+    // #parser
+    final Sink<String, CompletionStage<List<ParseEvent>>> parse =
+        Flow.<String>create()
+            .map(ByteString::fromString)
+            .via(XmlParsing.parser())
+            .toMat(Sink.seq(), Keep.right());
+    // #parser
 
-        // #parser-usage
-        final String doc = "<doc><elem>elem1</elem><elem>elem2</elem></doc>";
-        final CompletionStage<List<ParseEvent>> resultStage = Source.single(doc).runWith(parse, system);
-        // #parser-usage
+    // #parser-usage
+    final String doc = "<doc><elem>elem1</elem><elem>elem2</elem></doc>";
+    final CompletionStage<List<ParseEvent>> resultStage = Source.single(doc).runWith(parse, system);
+    // #parser-usage
 
-        resultStage
-            .thenAccept(
-                (list) -> {
-                    assertThat(
-                        list,
-                        hasItems(
-                            StartDocument.getInstance(),
-                            StartElement.create("doc", Collections.emptyMap()),
-                            StartElement.create("elem", Collections.emptyMap()),
-                            Characters.create("elem1"),
-                            EndElement.create("elem"),
-                            StartElement.create("elem", Collections.emptyMap()),
-                            Characters.create("elem2"),
-                            EndElement.create("elem"),
-                            EndElement.create("doc"),
-                            EndDocument.getInstance()));
-                })
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
-    }
+    resultStage
+        .thenAccept(
+            (list) -> {
+              assertThat(
+                  list,
+                  hasItems(
+                      StartDocument.getInstance(),
+                      StartElement.create("doc", Collections.emptyMap()),
+                      StartElement.create("elem", Collections.emptyMap()),
+                      Characters.create("elem1"),
+                      EndElement.create("elem"),
+                      StartElement.create("elem", Collections.emptyMap()),
+                      Characters.create("elem2"),
+                      EndElement.create("elem"),
+                      EndElement.create("doc"),
+                      EndDocument.getInstance()));
+            })
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+  }
 
-    @Test
-    public void parseAndReadEvents() throws Exception {
-        // #parser-to-data
-        ByteString doc = ByteString.fromString("<doc><elem>elem1</elem><elem>elem2</elem></doc>");
-        CompletionStage<List<String>> stage =
-            Source.single(doc)
-                .via(XmlParsing.parser())
-                .statefulMap(StringBuilder::new, (textBuffer, parseEvent) -> {
-                    // aggregation function
-                    switch (parseEvent.marker()) {
-                        case XMLStartElement:
-                            textBuffer.delete(0, textBuffer.length());
-                            return Pair.create(textBuffer, Optional.<String>empty());
-                        case XMLEndElement:
-                            EndElement s = (EndElement) parseEvent;
-                            switch (s.localName()) {
-                                case "elem":
-                                    String text = textBuffer.toString();
-                                    return Pair.create(textBuffer, Optional.of(text));
-                                default:
-                                    return Pair.create(textBuffer, Optional.<String>empty());
-                            }
-                        case XMLCharacters:
-                        case XMLCData:
-                            TextEvent t = (TextEvent) parseEvent;
-                            textBuffer.append(t.text());
-                            return Pair.create(textBuffer, Optional.<String>empty());
+  @Test
+  public void parseAndReadEvents() throws Exception {
+    // #parser-to-data
+    ByteString doc = ByteString.fromString("<doc><elem>elem1</elem><elem>elem2</elem></doc>");
+    CompletionStage<List<String>> stage =
+        Source.single(doc)
+            .via(XmlParsing.parser())
+            .statefulMap(
+                StringBuilder::new,
+                (textBuffer, parseEvent) -> {
+                  // aggregation function
+                  switch (parseEvent.marker()) {
+                    case XMLStartElement:
+                      textBuffer.delete(0, textBuffer.length());
+                      return Pair.create(textBuffer, Optional.<String>empty());
+                    case XMLEndElement:
+                      EndElement s = (EndElement) parseEvent;
+                      switch (s.localName()) {
+                        case "elem":
+                          String text = textBuffer.toString();
+                          return Pair.create(textBuffer, Optional.of(text));
                         default:
-                            return Pair.create(textBuffer, Optional.<String>empty());
-                    }
-                }, textBuffer -> Optional.of(Optional.of(textBuffer.toString())))
-                .via(Flow.flattenOptional())
-                .runWith(Sink.seq(), system);
+                          return Pair.create(textBuffer, Optional.<String>empty());
+                      }
+                    case XMLCharacters:
+                    case XMLCData:
+                      TextEvent t = (TextEvent) parseEvent;
+                      textBuffer.append(t.text());
+                      return Pair.create(textBuffer, Optional.<String>empty());
+                    default:
+                      return Pair.create(textBuffer, Optional.<String>empty());
+                  }
+                },
+                textBuffer -> Optional.of(Optional.of(textBuffer.toString())))
+            .via(Flow.flattenOptional())
+            .runWith(Sink.seq(), system);
 
-        List<String> list = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
-        assertThat(list, hasItems("elem1", "elem2"));
-        // #parser-to-data
-    }
+    List<String> list = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    assertThat(list, hasItems("elem1", "elem2"));
+    // #parser-to-data
+  }
 
-    @Test
-    public void xmlParserConfigured()
-        throws InterruptedException, ExecutionException, TimeoutException {
-        boolean[] configWasCalled = {false};
-        Consumer<AsyncXMLInputFactory> configureFactory = factory -> configWasCalled[0] = true;
-        final Sink<String, CompletionStage<List<ParseEvent>>> parse =
-            Flow.<String>create()
-                .map(ByteString::fromString)
-                .via(XmlParsing.parser(configureFactory))
-                .toMat(Sink.seq(), Keep.right());
+  @Test
+  public void xmlParserConfigured()
+      throws InterruptedException, ExecutionException, TimeoutException {
+    boolean[] configWasCalled = {false};
+    Consumer<AsyncXMLInputFactory> configureFactory = factory -> configWasCalled[0] = true;
+    final Sink<String, CompletionStage<List<ParseEvent>>> parse =
+        Flow.<String>create()
+            .map(ByteString::fromString)
+            .via(XmlParsing.parser(configureFactory))
+            .toMat(Sink.seq(), Keep.right());
 
-        final String doc = "<doc><elem>elem1</elem><elem>elem2</elem></doc>";
-        final CompletionStage<List<ParseEvent>> resultStage = Source.single(doc).runWith(parse, system);
+    final String doc = "<doc><elem>elem1</elem><elem>elem2</elem></doc>";
+    final CompletionStage<List<ParseEvent>> resultStage = Source.single(doc).runWith(parse, system);
 
-        resultStage
-            .thenAccept(
-                (list) -> {
-                    assertThat(
-                        list,
-                        hasItems(
-                            StartDocument.getInstance(),
-                            StartElement.create("doc", Collections.emptyMap()),
-                            StartElement.create("elem", Collections.emptyMap()),
-                            Characters.create("elem1"),
-                            EndElement.create("elem"),
-                            StartElement.create("elem", Collections.emptyMap()),
-                            Characters.create("elem2"),
-                            EndElement.create("elem"),
-                            EndElement.create("doc"),
-                            EndDocument.getInstance()));
-                })
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
-        assertThat(configWasCalled[0], is(true));
-    }
+    resultStage
+        .thenAccept(
+            (list) -> {
+              assertThat(
+                  list,
+                  hasItems(
+                      StartDocument.getInstance(),
+                      StartElement.create("doc", Collections.emptyMap()),
+                      StartElement.create("elem", Collections.emptyMap()),
+                      Characters.create("elem1"),
+                      EndElement.create("elem"),
+                      StartElement.create("elem", Collections.emptyMap()),
+                      Characters.create("elem2"),
+                      EndElement.create("elem"),
+                      EndElement.create("doc"),
+                      EndDocument.getInstance()));
+            })
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+    assertThat(configWasCalled[0], is(true));
+  }
 
-    @Test
-    public void xmlSubslice() throws InterruptedException, ExecutionException, TimeoutException {
+  @Test
+  public void xmlSubslice() throws InterruptedException, ExecutionException, TimeoutException {
 
-        // #subslice
-        final Sink<String, CompletionStage<List<ParseEvent>>> parse =
-            Flow.<String>create()
-                .map(ByteString::fromString)
-                .via(XmlParsing.parser())
-                .via(XmlParsing.subslice(Arrays.asList("doc", "elem", "item")))
-                .toMat(Sink.seq(), Keep.right());
-        // #subslice
+    // #subslice
+    final Sink<String, CompletionStage<List<ParseEvent>>> parse =
+        Flow.<String>create()
+            .map(ByteString::fromString)
+            .via(XmlParsing.parser())
+            .via(XmlParsing.subslice(Arrays.asList("doc", "elem", "item")))
+            .toMat(Sink.seq(), Keep.right());
+    // #subslice
 
-        // #subslice-usage
-        final String doc =
-            "<doc>"
-                + "  <elem>"
-                + "    <item>i1</item>"
-                + "    <item><sub>i2</sub></item>"
-                + "    <item>i3</item>"
-                + "  </elem>"
-                + "</doc>";
-        final CompletionStage<List<ParseEvent>> resultStage = Source.single(doc).runWith(parse, system);
-        // #subslice-usage
+    // #subslice-usage
+    final String doc =
+        "<doc>"
+            + "  <elem>"
+            + "    <item>i1</item>"
+            + "    <item><sub>i2</sub></item>"
+            + "    <item>i3</item>"
+            + "  </elem>"
+            + "</doc>";
+    final CompletionStage<List<ParseEvent>> resultStage = Source.single(doc).runWith(parse, system);
+    // #subslice-usage
 
-        resultStage
-            .thenAccept(
-                (list) -> {
-                    assertThat(
-                        list,
-                        hasItems(
-                            Characters.create("i1"),
-                            StartElement.create("sub", Collections.emptyMap()),
-                            Characters.create("i2"),
-                            EndElement.create("sub"),
-                            Characters.create("i3")));
-                })
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
-    }
+    resultStage
+        .thenAccept(
+            (list) -> {
+              assertThat(
+                  list,
+                  hasItems(
+                      Characters.create("i1"),
+                      StartElement.create("sub", Collections.emptyMap()),
+                      Characters.create("i2"),
+                      EndElement.create("sub"),
+                      Characters.create("i3")));
+            })
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+  }
 
-    @Test
-    public void xmlSubtree() throws InterruptedException, ExecutionException, TimeoutException {
+  @Test
+  public void xmlSubtree() throws InterruptedException, ExecutionException, TimeoutException {
 
-        // #subtree
-        final Sink<String, CompletionStage<List<Element>>> parse =
-            Flow.<String>create()
-                .map(ByteString::fromString)
-                .via(XmlParsing.parser())
-                .via(XmlParsing.subtree(Arrays.asList("doc", "elem", "item")))
-                .toMat(Sink.seq(), Keep.right());
-        // #subtree
+    // #subtree
+    final Sink<String, CompletionStage<List<Element>>> parse =
+        Flow.<String>create()
+            .map(ByteString::fromString)
+            .via(XmlParsing.parser())
+            .via(XmlParsing.subtree(Arrays.asList("doc", "elem", "item")))
+            .toMat(Sink.seq(), Keep.right());
+    // #subtree
 
-        // #subtree-usage
-        final String doc =
-            "<doc>"
-                + "  <elem>"
-                + "    <item>i1</item>"
-                + "    <item><sub>i2</sub></item>"
-                + "    <item>i3</item>"
-                + "  </elem>"
-                + "</doc>";
-        final CompletionStage<List<Element>> resultStage = Source.single(doc).runWith(parse, system);
-        // #subtree-usage
+    // #subtree-usage
+    final String doc =
+        "<doc>"
+            + "  <elem>"
+            + "    <item>i1</item>"
+            + "    <item><sub>i2</sub></item>"
+            + "    <item>i3</item>"
+            + "  </elem>"
+            + "</doc>";
+    final CompletionStage<List<Element>> resultStage = Source.single(doc).runWith(parse, system);
+    // #subtree-usage
 
-        resultStage
-            .thenAccept(
-                (list) -> {
-                    assertThat(
-                        list.stream().map(e -> XmlHelper.asString(e).trim()).collect(Collectors.toList()),
-                        hasItems("<item>i1</item>", "<item><sub>i2</sub></item>", "<item>i3</item>"));
-                })
-            .toCompletableFuture()
-            .get(5, TimeUnit.SECONDS);
-    }
+    resultStage
+        .thenAccept(
+            (list) -> {
+              assertThat(
+                  list.stream().map(e -> XmlHelper.asString(e).trim()).collect(Collectors.toList()),
+                  hasItems("<item>i1</item>", "<item><sub>i2</sub></item>", "<item>i3</item>"));
+            })
+        .toCompletableFuture()
+        .get(5, TimeUnit.SECONDS);
+  }
 
-    @BeforeClass
-    public static void setup() {
-        system = ActorSystem.create();
-    }
+  @BeforeClass
+  public static void setup() {
+    system = ActorSystem.create();
+  }
 
-    @AfterClass
-    public static void teardown() {
-        TestKit.shutdownActorSystem(system);
-    }
+  @AfterClass
+  public static void teardown() {
+    TestKit.shutdownActorSystem(system);
+  }
 }

--- a/xml/src/test/java/docs/javadsl/XmlWritingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlWritingTest.java
@@ -13,6 +13,17 @@
 
 package docs.javadsl;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.xml.stream.XMLOutputFactory;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.stream.connectors.xml.Characters;
@@ -33,19 +44,6 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import javax.xml.stream.XMLOutputFactory;
-
-import static org.junit.Assert.assertEquals;
 
 public class XmlWritingTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -99,9 +97,9 @@ public class XmlWritingTest {
 
     // #writer-usage
     final String doc =
-        "<?xml version='1.0' encoding='UTF-8'?>"
-            + "<bk:book xmlns:bk=\"urn:loc.gov:books\" xmlns:isbn=\"urn:ISBN:0-395-36341-6\">"
-            + "<bk:title>Cheaper by the Dozen</bk:title><isbn:number>1568491379</isbn:number></bk:book>";
+        "<?xml version='1.0' encoding='UTF-8'?><bk:book xmlns:bk=\"urn:loc.gov:books\""
+            + " xmlns:isbn=\"urn:ISBN:0-395-36341-6\"><bk:title>Cheaper by the"
+            + " Dozen</bk:title><isbn:number>1568491379</isbn:number></bk:book>";
     final List<Namespace> nmList = new ArrayList<>();
     nmList.add(Namespace.create("urn:loc.gov:books", Optional.of("bk")));
     nmList.add(Namespace.create("urn:ISBN:0-395-36341-6", Optional.of("isbn")));


### PR DESCRIPTION
* relates to issues seen in #1379 
* aim is to merge this and then add an entry to ignore the commit in git blame
* then 1379 should be mergeable without needing its own java reformatting

This runs ok on my laptop but I see it fails on CI.

I suspect at this stage that we would be better off turning off the Java formatting check in CI for this repo for the time being.