### PR TITLE
latest scala releases

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -16,8 +16,8 @@ object Dependencies {
 
   val CronBuild = sys.env.get("GITHUB_EVENT_NAME").contains("schedule")
 
-  val Scala212 = "2.12.20"
-  val Scala213 = "2.13.17" // update even in link-validator.conf
+  val Scala212 = "2.12.21"
+  val Scala213 = "2.13.18" // update even in link-validator.conf
   val Scala3 = "3.3.7"
   val ScalaVersions = Seq(Scala213, Scala212, Scala3)
 


### PR DESCRIPTION
CI builds for 1.x are failing because pekko snaphots need the latest scala releases.

https://github.com/apache/pekko-connectors/actions/runs/21737942866/job/62706937976