### PR TITLE
fix(file): In TarReader avoid prematurely completing source

### DIFF
--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/TarReaderStage.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/TarReaderStage.scala
@@ -103,9 +103,9 @@ private[file] class TarReaderStage
           subSource.foreach(_.complete())
           val remainingBuffer = buffer.drop(trailerLength)
           if (remainingBuffer.isEmpty && isClosed(flowIn)) {
-            completeStage()  // Safe: no more data to process
+            completeStage() // Safe: no more data to process
           } else {
-            readHeader(remainingBuffer)  // Continue processing
+            readHeader(remainingBuffer) // Continue processing
           }
         } else setHandlers(flowIn, flowOut, new ReadPastTrailer(metadata, buffer, subSource))
       }

--- a/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/TarArchiveSpec.scala
@@ -370,7 +370,7 @@ class TarArchiveSpec
       val result = tar.futureValue
 
       // All 3 files should be extracted, not just the first one
-      result should have length 3
+      (result should have).length(3)
       result(0) shouldBe metadata1 -> file1Content
       result(1) shouldBe metadata2 -> file2Content
       result(2) shouldBe metadata3 -> file3Content


### PR DESCRIPTION
when processing multi-file TAR archives

fix #1407