### PR TITLE
Update google-cloud-pubsub to 1.148.0 (#1420)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -258,8 +258,15 @@ lazy val googleCloudPubSubGrpc = pekkoConnectorProject(
   Compile / scalacOptions ++= Seq(
     "-Wconf:src=.+/pekko-grpc/main/.+:s",
     "-Wconf:src=.+/pekko-grpc/test/.+:s"),
-  compile / javacOptions := (compile / javacOptions).value.filterNot(_ == "-Xlint:deprecation")).enablePlugins(
-  PekkoGrpcPlugin).dependsOn(googleCommon)
+  // the following is needed to exclude the gRPC generated sources for protobuf-java from the sources,
+  // they cause Scaladoc tool fails - https://github.com/apache/pekko-connectors/issues/1440
+  // and issues like https://github.com/apache/pekko-connectors/issues/1457
+  Compile / sources := (Compile / sources).value.filterNot { f =>
+    f.getPath.replace('\\', '/').contains("/pekko-grpc/main/com/google/protobuf")
+  },
+  compile / javacOptions := (compile / javacOptions).value.filterNot(_ == "-Xlint:deprecation"))
+  .enablePlugins(PekkoGrpcPlugin)
+  .dependsOn(googleCommon)
 
 lazy val googleCloudStorage = pekkoConnectorProject(
   "google-cloud-storage",

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -306,7 +306,7 @@ object Dependencies {
     // see Pekko gRPC version in plugins.sbt
     libraryDependencies ++= Seq(
       // https://github.com/googleapis/java-pubsub/tree/master/proto-google-cloud-pubsub-v1/
-      "com.google.cloud" % "google-cloud-pubsub" % "1.143.1" % "protobuf-src",
+      "com.google.cloud" % "google-cloud-pubsub" % "1.148.0" % "protobuf-src",
       "io.grpc" % "grpc-auth" % org.apache.pekko.grpc.gen.BuildInfo.grpcVersion,
       "com.google.auth" % "google-auth-library-oauth2-http" % GoogleAuthVersion,
       "com.google.protobuf" % "protobuf-java" % protobufJavaVersion % Runtime,


### PR DESCRIPTION
* Update google-cloud-pubsub to 1.148.0

* workaround protobuf generated code compile issues

* Update build.sbt

cherry picks da186a146a43149926e00d83d79f1c90d23268a8 #1420 

includes a fix for #1457 