### PR TITLE
Rework jackson dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -249,9 +249,8 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-http-jackson" % PekkoHttpVersion % Provided,
       "org.apache.pekko" %% "pekko-http-spray-json" % PekkoHttpVersion,
       "io.spray" %% "spray-json" % "1.3.6",
-      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.20",
       "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310" % JacksonVersion % Test,
-      "io.specto" % "hoverfly-java" % hoverflyVersion % Test) ++ Mockito)
+      "io.specto" % "hoverfly-java" % hoverflyVersion % Test) ++ JacksonDatabindDependencies ++ Mockito)
 
   val ArrowVersion = "18.3.0"
   val GoogleBigQueryStorage = Seq(


### PR DESCRIPTION
Removed 'jackson-annotations' dependency from Dependencies.scala.

Jackson 2.21 now has jackson-annotations with just a 2.21 version (no patch version).

The BigQuery connector uses the main jackson-databind classes and it is best to have an explicit dependency on this jar. Due to the version strategy change in jackson-annotations, it is probably best to rely on it being imported transitively via jackson-databind. This avoids us having to manage 2 version numbers.