### PR TITLE
Update Dependencies (1.3.x)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -400,7 +400,7 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
       "software.amazon.awssdk" % "kinesis" % AwsSdk2Version,
       "software.amazon.awssdk" % "firehose" % AwsSdk2Version,
-      "software.amazon.kinesis" % "amazon-kinesis-client" % "3.2.1").map(
+      "software.amazon.kinesis" % "amazon-kinesis-client" % "3.4.0").map(
       _.excludeAll(
         ExclusionRule("software.amazon.awssdk", "apache-client"),
         ExclusionRule("software.amazon.awssdk", "netty-nio-client"))) ++ Seq(


### PR DESCRIPTION
Release under discussion.

These are no big version bumps, just picking up latest JDK8 supporting versions from some key dependencies.
* netty 4.2.10
* amazon sdk 2.42.2
* kinesis client 3.4.0
* jackson 2.19.4
* amqp-client 5.28.0
* cassanadra driver 4.19.2
* kudu client 1.18.1

