### PR TITLE
MQTT v5: expose MQTT 5 user properties on MqttMessage

### DIFF
--- a/mqtt/src/test/travis/acl
+++ b/mqtt/src/test/travis/acl
@@ -23,6 +23,7 @@ topic v5/coffee/level
 topic v5/source-spec/will
 topic v5/source-spec/manualacks
 topic v5/source-spec/pendingacks
+topic v5/source-spec/user-props
 topic v5/sink-spec/topic1
 topic v5/sink-spec/topic2
 topic v5/sink-spec/topic3
@@ -32,6 +33,7 @@ topic v5/source-test/topic2
 topic v5/source-test/will
 topic v5/source-test/manualacks
 topic v5/source-test/pendingacks
+topic v5/source-test/user-props
 topic v5/flow-spec/topic-ack
 topic v5/flow-test/topic-ack
 topic v5/typed-flow-spec/topic1

--- a/mqttv5/src/main/scala/org/apache/pekko/stream/connectors/mqttv5/impl/MqttFlowStage.scala
+++ b/mqttv5/src/main/scala/org/apache/pekko/stream/connectors/mqttv5/impl/MqttFlowStage.scala
@@ -19,6 +19,7 @@ import java.util.concurrent.atomic.AtomicInteger
 import scala.collection.mutable
 import scala.concurrent.Future
 import scala.concurrent.Promise
+import scala.jdk.CollectionConverters._
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -31,6 +32,7 @@ import org.apache.pekko.stream._
 import org.apache.pekko.stream.connectors.mqttv5.AuthSettings
 import org.apache.pekko.stream.connectors.mqttv5.MqttConnectionSettings
 import org.apache.pekko.stream.connectors.mqttv5.MqttMessage
+import org.apache.pekko.stream.connectors.mqttv5.MqttUserProperty
 import org.apache.pekko.stream.connectors.mqttv5.MqttOfflinePersistenceSettings
 import org.apache.pekko.stream.connectors.mqttv5.MqttQoS
 import org.apache.pekko.stream.connectors.mqttv5.scaladsl.MqttMessageWithAck
@@ -46,6 +48,7 @@ import org.eclipse.paho.mqttv5.client.MqttDisconnectResponse
 import org.eclipse.paho.mqttv5.common.MqttException
 import org.eclipse.paho.mqttv5.common.packet.MqttProperties
 import org.eclipse.paho.mqttv5.common.packet.MqttReturnCode
+import org.eclipse.paho.mqttv5.common.packet.UserProperty
 import org.eclipse.paho.mqttv5.common.{ MqttMessage => PahoMqttMessage }
 
 /**
@@ -235,8 +238,14 @@ abstract class MqttFlowStageLogic[I](
     new MqttCallback {
       override def messageArrived(topic: String, pahoMessage: PahoMqttMessage): Unit = {
         backpressurePahoClient.acquire()
+        val userProps: Seq[MqttUserProperty] =
+          Option(pahoMessage.getProperties)
+            .map(_.getUserProperties.asScala.map(p => MqttUserProperty(p.getKey, p.getValue)).toList)
+            .getOrElse(Nil)
         val message = new MqttMessageWithAck {
-          override val message: MqttMessage = MqttMessage(topic, ByteString.fromArrayUnsafe(pahoMessage.getPayload))
+          override val message: MqttMessage =
+            MqttMessage(topic, ByteString.fromArrayUnsafe(pahoMessage.getPayload))
+              .withUserProperties(userProps)
 
           override def ack(): Future[Done] = {
             val promise = Promise[Done]()
@@ -403,6 +412,12 @@ abstract class MqttFlowStageLogic[I](
     val pahoMsg = new PahoMqttMessage(msg.payload.toArray)
     pahoMsg.setQos(msg.qos.getOrElse(defaultQoS).value)
     pahoMsg.setRetained(msg.retained)
+
+    if (msg.userProperties.nonEmpty) {
+      val pahoProps = new MqttProperties()
+      pahoProps.setUserProperties(msg.userProperties.map(p => new UserProperty(p.key, p.value)).toList.asJava)
+      pahoMsg.setProperties(pahoProps)
+    }
 
     mqttClient.publish(
       msg.topic,

--- a/mqttv5/src/main/scala/org/apache/pekko/stream/connectors/mqttv5/model.scala
+++ b/mqttv5/src/main/scala/org/apache/pekko/stream/connectors/mqttv5/model.scala
@@ -15,11 +15,37 @@ package org.apache.pekko.stream.connectors.mqttv5
 
 import org.apache.pekko
 
+import scala.collection.immutable
+import scala.jdk.CollectionConverters._
+
+final class MqttUserProperty private (val key: String, val value: String) {
+  override def toString = s"MqttUserProperty(key=$key,value=$value)"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: MqttUserProperty =>
+      java.util.Objects.equals(this.key, that.key) &&
+      java.util.Objects.equals(this.value, that.value)
+    case _ => false
+  }
+
+  override def hashCode(): Int = java.util.Objects.hash(key, value)
+}
+
+object MqttUserProperty {
+
+  /** Scala API */
+  def apply(key: String, value: String): MqttUserProperty = new MqttUserProperty(key, value)
+
+  /** Java API */
+  def create(key: String, value: String): MqttUserProperty = new MqttUserProperty(key, value)
+}
+
 final class MqttMessage private (
     val topic: String,
     val payload: org.apache.pekko.util.ByteString,
     val qos: Option[MqttQoS],
-    val retained: Boolean
+    val retained: Boolean,
+    val userProperties: Array[MqttUserProperty]
 ) {
 
   def withTopic(value: String): MqttMessage = copy(topic = value)
@@ -28,26 +54,38 @@ final class MqttMessage private (
   def withQos(value: MqttQoS): MqttMessage = copy(qos = Option(value))
   def withRetained(value: Boolean): MqttMessage = if (retained == value) this else copy(retained = value)
 
-  private def copy(topic: String = topic,
+  /** Scala API */
+  def withUserProperties(value: immutable.Seq[MqttUserProperty]): MqttMessage =
+    copy(userProperties = value.toArray)
+
+  /** Java API */
+  def withUserProperties(value: java.util.List[MqttUserProperty]): MqttMessage =
+    copy(userProperties = value.asScala.toArray)
+
+  private def copy(
+      topic: String = topic,
       payload: pekko.util.ByteString = payload,
       qos: Option[MqttQoS] = qos,
-      retained: Boolean = retained): MqttMessage =
-    new MqttMessage(topic = topic, payload = payload, qos = qos, retained = retained)
+      retained: Boolean = retained,
+      userProperties: Array[MqttUserProperty] = userProperties): MqttMessage =
+    new MqttMessage(topic = topic, payload = payload, qos = qos, retained = retained, userProperties = userProperties)
 
   override def toString =
-    s"""MqttMessage(topic=$topic,payload=$payload,qos=$qos,retained=$retained)"""
+    s"""MqttMessage(topic=$topic,payload=$payload,qos=$qos,retained=$retained,userProperties=${userProperties.mkString(
+        "[", ", ", "]")})"""
 
   override def equals(other: Any): Boolean = other match {
     case that: MqttMessage =>
       java.util.Objects.equals(this.topic, that.topic) &&
       java.util.Objects.equals(this.payload, that.payload) &&
       java.util.Objects.equals(this.qos, that.qos) &&
-      java.util.Objects.equals(this.retained, that.retained)
+      java.util.Objects.equals(this.retained, that.retained) &&
+      java.util.Objects.equals(this.userProperties.toSeq, that.userProperties.toSeq)
     case _ => false
   }
 
   override def hashCode(): Int =
-    java.util.Objects.hash(topic, payload, qos, Boolean.box(retained))
+    java.util.Objects.hash(topic, payload, qos, Boolean.box(retained), userProperties.toSeq)
 }
 
 object MqttMessage {
@@ -59,7 +97,8 @@ object MqttMessage {
     topic,
     payload,
     qos = None,
-    retained = false)
+    retained = false,
+    userProperties = Array.empty)
 
   /** Java API */
   def create(
@@ -68,5 +107,6 @@ object MqttMessage {
     topic,
     payload,
     qos = None,
-    retained = false)
+    retained = false,
+    userProperties = Array.empty)
 }

--- a/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -23,6 +23,7 @@ import org.apache.pekko.stream.connectors.mqttv5.MqttConnectionSettings;
 import org.apache.pekko.stream.connectors.mqttv5.MqttMessage;
 import org.apache.pekko.stream.connectors.mqttv5.MqttQoS;
 import org.apache.pekko.stream.connectors.mqttv5.MqttSubscriptions;
+import org.apache.pekko.stream.connectors.mqttv5.MqttUserProperty;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttSink;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttSource;
@@ -49,6 +50,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
+import scala.jdk.javaapi.CollectionConverters;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -337,5 +340,42 @@ public class MqttSourceTest {
         assertEquals(
                 MqttMessage.create(willTopic, ByteString.fromString("ohi")),
                 elem.toCompletableFuture().get(3, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void receiveUserProperties() throws Exception {
+        final String topic = "v5/source-test/user-props";
+        MqttConnectionSettings connectionSettings =
+                MqttConnectionSettings.create("tcp://localhost:1883", "test-java-user-props", new MemoryPersistence());
+
+        Source<MqttMessage, CompletionStage<Done>> source =
+                MqttSource.atMostOnce(
+                        connectionSettings.withClientId("source-test/user-props-source"),
+                        MqttSubscriptions.create(topic, MqttQoS.atLeastOnce()),
+                        bufferSize);
+
+        Pair<CompletionStage<Done>, CompletionStage<MqttMessage>> result =
+                source.toMat(Sink.head(), Keep.both()).run(system);
+
+        result.first().toCompletableFuture().get(5, TimeUnit.SECONDS);
+
+        List<MqttUserProperty> userPropsToSend = Arrays.asList(
+                MqttUserProperty.create("x-trace-id", "abc123"),
+                MqttUserProperty.create("x-tenant", "acme"));
+        MqttMessage msg = MqttMessage.create(topic, ByteString.fromString("test"))
+                .withUserProperties(userPropsToSend);
+        Sink<MqttMessage, CompletionStage<Done>> mqttSink =
+                MqttSink.create(
+                        connectionSettings.withClientId("source-test/user-props-sink"),
+                        MqttQoS.atLeastOnce());
+        Source.single(msg).runWith(mqttSink, system);
+
+        MqttMessage received = result.second().toCompletableFuture().get(5, TimeUnit.SECONDS);
+        List<MqttUserProperty> userProps = Arrays.asList(received.userProperties());
+        assertEquals(2, userProps.size());
+        assertEquals("x-trace-id", userProps.get(0).key());
+        assertEquals("abc123", userProps.get(0).value());
+        assertEquals("x-tenant", userProps.get(1).key());
+        assertEquals("acme", userProps.get(1).value());
     }
 }

--- a/mqttv5/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
+++ b/mqttv5/src/test/scala/docs/scaladsl/MqttSourceSpec.scala
@@ -28,6 +28,7 @@ import org.apache.pekko.stream.connectors.mqttv5.MqttConnectionSettings
 import org.apache.pekko.stream.connectors.mqttv5.MqttMessage
 import org.apache.pekko.stream.connectors.mqttv5.MqttQoS
 import org.apache.pekko.stream.connectors.mqttv5.MqttSubscriptions
+import org.apache.pekko.stream.connectors.mqttv5.MqttUserProperty
 import org.apache.pekko.stream.connectors.mqttv5.scaladsl.MqttMessageWithAck
 import org.apache.pekko.stream.connectors.mqttv5.scaladsl.MqttSink
 import org.apache.pekko.stream.connectors.mqttv5.scaladsl.MqttSource
@@ -491,5 +492,24 @@ class MqttSourceSpec extends MqttSpecBase("MqttSourceSpec") {
       probe2.requestNext(5.seconds) shouldBe msg
       Await.result(proxyKs2, timeout).shutdown()
     }
+  }
+
+  "receive user properties from a message" in {
+    val topic = "v5/source-spec/user-props"
+    val expectedProps = Seq(
+      MqttUserProperty("x-trace-id", "abc123"),
+      MqttUserProperty("x-tenant", "acme"))
+
+    val (subscribed, result) = MqttSource
+      .atMostOnce(sourceSettings, MqttSubscriptions(topic, MqttQoS.AtLeastOnce), 8)
+      .toMat(Sink.head)(Keep.both)
+      .run()
+
+    Await.ready(subscribed, timeout)
+
+    val msg = MqttMessage(topic, ByteString("test")).withUserProperties(expectedProps)
+    Source.single(msg).runWith(MqttSink(sinkSettings, MqttQoS.AtLeastOnce))
+
+    result.futureValue.userProperties shouldBe expectedProps
   }
 }


### PR DESCRIPTION
Fixes #1371

This PR adds support for MQTT User Properties in the MQTT v5 connector, enabling use-cases that rely on User Properties for metadata transport.
Since the underlying Paho client already exposes the User Properties, they simply needed to be mapped to the connector's `MqttMessage` model.
It is now possible to read User Properties from MQTT messages using `MqttSource`s as well as to publish User Properties using `MqttSink`s.