### PR TITLE
Update hadoop-common, ... for HBase to 3.3.6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -302,7 +302,7 @@ object Dependencies {
 
   val HBase = {
     val hbaseVersion = "1.4.14"
-    val hadoopVersion = "2.7.7"
+    val hadoopVersion = "3.3.6"
     Seq(
       libraryDependencies ++= Seq(
         ("org.apache.hbase" % "hbase-shaded-client" % hbaseVersion).exclude("log4j", "log4j").exclude("org.slf4j",


### PR DESCRIPTION
## About this PR
📦 Updates 
* org.apache.hadoop:hadoop-common
* org.apache.hadoop:hadoop-mapreduce-client-core

 from `2.7.7` to `3.3.6`
 
 Supersedes https://github.com/apache/pekko-connectors/pull/374.