### PR TITLE
change ftp docker tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
       - "discovery.type=single-node"
       - "DISABLE_SECURITY_PLUGIN=true"
   ftp:
-    image: stilliard/pure-ftpd:latest
+    image: stilliard/pure-ftpd:hardened
     ports:
       - "21000:21"
       - "30000-30009:30000-30009"


### PR DESCRIPTION
ftp tests are failing and one possibility is that a recent set of new images for ftpd image have caused us problems

```
[info] FtpExamplesSpec:
[info] a file
USER *******
331 User username OK. Password required
PASS *******
--> [docs.scaladsl.FtpExamplesSpec: a file should be stored] Start of log messages of test that [Failed(org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2: A timeout occurred waiting for a future to complete. Waited 1 second.)]
16:16:15.641 INFO  [default-dispatcher-5] o.a.pekko.event.slf4j.Slf4jLogger     Slf4jLogger started
16:16:15.643 DEBUG [default-dispatcher-5] org.apache.pekko.event.EventStream    logger log1-Slf4jLogger started
16:16:15.643 DEBUG [default-dispatcher-5] org.apache.pekko.event.EventStream    Default Loggers started
16:16:15.686 DEBUG [default-dispatcher-6] zation(pekko://pekko-connectors-ftp)  Replacing JavaSerializer with DisabledJavaSerializer, due to `pekko.actor.allow-java-serialization = off`.
16:16:15.693 INFO  [ning-FtpExamplesSpec] o.a.p.s.c.t.scaladsl.LogCapturing     Logging started for test [docs.scaladsl.FtpExamplesSpec: a file should be stored]
16:16:15.709 DEBUG [default-dispatcher-5] o.apache.pekko.actor.ActorSystemImpl  Dispatcher id [pekko.stream.materializer.blocking-io-dispatcher] is an alias, actual dispatcher will be [pekko.actor.default-blocking-io-dispatcher]
16:16:16.713 INFO  [ning-FtpExamplesSpec] o.a.p.s.c.t.scaladsl.LogCapturing     Logging finished for test [docs.scaladsl.FtpExamplesSpec: a file should be stored] that [Failed(org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2: A timeout occurred waiting for a future to complete. Waited 1 second.)]
<-- [docs.scaladsl.FtpExamplesSpec: a file should be stored] End of log messages of test that [Failed(org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2: A timeout occurred waiting for a future to complete. Waited 1 second.)]
[info] - should be stored *** FAILED *** (1 second, 23 milliseconds)
[info]   A timeout occurred waiting for a future to complete. Waited 1 second. (FtpExamplesSpec.scala:80)
[info]   org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2:
[info]   at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValueImpl(ScalaFutures.scala:339)
[info]   at org.scalatest.concurrent.Futures$FutureConcept.futureValue(Futures.scala:394)
[info]   at org.scalatest.concurrent.Futures$FutureConcept.futureValue$(Futures.scala:393)
[info]   at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValue(ScalaFutures.scala:281)
[info]   at docs.scaladsl.FtpExamplesSpec.$anonfun$new$3(FtpExamplesSpec.scala:80)
[info]   at org.apache.pekko.stream.testkit.scaladsl.StreamTestKit$.assertAllStagesStopped(StreamTestKit.scala:60)
[info]   at docs.scaladsl.FtpExamplesSpec.$anonfun$new$2(FtpExamplesSpec.scala:67)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply(AnyWordSpecLike.scala:1240)
[info]   at org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing.withFixture(LogCapturing.scala:70)
[info]   at org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing.withFixture$(LogCapturing.scala:66)
[info]   at docs.scaladsl.FtpExamplesSpec.withFixture(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1(AnyWordSpecLike.scala:1238)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1(AnyWordSpecLike.scala:1250)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest(AnyWordSpecLike.scala:1250)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest$(AnyWordSpecLike.scala:1232)
[info]   at docs.scaladsl.FtpExamplesSpec.runTest(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1(AnyWordSpecLike.scala:1309)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:390)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:427)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests(AnyWordSpecLike.scala:1309)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests$(AnyWordSpecLike.scala:1308)
[info]   at docs.scaladsl.FtpExamplesSpec.runTests(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.Suite.run(Suite.scala:1114)
[info]   at org.scalatest.Suite.run$(Suite.scala:1096)
[info]   at docs.scaladsl.FtpExamplesSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1(AnyWordSpecLike.scala:1354)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run(AnyWordSpecLike.scala:1354)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run$(AnyWordSpecLike.scala:1352)
[info]   at docs.scaladsl.FtpExamplesSpec.org$scalatest$BeforeAndAfterAll$$super$run(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at docs.scaladsl.FtpExamplesSpec.run(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
USER *******
331 User username OK. Password required
PASS *******
--> [docs.scaladsl.FtpExamplesSpec: a file should be gzipped] Start of log messages of test that [Failed(org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2: A timeout occurred waiting for a future to complete. Waited 1 second.)]
16:16:16.739 INFO  [ning-FtpExamplesSpec] o.a.p.s.c.t.scaladsl.LogCapturing     Logging started for test [docs.scaladsl.FtpExamplesSpec: a file should be gzipped]
16:16:17.762 INFO  [ning-FtpExamplesSpec] o.a.p.s.c.t.scaladsl.LogCapturing     Logging finished for test [docs.scaladsl.FtpExamplesSpec: a file should be gzipped] that [Failed(org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2: A timeout occurred waiting for a future to complete. Waited 1 second.)]
<-- [docs.scaladsl.FtpExamplesSpec: a file should be gzipped] End of log messages of test that [Failed(org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2: A timeout occurred waiting for a future to complete. Waited 1 second.)]
[info] - should be gzipped *** FAILED *** (1 second, 24 milliseconds)
[info]   A timeout occurred waiting for a future to complete. Waited 1 second. (FtpExamplesSpec.scala:104)
[info]   org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2:
[info]   at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValueImpl(ScalaFutures.scala:339)
[info]   at org.scalatest.concurrent.Futures$FutureConcept.futureValue(Futures.scala:394)
[info]   at org.scalatest.concurrent.Futures$FutureConcept.futureValue$(Futures.scala:393)
[info]   at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValue(ScalaFutures.scala:281)
[info]   at docs.scaladsl.FtpExamplesSpec.$anonfun$new$5(FtpExamplesSpec.scala:104)
[info]   at org.apache.pekko.stream.testkit.scaladsl.StreamTestKit$.assertAllStagesStopped(StreamTestKit.scala:60)
[info]   at docs.scaladsl.FtpExamplesSpec.$anonfun$new$4(FtpExamplesSpec.scala:88)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply(AnyWordSpecLike.scala:1240)
[info]   at org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing.withFixture(LogCapturing.scala:70)
[info]   at org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing.withFixture$(LogCapturing.scala:66)
[info]   at docs.scaladsl.FtpExamplesSpec.withFixture(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1(AnyWordSpecLike.scala:1238)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1(AnyWordSpecLike.scala:1250)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest(AnyWordSpecLike.scala:1250)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest$(AnyWordSpecLike.scala:1232)
[info]   at docs.scaladsl.FtpExamplesSpec.runTest(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1(AnyWordSpecLike.scala:1309)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:390)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:427)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests(AnyWordSpecLike.scala:1309)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests$(AnyWordSpecLike.scala:1308)
[info]   at docs.scaladsl.FtpExamplesSpec.runTests(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.Suite.run(Suite.scala:1114)
[info]   at org.scalatest.Suite.run$(Suite.scala:1096)
[info]   at docs.scaladsl.FtpExamplesSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1(AnyWordSpecLike.scala:1354)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run(AnyWordSpecLike.scala:1354)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run$(AnyWordSpecLike.scala:1352)
[info]   at docs.scaladsl.FtpExamplesSpec.org$scalatest$BeforeAndAfterAll$$super$run(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at docs.scaladsl.FtpExamplesSpec.run(FtpExamplesSpec.scala:33)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
```