### PR TITLE
Ignore tests for file storage and gzipping

### DIFF
--- a/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
+++ b/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
@@ -64,7 +64,8 @@ class FtpExamplesSpec
   }
 
   "a file" should {
-    "be stored" in assertAllStagesStopped {
+    // https://github.com/apache/pekko-connectors/issues/1581 open to try to get this fixed
+    "be stored" ignore assertAllStagesStopped {
       // #storing
       import org.apache.pekko
       import pekko.stream.IOResult
@@ -85,7 +86,8 @@ class FtpExamplesSpec
 
     }
 
-    "be gzipped" in assertAllStagesStopped {
+    // https://github.com/apache/pekko-connectors/issues/1581 open to try to get this fixed
+    "be gzipped" ignore assertAllStagesStopped {
       import pekko.stream.IOResult
       import pekko.stream.connectors.ftp.scaladsl.Ftp
       import pekko.util.ByteString


### PR DESCRIPTION
Updated FtpExamplesSpec to ignore tests for storing and gzipping files due to an open issue.

Solution is not obvious and test failures caused lots of noise on every current build.

See #1581