### PR TITLE
Upgrade pekko-streams-circe to 2.0.0-M1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -307,10 +307,7 @@ lazy val ironmq = pekkoConnectorProject(
   "ironmq",
   "ironmq",
   Dependencies.IronMq,
-  Test / fork := true,
-  // org.mdedetrich libs don't have a release that supports Pekko 2 yet
-  // so we need to disable eviction warnings for now
-  evictionErrorLevel := Level.Info)
+  Test / fork := true)
 
 lazy val jms = pekkoConnectorProject("jms", "jms", Dependencies.Jms)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,7 +34,7 @@ object Dependencies {
   // Sync with plugins.sbt
   val PekkoGrpcBinaryVersion = "1.1"
   val PekkoHttpVersion = PekkoHttpDependency.version
-  val PekkoStreamsCirceVersion = "1.1.0"
+  val PekkoStreamsCirceVersion = "2.0.0-M1"
   val PekkoHttpBinaryVersion = PekkoHttpDependency.default.link
   val ScalaTestVersion = "3.2.20"
   val TestContainersScalaTestVersion = "0.44.1"


### PR DESCRIPTION
Upgrade to newly released Pekko Streams Circe 2.0.0-M1