### PR TITLE
Google Cloud Pub/Sub gRPC: subscribe() must not echo initial-only StreamingPullRequest fields on keepalive ticks

### DIFF
--- a/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
@@ -66,10 +66,13 @@ object GooglePubSub {
       .fromMaterializer { (mat, attr) =>
         val cancellable = new CompletableFuture[Cancellable]()
 
-        val subsequentRequest = request.toBuilder
-          .setSubscription("")
-          .setStreamAckDeadlineSeconds(0)
-          .build()
+        // Don't echo initial-only fields on keepalive requests. Pub/Sub allows only
+        // ackIds, modifyDeadlineSeconds, and modifyDeadlineAckIds on subsequent
+        // StreamingPullRequests; anything else from the initial request (subscription,
+        // streamAckDeadlineSeconds, clientId, maxOutstandingMessages, maxOutstandingBytes)
+        // gets back INVALID_ARGUMENT. defaultInstance clears them all at once and stays
+        // safe if the proto grows more initial-only fields.
+        val subsequentRequest = StreamingPullRequest.getDefaultInstance
 
         subscriber(mat, attr).client
           .streamingPull(

--- a/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
@@ -66,9 +66,13 @@ object GooglePubSub {
       .fromMaterializer { (mat, attr) =>
         val cancellable = Promise[Cancellable]()
 
-        val subsequentRequest = request
-          .withSubscription("")
-          .withStreamAckDeadlineSeconds(0)
+        // Don't echo initial-only fields on keepalive requests. Pub/Sub allows only
+        // ackIds, modifyDeadlineSeconds, and modifyDeadlineAckIds on subsequent
+        // StreamingPullRequests; anything else from the initial request (subscription,
+        // streamAckDeadlineSeconds, clientId, maxOutstandingMessages, maxOutstandingBytes)
+        // gets back INVALID_ARGUMENT. defaultInstance clears them all at once and stays
+        // safe if the proto grows more initial-only fields.
+        val subsequentRequest = StreamingPullRequest.defaultInstance
 
         subscriber(mat, attr).client
           .streamingPull(
@@ -76,8 +80,7 @@ object GooglePubSub {
               .single(request)
               .concat(
                 Source
-                  .tick(0.seconds, pollInterval, ())
-                  .map(_ => subsequentRequest)
+                  .tick(0.seconds, pollInterval, subsequentRequest)
                   .mapMaterializedValue(cancellable.success)))
           .mapConcat(_.receivedMessages.toVector)
           .mapMaterializedValue(_ => cancellable.future)

--- a/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesSpec.scala
@@ -18,18 +18,18 @@
 package org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc
 
 import org.apache.pekko
-import pekko.Done
+import pekko.{ Done, NotUsed }
 import pekko.actor.ActorSystem
-import pekko.stream.scaladsl.{ Sink, Source }
+import pekko.stream.scaladsl.{ Keep, Sink, Source }
 import pekko.stream.connectors.googlecloud.pubsub.grpc.scaladsl.{ GooglePubSub, GrpcSubscriber, PubSubAttributes }
 import com.google.protobuf.ByteString
 import com.google.pubsub.v1.pubsub._
+import org.apache.pekko.stream._
 
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
@@ -178,11 +178,11 @@ class AutoExtendAckDeadlinesSpec
       val cancellableFut = GooglePubSub
         .subscribe(initial, 100.millis)
         .withAttributes(PubSubAttributes.subscriber(testSubscriber))
-        .toMat(Sink.ignore)(pekko.stream.scaladsl.Keep.left)
+        .toMat(Sink.ignore)(Keep.left)
         .run()
 
       // Wait until the initial request plus at least 2 keepalive ticks have landed,
-      // then cancel. Polls instead of sleeping so a slow CI machine doesn't flake.
+      // then cancel.
       eventually(timeout(Span(5, Seconds)), interval(Span(50, Millis))) {
         captured.size should be >= 3
       }
@@ -226,16 +226,16 @@ class AutoExtendAckDeadlinesSpec
  */
 class CapturingStreamingPullClient(captured: ConcurrentLinkedQueue[StreamingPullRequest])(
     implicit sys: ActorSystem) extends TestSubscriberClientBase {
-  private implicit val mat: pekko.stream.Materializer = pekko.stream.Materializer.matFromSystem(sys)
+  private implicit val mat: Materializer = Materializer.matFromSystem(sys)
 
   override def streamingPull(
-      in: pekko.stream.scaladsl.Source[StreamingPullRequest, pekko.NotUsed])
-      : pekko.stream.scaladsl.Source[StreamingPullResponse, pekko.NotUsed] =
-    pekko.stream.scaladsl.Source
+      in: Source[StreamingPullRequest, NotUsed])
+      : Source[StreamingPullResponse, NotUsed] =
+    Source
       .maybe[StreamingPullResponse]
       .mapMaterializedValue { _ =>
         in.runForeach(req => captured.add(req))
-        pekko.NotUsed
+        NotUsed
       }
 }
 
@@ -244,8 +244,6 @@ class CapturingStreamingPullClient(captured: ConcurrentLinkedQueue[StreamingPull
  * for all methods. Tests override only the methods they need.
  */
 trait TestSubscriberClientBase extends SubscriberClient {
-  import pekko.NotUsed
-
   override def createSubscription(in: Subscription): Future[Subscription] = ???
   override def getSubscription(in: GetSubscriptionRequest): Future[Subscription] = ???
   override def updateSubscription(in: UpdateSubscriptionRequest): Future[Subscription] = ???
@@ -255,8 +253,8 @@ trait TestSubscriberClientBase extends SubscriberClient {
   override def acknowledge(in: AcknowledgeRequest): Future[com.google.protobuf.empty.Empty] = ???
   override def pull(in: PullRequest): Future[PullResponse] = ???
   override def streamingPull(
-      in: pekko.stream.scaladsl.Source[StreamingPullRequest, NotUsed])
-      : pekko.stream.scaladsl.Source[StreamingPullResponse, NotUsed] = ???
+      in: Source[StreamingPullRequest, NotUsed])
+      : Source[StreamingPullResponse, NotUsed] = ???
   override def modifyPushConfig(in: ModifyPushConfigRequest): Future[com.google.protobuf.empty.Empty] = ???
   override def getSnapshot(in: GetSnapshotRequest): Future[Snapshot] = ???
   override def listSnapshots(in: ListSnapshotsRequest): Future[ListSnapshotsResponse] = ???

--- a/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesSpec.scala
@@ -31,15 +31,17 @@ import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
 
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Millis, Seconds, Span }
 import org.scalatest.wordspec.AnyWordSpec
 
 class AutoExtendAckDeadlinesSpec
     extends AnyWordSpec
     with Matchers
     with BeforeAndAfterAll
-    with ScalaFutures {
+    with ScalaFutures
+    with Eventually {
 
   implicit val system: ActorSystem = ActorSystem("AutoExtendAckDeadlinesSpec")
   implicit val patience: PatienceConfig = PatienceConfig(10.seconds, 100.millis)
@@ -179,8 +181,11 @@ class AutoExtendAckDeadlinesSpec
         .toMat(Sink.ignore)(pekko.stream.scaladsl.Keep.left)
         .run()
 
-      // Allow several ticks to fire.
-      Thread.sleep(500)
+      // Wait until the initial request plus at least 2 keepalive ticks have landed,
+      // then cancel. Polls instead of sleeping so a slow CI machine doesn't flake.
+      eventually(timeout(Span(5, Seconds)), interval(Span(50, Millis))) {
+        captured.size should be >= 3
+      }
       cancellableFut.futureValue.cancel()
 
       val first = captured.poll()

--- a/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesSpec.scala
@@ -25,8 +25,10 @@ import pekko.stream.connectors.googlecloud.pubsub.grpc.scaladsl.{ GooglePubSub, 
 import com.google.protobuf.ByteString
 import com.google.pubsub.v1.pubsub._
 
+import java.util.concurrent.ConcurrentLinkedQueue
 import scala.concurrent.{ Future, Promise }
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.concurrent.ScalaFutures
@@ -156,8 +158,80 @@ class AutoExtendAckDeadlinesSpec
     }
   }
 
+  "GooglePubSub.subscribe" should {
+    "send only allowed fields on subsequent StreamingPullRequest messages" in {
+      // Regression test: the keepalive tick must NOT echo initial-only fields
+      // (clientId, maxOutstandingMessages, maxOutstandingBytes) back to the server,
+      // which would otherwise return INVALID_ARGUMENT on the first tick.
+      val captured = new ConcurrentLinkedQueue[StreamingPullRequest]()
+      val testSubscriber = new GrpcSubscriber(new CapturingStreamingPullClient(captured)(system))
+
+      val initial = StreamingPullRequest()
+        .withSubscription(subscription)
+        .withStreamAckDeadlineSeconds(60)
+        .withClientId("test-client")
+        .withMaxOutstandingMessages(100L)
+        .withMaxOutstandingBytes(10485760L)
+
+      val cancellableFut = GooglePubSub
+        .subscribe(initial, 100.millis)
+        .withAttributes(PubSubAttributes.subscriber(testSubscriber))
+        .toMat(Sink.ignore)(pekko.stream.scaladsl.Keep.left)
+        .run()
+
+      // Allow several ticks to fire.
+      Thread.sleep(500)
+      cancellableFut.futureValue.cancel()
+
+      val first = captured.poll()
+      first should not be null
+      withClue("initial request must carry caller-supplied fields verbatim: ") {
+        first.subscription shouldBe subscription
+        first.streamAckDeadlineSeconds shouldBe 60
+        first.clientId shouldBe "test-client"
+        first.maxOutstandingMessages shouldBe 100L
+        first.maxOutstandingBytes shouldBe 10485760L
+      }
+
+      val subsequent = Iterator
+        .continually(Option(captured.poll()))
+        .takeWhile(_.isDefined)
+        .flatten
+        .toList
+      subsequent should not be empty
+      subsequent.zipWithIndex.foreach { case (req, idx) =>
+        withClue(s"subsequent request #${idx + 1} must be the default instance: ") {
+          req.subscription shouldBe ""
+          req.streamAckDeadlineSeconds shouldBe 0
+          req.clientId shouldBe ""
+          req.maxOutstandingMessages shouldBe 0L
+          req.maxOutstandingBytes shouldBe 0L
+        }
+      }
+    }
+  }
+
   override def afterAll(): Unit =
     system.terminate()
+}
+
+/**
+ * Stub that captures every StreamingPullRequest sent on the client → server stream
+ * and keeps the response stream open indefinitely (so the polling tick keeps firing).
+ */
+class CapturingStreamingPullClient(captured: ConcurrentLinkedQueue[StreamingPullRequest])(
+    implicit sys: ActorSystem) extends TestSubscriberClientBase {
+  private implicit val mat: pekko.stream.Materializer = pekko.stream.Materializer.matFromSystem(sys)
+
+  override def streamingPull(
+      in: pekko.stream.scaladsl.Source[StreamingPullRequest, pekko.NotUsed])
+      : pekko.stream.scaladsl.Source[StreamingPullResponse, pekko.NotUsed] =
+    pekko.stream.scaladsl.Source
+      .maybe[StreamingPullResponse]
+      .mapMaterializedValue { _ =>
+        in.runForeach(req => captured.add(req))
+        pekko.NotUsed
+      }
 }
 
 /**


### PR DESCRIPTION
`subscribe(...)` was clearing only `subscription` and `streamAckDeadlineSeconds` on the keepalive request, leaving `clientId`, `maxOutstandingMessages`, and `maxOutstandingBytes` from the initial one. Pub/Sub rejects those three on subsequent requests with `INVALID_ARGUMENT`, so any caller setting `maxOutstandingMessages` loses the whole stream about a second after start.

Fix: one line on each DSL, use `StreamingPullRequest.defaultInstance` (Scala) / `getDefaultInstance` (Java) for the keepalive. Clears every initial-only field at once and stays safe if the proto grows more later.

Bug present since `3f1a4f7f28` (Jan 2019, alpakka era). Same code path still in alpakka, akka/alpakka#3468. Broader follow-up: #1620. Regression test added in `AutoExtendAckDeadlinesSpec`.

Closes #1624.