### PR TITLE
Fix unit test related to ftp timeout

### DIFF
--- a/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
+++ b/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
@@ -77,7 +77,7 @@ class FtpExamplesSpec
         .runWith(Ftp.toPath("file.txt", ftpSettings))
       // #storing
 
-      val ioResult = result.futureValue(timeout(Span(4, Seconds)))
+      val ioResult = result.futureValue(timeout(Span(8, Seconds)))
       ioResult should be(IOResult.createSuccessful(25))
 
       val p = fileExists("file.txt")
@@ -101,7 +101,7 @@ class FtpExamplesSpec
         .runWith(Ftp.toPath("file.txt.gz", ftpSettings))
       // #storing
 
-      val ioResult = result.futureValue(timeout(Span(4, Seconds)))
+      val ioResult = result.futureValue(timeout(Span(8, Seconds)))
       ioResult should be(IOResult.createSuccessful(61))
 
       val p = fileExists("file.txt.gz")

--- a/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
+++ b/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
@@ -64,8 +64,7 @@ class FtpExamplesSpec
   }
 
   "a file" should {
-    // https://github.com/apache/pekko-connectors/issues/1581 open to try to get this fixed
-    "be stored" ignore assertAllStagesStopped {
+    "be stored" in assertAllStagesStopped {
       // #storing
       import org.apache.pekko
       import pekko.stream.IOResult
@@ -78,7 +77,7 @@ class FtpExamplesSpec
         .runWith(Ftp.toPath("file.txt", ftpSettings))
       // #storing
 
-      val ioResult = result.futureValue(timeout(Span(1, Seconds)))
+      val ioResult = result.futureValue(timeout(Span(4, Seconds)))
       ioResult should be(IOResult.createSuccessful(25))
 
       val p = fileExists("file.txt")
@@ -86,8 +85,7 @@ class FtpExamplesSpec
 
     }
 
-    // https://github.com/apache/pekko-connectors/issues/1581 open to try to get this fixed
-    "be gzipped" ignore assertAllStagesStopped {
+    "be gzipped" in assertAllStagesStopped {
       import pekko.stream.IOResult
       import pekko.stream.connectors.ftp.scaladsl.Ftp
       import pekko.util.ByteString
@@ -103,7 +101,7 @@ class FtpExamplesSpec
         .runWith(Ftp.toPath("file.txt.gz", ftpSettings))
       // #storing
 
-      val ioResult = result.futureValue(timeout(Span(1, Seconds)))
+      val ioResult = result.futureValue(timeout(Span(4, Seconds)))
       ioResult should be(IOResult.createSuccessful(61))
 
       val p = fileExists("file.txt.gz")


### PR DESCRIPTION
This PR fixes the ftp unit test issue reported in #1581 by increasing the timeout for the test to 4 seconds (after noticing ~3s in tests):

```
[info] - should be stored (2 seconds, 883 milliseconds)
[info] - should be gzipped (2 seconds, 698 milliseconds)
```