### PR TITLE
support scala3 mongodb connector

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -525,7 +525,7 @@ def pekkoConnectorProject(projectId: String,
       AutomaticModuleName.settings(s"pekko.stream.connectors.$moduleName"),
       mimaPreviousArtifacts := {
         if (noMimaChecks.contains(moduleName) ||
-          (moduleName == "slick" && scalaVersion.value.startsWith("3"))) {
+          (moduleName == "mongodb" && scalaVersion.value.startsWith("3"))) {
           Set.empty
         } else {
           Set(organization.value %% name.value % mimaCompareVersion)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -392,7 +392,6 @@ object Dependencies {
       "org.apache.logging.log4j" % "log4j-to-slf4j" % Log4jVersion % Test))
 
   val MongoDb = Seq(
-    crossScalaVersions -= Scala3,
     libraryDependencies ++= Seq(
       "org.mongodb.scala" %% "mongo-scala-driver" % "5.8.0"))
 


### PR DESCRIPTION
https://mvnrepository.com/artifact/org.mongodb.scala/mongo-scala-driver/versions

seems like mongo-scala-driver supports Scala 3 since v5.7.0 driver

fixes #150