### PR TITLE
chore: re-enable javafmt check in CI via unified checkCodeStyle alias

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -52,10 +52,8 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
-      # Javafmt code style check disabled temporarily
-      # https://github.com/apache/pekko-connectors/issues/1401
-      - name: "Code style, compile tests, MiMa. Run locally with: sbt \"+Test/compile; +mimaReportBinaryIssues\""
-        run: sbt "+Test/compile; +mimaReportBinaryIssues"
+      - name: "Code style, compile tests, MiMa. Run locally with: sbt \"checkCodeStyle; +Test/compile; +mimaReportBinaryIssues\""
+        run: sbt "checkCodeStyle; +Test/compile; +mimaReportBinaryIssues"
 
       - name: "Integration Test Compile"
         run: sbt "+aws-spi-pekko-http-int-tests/Test/compile"

--- a/build.sbt
+++ b/build.sbt
@@ -127,8 +127,8 @@ lazy val `pekko-connectors` = project
     crossScalaVersions := List() // workaround for https://github.com/sbt/sbt/issues/3465
   )
 
-addCommandAlias("applyCodeStyle", ";scalafmtAll; scalafmtSbt; javafmtAll; +headerCreateAll")
-addCommandAlias("checkCodeStyle", ";+headerCheckAll; scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll")
+addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")
+addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
 
 lazy val amqp = pekkoConnectorProject("amqp", "amqp", Dependencies.Amqp)
 

--- a/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
+++ b/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
@@ -26,7 +26,6 @@ import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 
-
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 


### PR DESCRIPTION
### Motivation
Re-enable the javafmt code style check that was temporarily disabled (issue #1401), now using the unified `checkCodeStyle` alias that covers scalafmt, javafmt, and header checks in one command.

### Modification
- Remove the "javafmt disabled temporarily" comment from CI workflow
- Add `checkCodeStyle` to the sbt command in `check-build-test.yml`
- CI now runs: `sbt "checkCodeStyle; +Test/compile; +mimaReportBinaryIssues"`

### Result
CI enforces consistent code style checks (scalafmt + javafmt + headers) using the unified `checkCodeStyle` alias, matching the pattern used in other pekko sub-projects.

### Tests
Not run - CI config change only

### References
Refs #1401