### PR TITLE
fix: Scala 3.8+ forward compatibility

### DIFF
--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpConnectorLogic.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpConnectorLogic.scala
@@ -22,8 +22,8 @@ import scala.util.control.NonFatal
 
 private trait AmqpConnectorLogic { this: GraphStageLogic =>
 
-  private var connection: Connection = _
-  protected var channel: Channel = _
+  private var connection: Connection = null
+  protected var channel: Channel = null
 
   protected lazy val shutdownCallback: AsyncCallback[Throwable] = getAsyncCallback(onFailure)
   private lazy val shutdownListener = new ShutdownListener {

--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpRpcFlowStage.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AmqpRpcFlowStage.scala
@@ -58,7 +58,7 @@ private[amqp] final class AmqpRpcFlowStage(writeSettings: AmqpWriteSettings, buf
         private val exchange = settings.exchange.getOrElse("")
         private val routingKey = settings.routingKey.getOrElse("")
         private val queue = mutable.Queue[CommittableReadResult]()
-        private var queueName: String = _
+        private var queueName: String = null
         private var unackedMessages = 0
         private var outstandingMessages = 0
 

--- a/aws-event-bridge/src/test/scala/org/apache/pekko/stream/connectors/aws/eventbridge/IntegrationTestContext.scala
+++ b/aws-event-bridge/src/test/scala/org/apache/pekko/stream/connectors/aws/eventbridge/IntegrationTestContext.scala
@@ -34,8 +34,8 @@ trait IntegrationTestContext extends BeforeAndAfterAll with ScalaFutures {
 
   def eventBusEndpoint: String = s"http://localhost:4587"
 
-  implicit var eventBridgeClient: EventBridgeAsyncClient = _
-  var eventBusArn: String = _
+  implicit var eventBridgeClient: EventBridgeAsyncClient = null
+  var eventBusArn: String = null
 
   def createEventBus(): String =
     eventBridgeClient

--- a/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
+++ b/couchbase/src/main/scala/org/apache/pekko/stream/connectors/couchbase/model.scala
@@ -85,7 +85,7 @@ final class CouchbaseWriteSettings private (val parallelism: Int,
    */
   def withTimeout(timeout: FiniteDuration): CouchbaseWriteSettings = copy(timeout = timeout)
 
-  private[this] def copy(parallelism: Int = parallelism,
+  private def copy(parallelism: Int = parallelism,
       replicateTo: ReplicateTo = replicateTo,
       persistTo: PersistTo = persistTo,
       timeout: FiniteDuration = timeout) =

--- a/couchbase/src/test/scala/org/apache/pekko/stream/connectors/couchbase/testing/CouchbaseSupport.scala
+++ b/couchbase/src/test/scala/org/apache/pekko/stream/connectors/couchbase/testing/CouchbaseSupport.scala
@@ -63,7 +63,7 @@ trait CouchbaseSupport {
   val bucketName = "pekko"
   val queryBucketName = "pekkoquery"
 
-  var session: CouchbaseSession = _
+  var session: CouchbaseSession = null
 
   def beforeAll(): Unit = {
     session = Await.result(CouchbaseSession(sessionSettings, bucketName), 10.seconds)

--- a/csv-bench/src/main/scala/org/apache/pekko/stream/connectors/csv/scaladsl/CsvBench.scala
+++ b/csv-bench/src/main/scala/org/apache/pekko/stream/connectors/csv/scaladsl/CsvBench.scala
@@ -75,8 +75,8 @@ class CsvBench {
       "8192", // ~same size as row
       "65536" // ~8k larger than row
     ))
-  var bsSize: Int = _
-  var source: Source[ByteString, NotUsed] = _
+  var bsSize: Int = 0
+  var source: Source[ByteString, NotUsed] = null
 
   @Benchmark
   def parse(bh: Blackhole): Unit = {

--- a/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvFormatter.scala
+++ b/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvFormatter.scala
@@ -32,13 +32,13 @@ import scala.collection.immutable
     quotingStyle: CsvQuotingStyle,
     charset: Charset = StandardCharsets.UTF_8) {
 
-  private[this] val charsetName = charset.name()
+  private val charsetName = charset.name()
 
-  private[this] val delimiterBs = ByteString(String.valueOf(delimiter), charsetName)
-  private[this] val quoteBs = ByteString(String.valueOf(quoteChar), charsetName)
-  private[this] val duplicatedQuote = ByteString(String.valueOf(Array(quoteChar, quoteChar)), charsetName)
-  private[this] val duplicatedEscape = ByteString(String.valueOf(Array(escapeChar, escapeChar)), charsetName)
-  private[this] val endOfLineBs = ByteString(endOfLine, charsetName)
+  private val delimiterBs = ByteString(String.valueOf(delimiter), charsetName)
+  private val quoteBs = ByteString(String.valueOf(quoteChar), charsetName)
+  private val duplicatedQuote = ByteString(String.valueOf(Array(quoteChar, quoteChar)), charsetName)
+  private val duplicatedEscape = ByteString(String.valueOf(Array(escapeChar, escapeChar)), charsetName)
+  private val endOfLineBs = ByteString(endOfLine, charsetName)
 
   def toCsv(fields: immutable.Iterable[Any]): ByteString =
     if (fields.nonEmpty) nonEmptyToCsv(fields)

--- a/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvParser.scala
+++ b/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvParser.scala
@@ -60,12 +60,12 @@ import scala.collection.mutable
    *
    * May include previous chunks that start a field but do not complete it.
    */
-  private[this] var buffer: ByteString = ByteString.empty
+  private var buffer: ByteString = ByteString.empty
 
   /**
    * Flag to run BOM checks against first two bytes of the stream.
    */
-  private[this] var firstData = true
+  private var firstData = true
 
   /**
    * Current position within [[buffer]].
@@ -73,7 +73,7 @@ import scala.collection.mutable
    * Points to the same byte as [[current.head]].
    * Used for slicing fields out of [[buffer]] and for debug info.
    */
-  private[this] var pos: Int = 0
+  private var pos: Int = 0
 
   /**
    * Number of bytes dropped on the current row.
@@ -84,27 +84,27 @@ import scala.collection.mutable
    * [[pekko.util.ByteString.ByteStrings]] to a [[pekko.util.ByteString.ByteString1]]
    * to exploit the much faster [[ByteString.slice()]] implementation.
    */
-  private[this] var lineBytesDropped = 0
+  private var lineBytesDropped = 0
 
   /**
    * Position within the current row.
    *
    * Used for enforcing line length limits and as debug info for exceptions.
    */
-  private[this] def lineLength: Int = lineBytesDropped + pos
+  private def lineLength: Int = lineBytesDropped + pos
 
   /**
    * Position within [[buffer]] of the start of the current field.
    */
-  private[this] var fieldStart = 0
-  private[this] var currentLineNo = 1L
+  private var fieldStart = 0
+  private var currentLineNo = 1L
 
   /**
    * Reset after each row.
    */
-  private[this] val columns = mutable.ListBuffer[ByteString]()
-  private[this] var state: State = LineStart
-  private[this] val fieldBuilder = new FieldBuilder
+  private val columns = mutable.ListBuffer[ByteString]()
+  private var state: State = LineStart
+  private val fieldBuilder = new FieldBuilder
 
   /**
    * Current iterator being parsed.
@@ -114,7 +114,7 @@ import scala.collection.mutable
    *
    * We fully parse each chunk before getting the next, so we only need to track one [[ByteIterator]] at a time.
    */
-  private[this] var current: ByteIterator = ByteString.empty.iterator
+  private var current: ByteIterator = ByteString.empty.iterator
 
   def offer(next: ByteString): Unit =
     if (next.nonEmpty) {
@@ -137,17 +137,17 @@ import scala.collection.mutable
     line
   }
 
-  private[this] def advance(n: Int = 1): Unit = {
+  private def advance(n: Int = 1): Unit = {
     pos += n
     current.drop(n)
   }
 
-  private[this] def resetLine(): Unit = {
+  private def resetLine(): Unit = {
     dropReadBuffer()
     lineBytesDropped = 0
   }
 
-  private[this] def dropReadBuffer() = {
+  private def dropReadBuffer() = {
     buffer = buffer.drop(pos)
     lineBytesDropped += pos
     pos = 0
@@ -163,8 +163,8 @@ import scala.collection.mutable
     /**
      * false if [[builder]] is null.
      */
-    private[this] var useBuilder = false
-    private[this] var builder: ByteStringBuilder = _
+    private var useBuilder = false
+    private var builder: ByteStringBuilder = null
 
     /**
      * Set up the ByteString builder instead of relying on `ByteString.slice`.
@@ -186,12 +186,12 @@ import scala.collection.mutable
 
   }
 
-  private[this] def noCharEscaped() =
+  private def noCharEscaped() =
     throw new MalformedCsvException(currentLineNo,
       lineLength,
       s"wrong escaping at $currentLineNo:$lineLength, no character after escape")
 
-  private[this] def checkForByteOrderMark(): Unit =
+  private def checkForByteOrderMark(): Unit =
     if (buffer.length >= 2) {
       if (buffer.startsWith(ByteOrderMark.UTF_8)) {
         advance(3)
@@ -209,7 +209,7 @@ import scala.collection.mutable
       }
     }
 
-  private[this] def parseLine(): Unit = {
+  private def parseLine(): Unit = {
     if (firstData) {
       checkForByteOrderMark()
       firstData = false
@@ -217,7 +217,7 @@ import scala.collection.mutable
     churn()
   }
 
-  private[this] def churn(): Unit = {
+  private def churn(): Unit = {
     while (state != LineEnd && pos < buffer.length) {
       if (lineLength >= maximumLineLength)
         throw new MalformedCsvException(
@@ -405,7 +405,7 @@ import scala.collection.mutable
       }
     }
   }
-  private[this] def maybeExtractLine(requireLineEnd: Boolean): Option[List[ByteString]] =
+  private def maybeExtractLine(requireLineEnd: Boolean): Option[List[ByteString]] =
     if (requireLineEnd) {
       state match {
         case LineEnd =>

--- a/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvParsingStage.scala
+++ b/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvParsingStage.scala
@@ -40,7 +40,7 @@ import scala.util.control.NonFatal
 
   override def createLogic(inheritedAttributes: Attributes) =
     new GraphStageLogic(shape) with InHandler with OutHandler {
-      private[this] val buffer = new CsvParser(delimiter, quoteChar, escapeChar, maximumLineLength)
+      private val buffer = new CsvParser(delimiter, quoteChar, escapeChar, maximumLineLength)
 
       setHandlers(in, out, this)
 

--- a/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvToMapJavaStage.scala
+++ b/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/impl/CsvToMapJavaStage.scala
@@ -57,7 +57,7 @@ import pekko.util.ByteString
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) {
-      private[this] var headers = columnNames
+      private var headers = columnNames
 
       setHandler(
         in,

--- a/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/scaladsl/ByteOrderMark.scala
+++ b/csv/src/main/scala/org/apache/pekko/stream/connectors/csv/scaladsl/ByteOrderMark.scala
@@ -23,7 +23,7 @@ import org.apache.pekko.util.ByteString
  */
 object ByteOrderMark {
 
-  private[this] final val ZeroZero = ByteString.apply(0x00.toByte, 0x00.toByte)
+  private final val ZeroZero = ByteString.apply(0x00.toByte, 0x00.toByte)
 
   /** Byte Order Mark for UTF-16 big-endian */
   final val UTF_16_BE = ByteString.apply(0xFE.toByte, 0xFF.toByte)

--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/scaladsl/LogRotatorSink.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/scaladsl/LogRotatorSink.scala
@@ -97,7 +97,7 @@ final private class LogRotatorSink[T, C, R](triggerGeneratorCreator: () => T => 
 
   private final class Logic(promise: Promise[Done]) extends GraphStageLogic(shape) {
     val triggerGenerator: T => Option[C] = triggerGeneratorCreator()
-    var sourceOut: SubSourceOutlet[T] = _
+    var sourceOut: SubSourceOutlet[T] = null
     var sinkCompletions: immutable.Seq[Future[R]] = immutable.Seq.empty
     var isFinishing = false
 

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpBrowserGraphStage.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpBrowserGraphStage.scala
@@ -34,9 +34,9 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings]
   def createLogic(inheritedAttributes: Attributes): FtpGraphStageLogic[FtpFile, FtpClient, S] = {
     val logic = new FtpGraphStageLogic[FtpFile, FtpClient, S](shape, ftpLike, connectionSettings, ftpClient) {
 
-      private[this] var buffer: Seq[FtpFile] = Seq.empty[FtpFile]
+      private var buffer: Seq[FtpFile] = Seq.empty[FtpFile]
 
-      private[this] var traversed: Seq[FtpFile] = Seq.empty[FtpFile]
+      private var traversed: Seq[FtpFile] = Seq.empty[FtpFile]
 
       setHandler(
         out,
@@ -70,11 +70,11 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings]
 
       override protected[this] def matFailure(t: Throwable) = true
 
-      private[this] def initBuffer(basePath: String) =
+      private def initBuffer(basePath: String) =
         getFilesFromPath(basePath)
 
       @scala.annotation.tailrec
-      private[this] def fillBuffer(): Unit = buffer match {
+      private def fillBuffer(): Unit = buffer match {
         case head +: tail if head.isDirectory && branchSelector(head) =>
           buffer = getFilesFromPath(head.path) ++ tail
           if (emitTraversedDirectories) traversed = traversed :+ head
@@ -82,7 +82,7 @@ private[ftp] trait FtpBrowserGraphStage[FtpClient, S <: RemoteFileSettings]
         case _ => // do nothing
       }
 
-      private[this] def getFilesFromPath(basePath: String) =
+      private def getFilesFromPath(basePath: String) =
         if (basePath.isEmpty)
           graphStageFtpLike.listFiles(handler.get)
         else

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpIOGraphStage.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/FtpIOGraphStage.scala
@@ -79,8 +79,8 @@ private[ftp] trait FtpIOSourceStage[FtpClient, S <: RemoteFileSettings]
 
     val logic = new FtpGraphStageLogic[ByteString, FtpClient, S](shape, ftpLike, connectionSettings, ftpClient) {
 
-      private[this] var isOpt: Option[InputStream] = None
-      private[this] var readBytesTotal: Long = 0L
+      private var isOpt: Option[InputStream] = None
+      private var readBytesTotal: Long = 0L
 
       setHandler(
         out,
@@ -158,7 +158,7 @@ private[ftp] trait FtpIOSourceStage[FtpClient, S <: RemoteFileSettings]
         matValuePromise.tryFailure(new IOOperationIncompleteException(readBytesTotal, t))
 
       /** BLOCKING I/O READ */
-      private[this] def readChunk() = {
+      private def readChunk() = {
         def read(arr: Array[Byte]) =
           isOpt.flatMap { is =>
             val readBytes = is.read(arr)
@@ -200,8 +200,8 @@ private[ftp] trait FtpIOSinkStage[FtpClient, S <: RemoteFileSettings]
 
     val logic = new FtpGraphStageLogic[ByteString, FtpClient, S](shape, ftpLike, connectionSettings, ftpClient) {
 
-      private[this] var osOpt: Option[OutputStream] = None
-      private[this] var writtenBytesTotal: Long = 0L
+      private var osOpt: Option[OutputStream] = None
+      private var writtenBytesTotal: Long = 0L
 
       setHandler(
         in,
@@ -262,7 +262,7 @@ private[ftp] trait FtpIOSinkStage[FtpClient, S <: RemoteFileSettings]
         matValuePromise.tryFailure(new IOOperationIncompleteException(writtenBytesTotal, t))
 
       /** BLOCKING I/O WRITE */
-      private[this] def write(bytes: ByteString) =
+      private def write(bytes: ByteString) =
         osOpt.foreach { os =>
           os.write(bytes.toArray)
           writtenBytesTotal += bytes.size

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/SftpOperations.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/impl/SftpOperations.scala
@@ -191,7 +191,7 @@ private[ftp] trait SftpOperations { self: FtpLike[SSHClient, SftpSettings] =>
       }
     }
 
-  private[this] def authPublickey(identity: SftpIdentity)(implicit ssh: SSHClient) = {
+  private def authPublickey(identity: SftpIdentity)(implicit ssh: SSHClient) = {
     def bats(array: Array[Byte]): String = new String(array, StandardCharsets.UTF_8)
 
     val passphrase =

--- a/geode/src/main/scala/org/apache/pekko/stream/connectors/geode/impl/stage/GeodeCQueryGraphLogic.scala
+++ b/geode/src/main/scala/org/apache/pekko/stream/connectors/geode/impl/stage/GeodeCQueryGraphLogic.scala
@@ -44,7 +44,7 @@ private[geode] abstract class GeodeCQueryGraphLogic[V](val shape: SourceShape[V]
 
   val onElement: AsyncCallback[V]
 
-  private var query: CqQuery = _
+  private var query: CqQuery = null
 
   override def executeQuery() = Try {
 

--- a/geode/src/main/scala/org/apache/pekko/stream/connectors/geode/impl/stage/GeodeSourceStageLogic.scala
+++ b/geode/src/main/scala/org/apache/pekko/stream/connectors/geode/impl/stage/GeodeSourceStageLogic.scala
@@ -25,7 +25,7 @@ import scala.util.{ Failure, Success, Try }
 private[geode] abstract class GeodeSourceStageLogic[V](shape: SourceShape[V], clientCache: ClientCache)
     extends GraphStageLogic(shape) {
 
-  protected var initialResultsIterator: java.util.Iterator[V] = _
+  protected var initialResultsIterator: java.util.Iterator[V] = null
 
   val onConnect: AsyncCallback[Unit]
 

--- a/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
+++ b/google-cloud-bigquery-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorage.scala
@@ -113,7 +113,7 @@ object BigQueryStorage {
       : Source[(ReadSession.Schema, java.util.List[Source[ReadRowsResponse.Rows, NotUsed]]), CompletionStage[NotUsed]] =
     create(projectId, datasetId, tableId, dataFormat, None, maxNumStreams)
 
-  private[this] def create(
+  private def create(
       projectId: String,
       datasetId: String,
       tableId: String,
@@ -206,7 +206,7 @@ object BigQueryStorage {
       um: Unmarshaller[ByteString, A]): Source[A, CompletionStage[NotUsed]] =
     createMergedStreams(projectId, datasetId, tableId, dataFormat, None, maxNumStreams, um.asScala)
 
-  private[this] def createMergedStreams[A](
+  private def createMergedStreams[A](
       projectId: String,
       datasetId: String,
       tableId: String,

--- a/google-cloud-bigquery/src/main/mima-filters/2.0.x.backward.excludes/context-bounds.excludes
+++ b/google-cloud-bigquery/src/main/mima-filters/2.0.x.backward.excludes/context-bounds.excludes
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Converting context bound [T: FromResponseUnmarshaller] to explicit implicit
+# parameter reorders the implicit parameter list at the bytecode level.
+# This is a binary-incompatible change but does not affect source-level callers
+# using implicit resolution. BigQuery API is @ApiMayChange.
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.stream.connectors.googlecloud.bigquery.scaladsl.BigQuery.singleRequest")

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -43,7 +43,7 @@ trait GCStorageStreamIntegrationSpec
   private implicit val defaultPatience: PatienceConfig =
     PatienceConfig(timeout = 60.seconds, interval = 60.millis)
 
-  var folderName: String = _
+  var folderName: String = null
 
   def testFileName(file: String): String = folderName + file
 

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/GoogleHttp.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/GoogleHttp.scala
@@ -87,12 +87,13 @@ private[connectors] final class GoogleHttp private (val http: HttpExt) extends A
    * If `authenticate = true` adds an Authorization header to each request.
    * Retries the request if the [[FromResponseUnmarshaller]] throws a [[pekko.stream.connectors.google.util.Retry]].
    */
-  def cachedHostConnectionPool[T: FromResponseUnmarshaller](
+  def cachedHostConnectionPool[T](
       host: String,
       port: Int = -1,
       https: Boolean = true,
       authenticate: Boolean = true,
-      parallelism: Int = 1): Flow[HttpRequest, T, Future[HostConnectionPool]] =
+      parallelism: Int = 1)(implicit um: FromResponseUnmarshaller[T])
+      : Flow[HttpRequest, T, Future[HostConnectionPool]] =
     Flow[HttpRequest]
       .map((_, ()))
       .viaMat(cachedHostConnectionPoolWithContext[T, Unit](host, port, https, authenticate, parallelism).asFlow)(
@@ -104,12 +105,13 @@ private[connectors] final class GoogleHttp private (val http: HttpExt) extends A
    * If `authenticate = true` adds an Authorization header to each request.
    * Retries the request if the [[FromResponseUnmarshaller]] throws a [[pekko.stream.connectors.google.util.Retry]].
    */
-  def cachedHostConnectionPoolWithContext[T: FromResponseUnmarshaller, Ctx](
+  def cachedHostConnectionPoolWithContext[T, Ctx](
       host: String,
       port: Int = -1,
       https: Boolean = true,
       authenticate: Boolean = true,
-      parallelism: Int = 1): FlowWithContext[HttpRequest, Ctx, Try[T], Ctx, Future[HostConnectionPool]] =
+      parallelism: Int = 1)(implicit um: FromResponseUnmarshaller[T])
+      : FlowWithContext[HttpRequest, Ctx, Try[T], Ctx, Future[HostConnectionPool]] =
     FlowWithContext.fromTuples {
       Flow.fromMaterializer { (mat, attr) =>
         implicit val settings: GoogleSettings = GoogleAttributes.resolveSettings(mat, attr)

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/javadsl/Google.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/javadsl/Google.scala
@@ -47,7 +47,7 @@ private[connectors] trait Google {
       unmarshaller: Unmarshaller[HttpResponse, T],
       settings: GoogleSettings,
       system: ClassicActorSystemProvider): CompletionStage[T] =
-    ScalaGoogle.singleRequest[T](request)(unmarshaller.asScala, system, settings).asJava
+    ScalaGoogle.singleRequest[T](request)(system, settings, unmarshaller.asScala).asJava
 
   /**
    * Makes a series of requests to page through a resource. Authentication is handled automatically.

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/jwt/JwtSprayJson.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/jwt/JwtSprayJson.scala
@@ -82,9 +82,9 @@ private[google] class JwtSprayJson private (defaultClock: Clock)
       jwtId = safeGetField[String](jsObj, "jti"))
   }
 
-  private[this] def safeRead[A: JsonReader](js: JsValue) =
+  private def safeRead[A: JsonReader](js: JsValue) =
     safeReader[A].read(js).fold(_ => None, a => Option(a))
 
-  private[this] def safeGetField[A: JsonReader](js: JsObject, name: String) =
+  private def safeGetField[A: JsonReader](js: JsObject, name: String) =
     js.fields.get(name).flatMap(safeRead[A])
 }

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/scaladsl/Google.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/scaladsl/Google.scala
@@ -40,8 +40,9 @@ private[connectors] trait Google {
    * @tparam T the data model for the resource
    * @return a [[scala.concurrent.Future]] containing the unmarshalled response
    */
-  final def singleRequest[T: FromResponseUnmarshaller](
-      request: HttpRequest)(implicit system: ClassicActorSystemProvider, settings: GoogleSettings): Future[T] =
+  final def singleRequest[T](
+      request: HttpRequest)(implicit system: ClassicActorSystemProvider, settings: GoogleSettings,
+      um: FromResponseUnmarshaller[T]): Future[T] =
     GoogleHttp().singleAuthenticatedRequest[T](request)
 
   /**
@@ -64,7 +65,8 @@ private[connectors] trait Google {
    * @tparam Out the data model for the resource
    * @return a [[pekko.stream.scaladsl.Sink]] that materializes a [[scala.concurrent.Future]] containing the unmarshalled resource
    */
-  final def resumableUpload[Out: FromResponseUnmarshaller](request: HttpRequest): Sink[ByteString, Future[Out]] =
+  final def resumableUpload[Out](request: HttpRequest)(
+      implicit um: FromResponseUnmarshaller[Out]): Sink[ByteString, Future[Out]] =
     ResumableUpload[Out](request)
 
 }

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsReaderSpec.scala
@@ -39,7 +39,7 @@ class HdfsReaderSpec
     with BeforeAndAfterEach
     with LogCapturing {
 
-  private var hdfsCluster: MiniDFSCluster = _
+  private var hdfsCluster: MiniDFSCluster = null
   private val destination = "/tmp/pekko-connectors/"
 
   implicit val system: ActorSystem = ActorSystem()

--- a/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
+++ b/hdfs/src/test/scala/docs/scaladsl/HdfsWriterSpec.scala
@@ -41,7 +41,7 @@ class HdfsWriterSpec
     with BeforeAndAfterEach
     with LogCapturing {
 
-  private var hdfsCluster: MiniDFSCluster = _
+  private var hdfsCluster: MiniDFSCluster = null
   private val destination = "/tmp/pekko-connectors/"
 
   implicit val system: ActorSystem = ActorSystem()

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/InfluxDbSourceStage.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/InfluxDbSourceStage.scala
@@ -56,7 +56,7 @@ private[influxdb] final class InfluxDbSourceLogic[T](clazz: Class[T],
     shape: SourceShape[T])
     extends InfluxDbBaseSourceLogic[T](influxDB, query, outlet, shape) {
 
-  var resultMapperHelper: PekkoConnectorsResultMapperHelper = _
+  var resultMapperHelper: PekkoConnectorsResultMapperHelper = null
 
   override def preStart(): Unit = {
     resultMapperHelper = new PekkoConnectorsResultMapperHelper

--- a/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/FlowSpec.scala
@@ -47,7 +47,7 @@ class FlowSpec
 
   final val DatabaseName = this.getClass.getSimpleName
 
-  implicit var influxDB: InfluxDB = _
+  implicit var influxDB: InfluxDB = null
 
   override protected def beforeAll(): Unit =
     influxDB = setupConnection(DatabaseName)

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSourceSpec.scala
@@ -41,7 +41,7 @@ class InfluxDbSourceSpec
 
   implicit val system: ActorSystem = ActorSystem()
 
-  implicit var influxDB: InfluxDB = _
+  implicit var influxDB: InfluxDB = null
 
   override protected def beforeAll(): Unit =
     influxDB = setupConnection(DatabaseName)

--- a/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
+++ b/influxdb/src/test/scala/docs/scaladsl/InfluxDbSpec.scala
@@ -46,7 +46,7 @@ class InfluxDbSpec
 
   final val DatabaseName = this.getClass.getSimpleName
 
-  implicit var influxDB: InfluxDB = _
+  implicit var influxDB: InfluxDB = null
 
   // #define-class
   override protected def beforeAll(): Unit = {

--- a/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqPullStage.scala
+++ b/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqPullStage.scala
@@ -68,7 +68,7 @@ private[ironmq] final class IronMqPullStage(queueName: String, settings: IronMqS
       private var fetching: Boolean = false
 
       private var buffer: List[ReservedMessage] = List.empty
-      private var client: IronMqClient = _ // set in preStart
+      private var client: IronMqClient = null // set in preStart
 
       override def preStart(): Unit =
         client = IronMqClient(settings)(materializer.system, materializer)

--- a/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqPushStage.scala
+++ b/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqPushStage.scala
@@ -50,7 +50,7 @@ private[ironmq] class IronMqPushStage(queueName: String, settings: IronMqSetting
 
       private var runningFutures: Int = 0
       private var exceptionFromUpstream: Option[Throwable] = None
-      private var client: IronMqClient = _ // set in preStart
+      private var client: IronMqClient = null // set in preStart
 
       override def preStart(): Unit = {
         super.preStart()

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Envelopes.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Envelopes.scala
@@ -29,7 +29,7 @@ case class AckEnvelope private[jakartams] (message: jms.Message, private val jms
 
 case class TxEnvelope private[jakartams] (message: jms.Message, private val jmsSession: JmsSession) {
 
-  private[this] val commitPromise = Promise[() => Unit]()
+  private val commitPromise = Promise[() => Unit]()
 
   private[jakartams] val commitFuture: Future[() => Unit] = commitPromise.future
 

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsBrowseStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsBrowseStage.scala
@@ -36,10 +36,10 @@ private[jakartams] final class JmsBrowseStage(settings: JmsBrowseSettings, queue
     new GraphStageLogic(shape) with OutHandler {
       setHandler(out, this)
 
-      var connection: jms.Connection = _
-      var session: jms.Session = _
-      var browser: jms.QueueBrowser = _
-      var messages: java.util.Enumeration[jms.Message] = _
+      var connection: jms.Connection = null
+      var session: jms.Session = null
+      var browser: jms.QueueBrowser = null
+      var messages: java.util.Enumeration[jms.Message] = null
 
       override def preStart(): Unit = {
         val ackMode = settings.acknowledgeMode.mode

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsConnector.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsConnector.scala
@@ -39,7 +39,7 @@ private[jakartams] trait JmsConnector[S <: JmsSession] {
 
   import JmsConnector._
 
-  implicit protected var ec: ExecutionContext = _
+  implicit protected var ec: ExecutionContext = null
 
   private var jmsSessions = Seq.empty[S]
 
@@ -53,7 +53,7 @@ private[jakartams] trait JmsConnector[S <: JmsSession] {
 
   private val connectionFailedCB = getAsyncCallback[Throwable](connectionFailed)
 
-  private var connectionStateQueue: SourceQueueWithComplete[InternalConnectionState] = _
+  private var connectionStateQueue: SourceQueueWithComplete[InternalConnectionState] = null
 
   private val connectionStateSourcePromise = Promise[Source[InternalConnectionState, NotUsed]]()
 

--- a/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsSharedServerSpec.scala
+++ b/jakartams/src/test/scala/org/apache/pekko/stream/connectors/jakartams/JmsSharedServerSpec.scala
@@ -22,8 +22,8 @@ import scala.util.Random
  * Creates a single server and connection factory which is shared for all tests.
  */
 abstract class JmsSharedServerSpec extends JmsSpec {
-  private var jmsBroker: EmbeddedActiveMQServer = _
-  private var connectionFactory: ConnectionFactory = _
+  private var jmsBroker: EmbeddedActiveMQServer = null
+  private var connectionFactory: ConnectionFactory = null
   private val SHARED_SERVER_ID: Int = 2
 
   override def beforeAll(): Unit = {

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/Envelopes.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/Envelopes.scala
@@ -29,7 +29,7 @@ case class AckEnvelope private[jms] (message: jms.Message, private val jmsSessio
 
 case class TxEnvelope private[jms] (message: jms.Message, private val jmsSession: JmsSession) {
 
-  private[this] val commitPromise = Promise[() => Unit]()
+  private val commitPromise = Promise[() => Unit]()
 
   private[jms] val commitFuture: Future[() => Unit] = commitPromise.future
 

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsBrowseStage.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsBrowseStage.scala
@@ -36,10 +36,10 @@ private[jms] final class JmsBrowseStage(settings: JmsBrowseSettings, queue: Dest
     new GraphStageLogic(shape) with OutHandler {
       setHandler(out, this)
 
-      var connection: jms.Connection = _
-      var session: jms.Session = _
-      var browser: jms.QueueBrowser = _
-      var messages: java.util.Enumeration[jms.Message] = _
+      var connection: jms.Connection = null
+      var session: jms.Session = null
+      var browser: jms.QueueBrowser = null
+      var messages: java.util.Enumeration[jms.Message] = null
 
       override def preStart(): Unit = {
         val ackMode = settings.acknowledgeMode.mode

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsConnector.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsConnector.scala
@@ -40,7 +40,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
 
   import JmsConnector._
 
-  implicit protected var ec: ExecutionContext = _
+  implicit protected var ec: ExecutionContext = null
 
   private var jmsSessions = Seq.empty[S]
 
@@ -54,7 +54,7 @@ private[jms] trait JmsConnector[S <: JmsSession] {
 
   private val connectionFailedCB = getAsyncCallback[Throwable](connectionFailed)
 
-  private var connectionStateQueue: SourceQueueWithComplete[InternalConnectionState] = _
+  private var connectionStateQueue: SourceQueueWithComplete[InternalConnectionState] = null
 
   private val connectionStateSourcePromise = Promise[Source[InternalConnectionState, NotUsed]]()
 

--- a/jms/src/test/scala/org/apache/pekko/stream/connectors/jms/JmsSharedServerSpec.scala
+++ b/jms/src/test/scala/org/apache/pekko/stream/connectors/jms/JmsSharedServerSpec.scala
@@ -22,8 +22,8 @@ import scala.util.Random
  * Creates a single server and connection factory which is shared for all tests.
  */
 abstract class JmsSharedServerSpec extends JmsSpec {
-  private var jmsBroker: JmsBroker = _
-  private var connectionFactory: ConnectionFactory = _
+  private var jmsBroker: JmsBroker = null
+  private var connectionFactory: ConnectionFactory = null
 
   override def beforeAll(): Unit = {
     jmsBroker = JmsBroker()

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSchedulerSourceStage.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSchedulerSourceStage.scala
@@ -72,9 +72,9 @@ private[kinesis] class KinesisSchedulerSourceStage(
 
     // We're transmitting backpressure from the Outlet to the Scheduler using a Semaphore instance
     // semaphore.acquire ~> callback ~> push downstream ~> semaphore.release
-    private[this] val backpressureSemaphore = new Semaphore(bufferSize)
-    private[this] val buffer = mutable.Queue.empty[CommittableRecord]
-    private[this] var schedulerOpt: Option[Scheduler] = None
+    private val backpressureSemaphore = new Semaphore(bufferSize)
+    private val buffer = mutable.Queue.empty[CommittableRecord]
+    private var schedulerOpt: Option[Scheduler] = None
 
     override def preStart(): Unit = {
       implicit val ec: ExecutionContext = executionContext(attributes)

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/KinesisSourceStage.scala
@@ -69,9 +69,9 @@ private[kinesis] class KinesisSourceStage(shardSettings: ShardSettings, amazonKi
 
       import shardSettings._
 
-      private[this] var currentShardIterator: String = _
-      private[this] val buffer = mutable.Queue.empty[Record]
-      private[this] var self: StageActor = _
+      private var currentShardIterator: String = null
+      private val buffer = mutable.Queue.empty[Record]
+      private var self: StageActor = null
 
       override def preStart(): Unit = {
         self = getStageActor(awaitingShardIterator)
@@ -144,19 +144,19 @@ private[kinesis] class KinesisSourceStage(shardSettings: ShardSettings, amazonKi
           log.warning("unexpected timer [{}]", other)
       }
 
-      private[this] val handleGetRecords: Try[GetRecordsResponse] => Unit = {
+      private val handleGetRecords: Try[GetRecordsResponse] => Unit = {
         case Failure(exception) => self.ref ! GetRecordsFailure(exception)
         case Success(result)    => self.ref ! GetRecordsSuccess(result)
       }
 
-      private[this] def requestRecords(): Unit =
+      private def requestRecords(): Unit =
         amazonKinesisAsync
           .getRecords(
             GetRecordsRequest.builder().limit(limit).shardIterator(currentShardIterator).build())
           .asScala
           .onComplete(handleGetRecords)(parasitic)
 
-      private[this] def requestShardIterator(): Unit = {
+      private def requestShardIterator(): Unit = {
         val request = Function
           .chain[GetShardIteratorRequest.Builder](
             Seq(

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/ShardProcessor.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/impl/ShardProcessor.scala
@@ -48,8 +48,8 @@ private[kinesis] class ShardProcessor(
   // by the AWS KCL Scheduler after the Scheduler run() method has been invoked.
   private val lastRecordSemaphore = new Semaphore(1)
 
-  private var shardData: ShardProcessorData = _
-  private var checkpointer: RecordProcessorCheckpointer = _
+  private var shardData: ShardProcessorData = null
+  private var checkpointer: RecordProcessorCheckpointer = null
   private var shutdown: Option[ShutdownReason] = None
 
   override def initialize(initializationInput: InitializationInput): Unit =

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSchedulerSourceSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSchedulerSourceSpec.scala
@@ -270,8 +270,8 @@ class KinesisSchedulerSourceSpec
 
     private val semaphore = new Semaphore(0)
 
-    var recordProcessor: ShardRecordProcessor = _
-    var otherRecordProcessor: ShardRecordProcessor = _
+    var recordProcessor: ShardRecordProcessor = null
+    var otherRecordProcessor: ShardRecordProcessor = null
     private val schedulerBuilder = { (x: ShardRecordProcessorFactory) =>
       recordProcessor = x.shardRecordProcessor()
       otherRecordProcessor = x.shardRecordProcessor()
@@ -334,7 +334,7 @@ class KinesisSchedulerSourceSpec
     "checkpoint batch of records with same sequence number" in new KinesisSchedulerCheckpointContext {
       val checkpointer: KinesisClientRecord => Unit =
         org.mockito.Mockito.mock(classOf[KinesisClientRecord => Unit])
-      var latestRecord: KinesisClientRecord = _
+      var latestRecord: KinesisClientRecord = null
       val allRecordsPushed: Future[Unit] = Future {
         for (i <- 1 to 3) {
           val clientRecord = org.mockito.Mockito.mock(classOf[KinesisClientRecord])
@@ -370,8 +370,8 @@ class KinesisSchedulerSourceSpec
     "checkpoint batch of records of different shards" in new KinesisSchedulerCheckpointContext {
       val checkpointerShard1: KinesisClientRecord => Unit =
         org.mockito.Mockito.mock(classOf[KinesisClientRecord => Unit])
-      var latestRecordShard1: KinesisClientRecord = _
-      var latestRecordShard2: KinesisClientRecord = _
+      var latestRecordShard1: KinesisClientRecord = null
+      var latestRecordShard2: KinesisClientRecord = null
       val checkpointerShard2: KinesisClientRecord => Unit =
         org.mockito.Mockito.mock(classOf[KinesisClientRecord => Unit])
 

--- a/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbFlowStage.scala
+++ b/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbFlowStage.scala
@@ -55,8 +55,8 @@ private[orientdb] class OrientDbFlowStage[T, C](
 
   sealed abstract class OrientDbLogic extends GraphStageLogic(shape) with InHandler with OutHandler {
 
-    protected var client: ODatabaseSession = _
-    protected var oObjectClient: OObjectDatabaseTx = _
+    protected var client: ODatabaseSession = null
+    protected var oObjectClient: OObjectDatabaseTx = null
 
     override def preStart(): Unit = {
       client = settings.oDatabasePool.acquire()

--- a/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbSourceStage.scala
+++ b/orientdb/src/main/scala/org/apache/pekko/stream/connectors/orientdb/impl/OrientDbSourceStage.scala
@@ -126,8 +126,8 @@ private[orientdb] final class OrientDbSourceStage[T](className: String,
 
   private abstract class Logic extends GraphStageLogic(shape) with OutHandler {
 
-    protected var client: ODatabaseSession = _
-    protected var oObjectClient: OObjectDatabaseTx = _
+    protected var client: ODatabaseSession = null
+    protected var oObjectClient: OObjectDatabaseTx = null
     protected var skip = settings.skip
 
     override def preStart(): Unit = {

--- a/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
+++ b/orientdb/src/test/scala/docs/scaladsl/OrientDbSpec.scala
@@ -72,9 +72,9 @@ class OrientDbSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with
   case class Book(title: String)
   // #define-class
 
-  var orientDB: OrientDB = _
-  var oDatabase: ODatabasePool = _
-  var client: ODatabaseSession = _
+  var orientDB: OrientDB = null
+  var oDatabase: ODatabasePool = null
+  var client: ODatabaseSession = null
 
   override def beforeAll() = {
     orientDB = new OrientDB(url, username, password, OrientDBConfig.defaultConfig())

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaFlow.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaFlow.scala
@@ -41,7 +41,7 @@ import scala.util.{ Failure, Success, Try }
 
   val clientConfig = writerSettings.clientConfig
 
-  private var writer: EventStreamWriter[A] = _
+  private var writer: EventStreamWriter[A] = null
 
   private val semaphore = new Semaphore(writerSettings.maximumInflightMessages)
 

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaSource.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaSource.scala
@@ -47,7 +47,7 @@ import scala.util.{ Failure, Success, Try }
 
   private def out: Outlet[PravegaEvent[A]] = shape.out
 
-  private var reader: EventStreamReader[A] = _
+  private var reader: EventStreamReader[A] = null
 
   protected val clientConfig: ClientConfig = readerSettings.clientConfig
 

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableReadFlow.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableReadFlow.scala
@@ -42,8 +42,8 @@ import scala.util.control.NonFatal
   private def in: Inlet[K] = shape.in
   private def out: Outlet[Option[V]] = shape.out
 
-  private var keyValueTableFactory: KeyValueTableFactory = _
-  private var table: KeyValueTable = _
+  private var keyValueTableFactory: KeyValueTableFactory = null
+  private var table: KeyValueTable = null
 
   @volatile
   private var inFlight = 0

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableSource.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableSource.scala
@@ -51,8 +51,8 @@ import io.pravega.common.util.AsyncIterator
 
   private def out = shape.out
 
-  private var keyValueTableFactory: KeyValueTableFactory = _
-  private var table: KeyValueTable = _
+  private var keyValueTableFactory: KeyValueTableFactory = null
+  private var table: KeyValueTable = null
 
   private val queue = mutable.Queue.empty[TableEntry[V]]
 

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableWriteFlow.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableWriteFlow.scala
@@ -47,9 +47,9 @@ import scala.util.control.NonFatal
   private def in = shape.in
   private def out = shape.out
 
-  private var keyValueTableFactory: KeyValueTableFactory = _
+  private var keyValueTableFactory: KeyValueTableFactory = null
 
-  private var table: KeyValueTable = _
+  private var table: KeyValueTable = null
 
   private val onAir = new AtomicInteger
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -62,14 +62,27 @@ object Common extends AutoPlugin {
       "-feature",
       "-unchecked",
       "-deprecation",
-      "-Xlint",
-      "-Ywarn-dead-code",
-      "-Wconf:cat=unused-nowarn:s",
-      "-Wconf:msg=Prefer the Scala annotation over Java's `@Deprecated`:s",
       "-release:17"),
     scalacOptions ++= {
-      if (isScala3.value) Seq("-Yfuture-lazy-vals")
-      else Seq.empty
+      if (isScala3.value) Seq(
+        "-Yfuture-lazy-vals",
+        "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+        "-Wconf:msg=is deprecated for wildcard arguments of types:s",
+        "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
+        "-Wconf:msg=with as a type operator has been deprecated:s",
+        "-Wconf:msg=Unreachable case except for null:s",
+        "-Wconf:msg=is no longer supported for vararg splices:s",
+        "-Wconf:msg=is not declared infix:s",
+        "-Wconf:msg=auto insertion will be deprecated:s",
+        "-Wconf:msg=Ignoring \\[this\\] qualifier:s",
+        "-Wconf:msg=trait App in package scala is deprecated:s",
+        "-Wconf:msg=pattern binding uses refutable extractor:s",
+        "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+      else Seq(
+        "-Xlint",
+        "-Ywarn-dead-code",
+        "-Wconf:cat=unused-nowarn:s",
+        "-Wconf:msg=Prefer the Scala annotation over Java's `@Deprecated`:s")
     },
     Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
       "-doc-title",

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/HttpRequests.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/HttpRequests.scala
@@ -327,7 +327,7 @@ import scala.xml.NodeSeq
       .withDefaultHeaders(allHeaders)
   }
 
-  private[this] def s3Request(s3Location: S3Location, method: HttpMethod, uriFn: Uri => Uri = identity)(
+  private def s3Request(s3Location: S3Location, method: HttpMethod, uriFn: Uri => Uri = identity)(
       implicit conf: S3Settings): HttpRequest = {
     val loc = s3Location.validate(conf)
     val s3RequestUri = uriFn(requestUri(loc.bucket, Some(loc.key)))
@@ -340,7 +340,7 @@ import scala.xml.NodeSeq
   }
 
   @throws(classOf[IllegalUriException])
-  private[this] def requestAuthority(bucket: String, region: Region)(implicit conf: S3Settings): Authority = {
+  private def requestAuthority(bucket: String, region: Region)(implicit conf: S3Settings): Authority = {
     (conf.endpointUrl, conf.accessStyle) match {
       case (None, PathAccessStyle) =>
         Authority(Uri.Host(s"s3.$region.amazonaws.com"))
@@ -356,7 +356,7 @@ import scala.xml.NodeSeq
     }
   }
 
-  private[this] def requestUri(bucket: String, key: Option[String])(implicit conf: S3Settings): Uri = {
+  private def requestUri(bucket: String, key: Option[String])(implicit conf: S3Settings): Uri = {
     val basePath = conf.accessStyle match {
       case PathAccessStyle =>
         Uri.Path / bucket

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/Signer.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/auth/Signer.scala
@@ -46,16 +46,16 @@ import pekko.stream.scaladsl.Source
         .mapMaterializedValue(_ => NotUsed)
     }
 
-  private[this] def sessionHeader(key: SigningKey): Option[HttpHeader] =
+  private def sessionHeader(key: SigningKey): Option[HttpHeader] =
     key.sessionToken.map(RawHeader("X-Amz-Security-Token", _))
 
-  private[this] def authorizationHeader(algorithm: String,
+  private def authorizationHeader(algorithm: String,
       key: SigningKey,
       requestDate: ZonedDateTime,
       canonicalRequest: CanonicalRequest): HttpHeader =
     RawHeader("Authorization", authorizationString(algorithm, key, requestDate, canonicalRequest))
 
-  private[this] def authorizationString(algorithm: String,
+  private def authorizationString(algorithm: String,
       key: SigningKey,
       requestDate: ZonedDateTime,
       canonicalRequest: CanonicalRequest): String = {

--- a/sns/src/test/scala/org/apache/pekko/stream/connectors/sns/IntegrationTestContext.scala
+++ b/sns/src/test/scala/org/apache/pekko/stream/connectors/sns/IntegrationTestContext.scala
@@ -35,8 +35,8 @@ trait IntegrationTestContext extends BeforeAndAfterAll with ScalaFutures {
 
   def snsEndpoint: String = s"http://localhost:4100"
 
-  implicit var snsClient: SnsAsyncClient = _
-  var topicArn: String = _
+  implicit var snsClient: SnsAsyncClient = null
+  var topicArn: String = null
 
   private val topicNumber = new AtomicInteger()
 

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -47,9 +47,9 @@ class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Sca
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(5.seconds)
 
-  private var cluster: MiniSolrCloudCluster = _
+  private var cluster: MiniSolrCloudCluster = null
 
-  private var zkTestServer: ZkTestServer = _
+  private var zkTestServer: ZkTestServer = null
   implicit val system: ActorSystem = ActorSystem()
   implicit val commitExecutionContext: ExecutionContext = ExecutionContext.global
 

--- a/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/impl/BalancingMapAsync.scala
+++ b/sqs/src/main/scala/org/apache/pekko/stream/connectors/sqs/impl/BalancingMapAsync.scala
@@ -60,7 +60,7 @@ import scala.util.{ Failure, Success }
     new GraphStageLogic(shape) with InHandler with OutHandler {
 
       lazy val decider = inheritedAttributes.mandatoryAttribute[SupervisionStrategy].decider
-      var buffer: Buffer[Holder[Out]] = _
+      var buffer: Buffer[Holder[Out]] = null
       var parallelism = maxParallelism
 
       private val futureCB = getAsyncCallback[Holder[Out]](holder =>

--- a/udp/src/main/scala/org/apache/pekko/stream/connectors/udp/impl/UdpBind.scala
+++ b/udp/src/main/scala/org/apache/pekko/stream/connectors/udp/impl/UdpBind.scala
@@ -40,7 +40,7 @@ import scala.concurrent.{ Future, Promise }
   private def in = shape.in
   private def out = shape.out
 
-  private var listener: ActorRef = _
+  private var listener: ActorRef = null
 
   override def preStart(): Unit = {
     implicit val sender: ActorRef = getStageActor(processIncoming).ref

--- a/udp/src/main/scala/org/apache/pekko/stream/connectors/udp/impl/UdpSend.scala
+++ b/udp/src/main/scala/org/apache/pekko/stream/connectors/udp/impl/UdpSend.scala
@@ -38,7 +38,7 @@ import scala.collection.immutable.Iterable
   private def in = shape.in
   private def out = shape.out
 
-  private var simpleSender: ActorRef = _
+  private var simpleSender: ActorRef = null
 
   override def preStart(): Unit = {
     getStageActor(processIncoming)

--- a/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/impl/StreamingXmlParser.scala
+++ b/xml/src/main/scala/org/apache/pekko/stream/connectors/xml/impl/StreamingXmlParser.scala
@@ -66,7 +66,7 @@ private[xml] object StreamingXmlParser {
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) with InHandler with OutHandler {
       private var started: Boolean = false
-      private var context: Ctx = _
+      private var context: Ctx = null.asInstanceOf[Ctx]
 
       import javax.xml.stream.XMLStreamConstants
 


### PR DESCRIPTION
## Summary
- Replace `= _` with explicit defaults in var declarations (67 locations, deprecated in Scala 3.8)
- Replace `private[this]` with `private` (17 files, deprecated in Scala 3.8)
- Change context bounds to explicit implicit parameters in Google connector methods called with explicit args from Java API
- Add `-Wconf` suppressions for cross-version incompatible warnings in Scala 3 compiler options

## Details
This PR prepares pekko-connectors for Scala 3.8/3.9 adoption while maintaining compatibility with current Scala 3.3.x and 2.13.x production builds.

### Key changes

**Bulk syntax fixes (~80 locations across 50+ files):**
- `var x: T = _` → `var x: T = null` (or `= 0` for primitives, `= null.asInstanceOf[T]` for generic types)
- `private[this]` → `private`

**Context bounds fix (4 methods):**
Changed context bounds `[T: FromResponseUnmarshaller]` to explicit implicit parameters `(implicit um: FromResponseUnmarshaller[T])` in methods where Java API wrappers pass the implicit argument explicitly:
- `GoogleHttp.cachedHostConnectionPool`
- `GoogleHttp.cachedHostConnectionPoolWithContext`
- `scaladsl.Google.singleRequest`
- `scaladsl.Google.resumableUpload`

**Compiler options (`project/Common.scala`):**
- Moved Scala 2-only options (`-Xlint`, `-Ywarn-dead-code`, `cat=unused-nowarn`) to conditional block
- Added `-Wconf` suppressions for Scala 3 cross-version warnings

Verified: clean compilation on Scala 3.8.4 with zero warnings.

## Test plan
- [x] `sbt "++3.8.4; compile"` — zero warnings
- [ ] CI passes on current Scala 3.3.x and 2.13.x
- [ ] No binary compatibility issues