### PR TITLE
docs: remove stale JDK 11 deprecation comments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -302,7 +302,7 @@ lazy val influxdb = pekkoConnectorProject(
   "influxdb",
   Dependencies.InfluxDB,
   Compile / scalacOptions ++= Seq(
-    // JDK 11: method isAccessible in class AccessibleObject is deprecated
+    // project baseline is Java 17: method isAccessible in class AccessibleObject is deprecated
     "-Wconf:cat=deprecation:s"))
 
 lazy val ironmq = pekkoConnectorProject(

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/PekkoConnectorsResultMapperHelper.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/impl/PekkoConnectorsResultMapperHelper.scala
@@ -72,7 +72,7 @@ private[impl] class PekkoConnectorsResultMapperHelper {
         val columnName: String = column.name()
         val fieldType: Class[?] = field.getType()
 
-        val isAccessible = field.isAccessible() // deprecated in JDK 11+
+        val isAccessible = field.isAccessible()
         if (!isAccessible) {
           field.setAccessible(true);
         }
@@ -181,7 +181,7 @@ private[impl] class PekkoConnectorsResultMapperHelper {
     if (value == null) return
     val fieldType = field.getType
     try {
-      val isAccessible = field.isAccessible() // deprecated in JDK 11+
+      val isAccessible = field.isAccessible()
       if (!isAccessible) field.setAccessible(true)
       if (fieldValueModified(fieldType, field, obj, value, precision) || fieldValueForPrimitivesModified(
           fieldType,

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -118,7 +118,7 @@ object Common extends AutoPlugin {
       "-Xlint:overloads",
       "-Xlint:overrides",
       "-Xlint:rawtypes",
-      // JDK 11 "-Xlint:removal",
+      // project baseline is Java 17: "-Xlint:removal",
       "-Xlint:static",
       "-Xlint:try",
       "-Xlint:unchecked",


### PR DESCRIPTION
### Motivation

Java 17 is the project baseline. Inline `// deprecated in JDK 11+` notes and `// JDK 11 ...` markers annotate facts that are universally known for any Java 17+ reader and add noise. Aligned with the comment style introduced by apache/pekko#3075 ("project baseline is Java 17").

### Modification

- Drop the trailing `// deprecated in JDK 11+` comment from both `field.isAccessible()` call sites in `influxdb/src/main/scala/.../PekkoConnectorsResultMapperHelper.scala`. The calls themselves are retained — only the redundant deprecation note is removed.
- Update stale `// JDK 11 ...` notes in `project/Common.scala` (the commented-out `-Xlint:removal` scalac option) and `build.sbt` (the influxdb `-Wconf:cat=deprecation:s` silencing) to `// project baseline is Java 17: ...`.

### Result

No behavior change. Comments now reflect the actual Java baseline.

### Tests

- Not run - docs only (comment-only diff; no Scala/sbt behavior change).
- `git diff --check` — clean.

### References

- apache/pekko#3075 — same `// project baseline is Java 17: ...` comment style.