### PR TITLE
fix: resolve compiler warnings across connector modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -398,6 +398,7 @@ lazy val docs = project
     publish / skip := true,
     pekkoParadoxGithub := Some("https://github.com/apache/pekko-connectors"),
     previewPath := (Paradox / siteSubdirName).value,
+    Global / excludeLintKeys += previewPath,
     Preprocess / siteSubdirName := s"api/pekko-connectors/${projectInfoVersion.value}",
     Preprocess / sourceDirectory := (LocalRootProject / ScalaUnidoc / unidoc / target).value,
     Preprocess / preprocessRules := Seq(

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
@@ -95,6 +95,7 @@ public final class DirectoryChangesSource<T> extends GraphStage<SourceShape<T>> 
     return new TimerGraphStageLogic(shape) {
       private final Queue<T> buffer = new ArrayDeque<>();
       private final WatchService service = directoryPath.getFileSystem().newWatchService();
+      @SuppressWarnings({"deprecation", "removal"})
       private final WatchKey watchKey =
           directoryPath.register(
               service,

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
@@ -95,6 +95,7 @@ public final class DirectoryChangesSource<T> extends GraphStage<SourceShape<T>> 
     return new TimerGraphStageLogic(shape) {
       private final Queue<T> buffer = new ArrayDeque<>();
       private final WatchService service = directoryPath.getFileSystem().newWatchService();
+
       @SuppressWarnings({"deprecation", "removal"})
       private final WatchKey watchKey =
           directoryPath.register(

--- a/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/impl/DeprecatedCredentials.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/impl/DeprecatedCredentials.scala
@@ -17,6 +17,7 @@ import org.apache.pekko.annotation.InternalApi
 import io.grpc.{ CallCredentials, Metadata }
 
 import java.util.concurrent.Executor
+import scala.annotation.nowarn
 
 /**
  * Marker class indicating that credentials should be resolved via GoogleSettings.
@@ -29,6 +30,7 @@ private[grpc] final case class DeprecatedCredentials(underlying: CallCredentials
       applier: CallCredentials.MetadataApplier): Unit =
     underlying.applyRequestMetadata(requestInfo, appExecutor, applier)
 
+  @nowarn("msg=is deprecated")
   override def thisUsesUnstableApi(): Unit = underlying.thisUsesUnstableApi()
 }
 

--- a/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStream.scala
+++ b/google-cloud-storage/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStream.scala
@@ -160,10 +160,10 @@ import scala.concurrent.ExecutionContext.parasitic
         implicit val um: Unmarshaller[HttpResponse, StorageObject] = Unmarshaller.withMaterializer {
           implicit ec => implicit mat =>
             {
-              case HttpResponse(status, _, entity, _) if status.isSuccess() =>
-                Unmarshal(entity).to[StorageObject]
-              case HttpResponse(status, _, entity, _) =>
-                Unmarshal(entity).to[String].flatMap { errorString =>
+              case HttpResponse(status, _, responseEntity, _) if status.isSuccess() =>
+                Unmarshal(responseEntity).to[StorageObject]
+              case HttpResponse(status, _, responseEntity, _) =>
+                Unmarshal(responseEntity).to[String].flatMap { errorString =>
                   Future.failed(new RuntimeException(s"Uploading part failed with status $status: $errorString"))
                 }
             }: PartialFunction[HttpResponse, Future[StorageObject]]

--- a/hbase/src/main/scala/org/apache/pekko/stream/connectors/hbase/impl/HBaseCapabilities.scala
+++ b/hbase/src/main/scala/org/apache/pekko/stream/connectors/hbase/impl/HBaseCapabilities.scala
@@ -25,8 +25,6 @@ import scala.concurrent.{ Await, Future }
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{ Failure, Success, Try }
 
-import scala.language.postfixOps
-
 private[impl] trait HBaseCapabilities { this: StageLogging =>
 
   def twr[A <: Closeable, B](resource: A)(doWork: A => B): Try[B] =

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsProducerStage.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/impl/JmsProducerStage.scala
@@ -25,6 +25,7 @@ import pekko.stream.stage._
 import pekko.util.OptionVal
 import pekko.{ Done, NotUsed }
 
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NoStackTrace
@@ -75,6 +76,7 @@ private[jakartams] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], P
     (logic, logic.status)
   }
 
+  @nowarn("msg=inferred structural type")
   private def producerLogic(inheritedAttributes: Attributes) =
     new TimerGraphStageLogic(shape) with JmsProducerConnector with GraphStageCompanion with StageLogging {
 

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsProducerStage.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/impl/JmsProducerStage.scala
@@ -25,6 +25,7 @@ import pekko.stream.stage._
 import pekko.util.OptionVal
 
 import javax.jms
+import scala.annotation.nowarn
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import scala.util.control.NoStackTrace
@@ -74,6 +75,7 @@ private[jms] final class JmsProducerStage[E <: JmsEnvelope[PassThrough], PassThr
     (logic, logic.status)
   }
 
+  @nowarn("msg=inferred structural type")
   private def producerLogic(inheritedAttributes: Attributes) =
     new TimerGraphStageLogic(shape) with JmsProducerConnector with GraphStageCompanion with StageLogging {
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -43,7 +43,7 @@ object Common extends AutoPlugin {
     fatalWarnings := true,
     mimaReportSignatureProblems := true,
     // Ignore unused keys which affect documentation
-    excludeLintKeys ++= Set(scmInfo, projectInfoVersion, autoAPIMappings))
+    excludeLintKeys ++= Set(scmInfo, projectInfoVersion, autoAPIMappings, mimaReportSignatureProblems))
 
   val packagesToSkip = "org.apache.pekko.pattern:" + // for some reason Scaladoc creates this
     "org.mongodb.scala:" + // this one is a mystery as well

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/SplitAfterSizeWithContext.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/SplitAfterSizeWithContext.scala
@@ -20,6 +20,8 @@ import pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import pekko.stream.{ Attributes, FlowShape, Inlet, Outlet }
 import pekko.util.ByteString
 
+import scala.annotation.nowarn
+
 /**
  * Internal Api
  *
@@ -42,6 +44,7 @@ import pekko.util.ByteString
 
   private case object NewStream
 
+  @nowarn("msg=inferred structural type")
   private def insertMarkers[C](minChunkSize: Long) =
     new GraphStage[FlowShape[(ByteString, C), Any]] {
       val in = Inlet[(ByteString, C)]("SplitAfterSize.in")

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
@@ -334,14 +334,6 @@ object S3 {
       contentLength: Long): Source[ObjectMetadata, NotUsed] =
     putObject(bucket, key, data, contentLength, ContentTypes.APPLICATION_OCTET_STREAM)
 
-  private def toJava[M](
-      download: pekko.stream.scaladsl.Source[Option[
-          (pekko.stream.scaladsl.Source[ByteString, M], ObjectMetadata)], NotUsed])
-      : Source[Optional[JPair[Source[ByteString, M], ObjectMetadata]], NotUsed] =
-    download.map {
-      _.map { case (stream, meta) => JPair(stream.asJava, meta) }.toJava
-    }.asJava
-
   /**
    * Gets a S3 Object
    *

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/settings.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/settings.scala
@@ -620,7 +620,7 @@ object S3Settings {
       if (c.hasPath(credProviderPath)) {
         c.getString(credProviderPath) match {
           case "default" =>
-            DefaultCredentialsProvider.create()
+            DefaultCredentialsProvider.builder().build()
 
           case "static" =>
             val aki = c.getString("aws.credentials.access-key-id")
@@ -637,10 +637,10 @@ object S3Settings {
             AnonymousCredentialsProvider.create()
 
           case _ =>
-            DefaultCredentialsProvider.create()
+            DefaultCredentialsProvider.builder().build()
         }
       } else {
-        DefaultCredentialsProvider.create()
+        DefaultCredentialsProvider.builder().build()
       }
     }
 


### PR DESCRIPTION
### Motivation
Multiple Scala and Java compiler warnings accumulated across connector modules: unused imports, variable shadowing, unused private methods, deprecated API usage, structural type inference, and sbt lint keys.

### Modification
- Remove unused `scala.language.postfixOps` import in hbase
- Rename shadowed `entity` to `responseEntity` in google-cloud-storage Unmarshaller
- Remove unused private `toJava` method in s3 javadsl
- Replace deprecated `DefaultCredentialsProvider.create()` with `builder().build()` in s3
- Suppress deprecated `SensitivityWatchEventModifier` (needed for macOS compatibility) in file
- Suppress deprecated `thisUsesUnstableApi()` gRPC override in google-cloud-pub-sub-grpc
- Suppress structural type inference warnings in jms/jakartams/s3 with `@nowarn`
- Add `mimaReportSignatureProblems` to sbt `excludeLintKeys`

### Result
Cleaner compilation output with all actionable code-level warnings resolved.

### Tests
- `sbt "clean; compile"` - all code warnings resolved

### References
None - compiler warning cleanup