### PR TITLE
fix: make -Yfuture-lazy-vals conditional for Scala 3.9+

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -76,7 +76,9 @@ object Common extends AutoPlugin {
         "-Wconf:msg=Ignoring \\[this\\] qualifier:s",
         "-Wconf:msg=trait App in package scala is deprecated:s",
         "-Wconf:msg=pattern binding uses refutable extractor:s") ++
-        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
+      (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
+         Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+       else Seq.empty)
       else Seq(
         "-Xlint",
         "-Ywarn-dead-code",

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -65,7 +65,6 @@ object Common extends AutoPlugin {
       "-release:17"),
     scalacOptions ++= {
       if (isScala3.value) Seq(
-        "-Yfuture-lazy-vals",
         "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
         "-Wconf:msg=is deprecated for wildcard arguments of types:s",
         "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
@@ -76,8 +75,8 @@ object Common extends AutoPlugin {
         "-Wconf:msg=auto insertion will be deprecated:s",
         "-Wconf:msg=Ignoring \\[this\\] qualifier:s",
         "-Wconf:msg=trait App in package scala is deprecated:s",
-        "-Wconf:msg=pattern binding uses refutable extractor:s",
-        "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+        "-Wconf:msg=pattern binding uses refutable extractor:s") ++
+        (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
       else Seq(
         "-Xlint",
         "-Ywarn-dead-code",


### PR DESCRIPTION
### Motivation
Scala 3.9 removed the `-Yfuture-lazy-vals` compiler option as the future lazy vals behavior is now the default. Passing this flag on Scala 3.9+ causes a compilation error.

### Modification
Made `-Yfuture-lazy-vals` conditional on Scala minor version < 9 using `CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)`.

### Result
Project compiles on both Scala 3.3.x (which needs the flag) and Scala 3.9+ (which has the behavior by default).

### Tests
- `sbt "++3.9.0-RC1!; compile"` — no -Yfuture-lazy-vals error
- `sbt "++3.3.7!; compile"` — flag still applied

### References
- Part of the Scala 3.9 compatibility effort across all Pekko projects