### PR TITLE
pin sbt 1.x dependency

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -9,6 +9,8 @@ updates.pin  = [
   { groupId = "org.apache.activemq", version = "5." }
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
+  # we have too many build plugins that need sbt 1.x
+  { groupId = "org.scala-sbt", artifactId = "sbt"  version = "1." }
 ]
 
 updates.ignore = [


### PR DESCRIPTION
We are not yet ready for sbt 2.0.0. Many sbt plugins will need to be updated to support sbt 2. Let's pin sbt, for now.