### PR TITLE
fix: correct various typos across pekko-connectors modules

### DIFF
--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AbstractAmqpAsyncFlowStageLogic.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/impl/AbstractAmqpAsyncFlowStageLogic.scala
@@ -72,7 +72,7 @@ import scala.concurrent.Promise
     val callback = getAsyncCallback[(DeliveryTag, Boolean)] {
       case (tag: DeliveryTag, multiple: Boolean) => confirmCallback(tag, multiple)
     }
-    new ConfirmCallback { // cant use function literal because it doesn't work with 2.11
+    new ConfirmCallback { // can't use function literal because it doesn't work with 2.11
       override def handle(tag: DeliveryTag, multiple: Boolean): Unit = callback.invoke((tag, multiple))
     }
   }

--- a/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
+++ b/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
@@ -127,7 +127,8 @@ public class JavaDslTest {
     source.runWith(sink, system).toCompletableFuture().get(10, TimeUnit.SECONDS);
 
     Assert.assertNull(
-        queue.retrieveMessage()); // There should be no message because of initial visibility timeout
+        queue
+            .retrieveMessage()); // There should be no message because of initial visibility timeout
   }
 
   @Test

--- a/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
+++ b/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
@@ -127,7 +127,7 @@ public class JavaDslTest {
     source.runWith(sink, system).toCompletableFuture().get(10, TimeUnit.SECONDS);
 
     Assert.assertNull(
-        queue.retrieveMessage()); // There should be no message because of inital visibility timeout
+        queue.retrieveMessage()); // There should be no message because of initial visibility timeout
   }
 
   @Test

--- a/contributor-advice.md
+++ b/contributor-advice.md
@@ -106,7 +106,7 @@ All Apache Pekko APIs aim to evolve in a binary compatible way within minor vers
 
 1. To generate a case class replacement, consider using [Kaze Class](https://github.com/ktoso/kaze-class)
 
-See [Binary Compatibilty Rules](https://pekko.apache.org/docs/pekko/current/common/binary-compatibility-rules.html) in the Apache Pekko documentation.
+See [Binary Compatibility Rules](https://pekko.apache.org/docs/pekko/current/common/binary-compatibility-rules.html) in the Apache Pekko documentation.
 
 See [Binary Compatibility for library authors](https://docs.scala-lang.org/overviews/core/binary-compatibility-for-library-authors.html)
 

--- a/couchbase/src/main/resources/reference.conf
+++ b/couchbase/src/main/resources/reference.conf
@@ -4,7 +4,7 @@ pekko.connectors.couchbase {
   session {
     # The couchbase nodes to connect to as hostnames of ip-addresses
     nodes = ["localhost"]
-    # credentials are required fields with no defauls:
+    # credentials are required fields with no defaults:
     # username = "admin"
     # password = "ArG$n2xuYf*K2YXoaipnWrF"
   }

--- a/csv/src/test/scala/org/apache/pekko/stream/connectors/csv/CsvParserSpec.scala
+++ b/csv/src/test/scala/org/apache/pekko/stream/connectors/csv/CsvParserSpec.scala
@@ -230,7 +230,7 @@ class CsvParserSpec extends AnyWordSpec with Matchers with OptionValues with Log
       splitInput("A,B\\", "\\", List("A", "B\\"))
     }
 
-    "handle escaping withing quotes, split over two inputs" in {
+    "handle escaping within quotes, split over two inputs" in {
       splitInput("\"\\", "\\A\",B", List("\\A", "B"))
       splitInput("\"A\\", "\\A\",B", List("A\\A", "B"))
       splitInput("A,\"\\", "\\B\"", List("A", "\\B"))

--- a/docs/src/main/paradox/couchbase.md
+++ b/docs/src/main/paradox/couchbase.md
@@ -14,7 +14,7 @@ Apache Pekko Connectors Couchbase allows you to read and write to Couchbase. You
 
 The Couchbase connector supports all document formats which are supported by the SDK. All those formats use the @java[`Document<T>`]@scala[`Document[T]`] interface and this is the level of abstraction that this connector is using.
 
-In v1.1.0, there is also a Couchbase3 connector that provides the equivalent support using the Couchbase Client v3. This conector continues to use the Couchbase Client v2.
+In v1.1.0, there is also a Couchbase3 connector that provides the equivalent support using the Couchbase Client v3. This connector continues to use the Couchbase Client v2.
 
 @@project-info{ projectId="couchbase" }
 

--- a/docs/src/main/paradox/jms/browse.md
+++ b/docs/src/main/paradox/jms/browse.md
@@ -46,7 +46,7 @@ Java
 : @@snip [snip](/jms/src/test/java/docs/javadsl/JmsSettingsTest.java) { #consumer-settings }
 
 
-The Apache Pekko Connectors JMS browse soruce is configured via default settings in the [HOCON](https://github.com/lightbend/config#using-hocon-the-json-superset) config file section `pekko.connectors.jms.browse` in your `application.conf`, and settings may be tweaked in the code using the `withXyz` methods. On the second tab the section from `reference.conf` shows the structure to use for configuring multiple set-ups.
+The Apache Pekko Connectors JMS browse source is configured via default settings in the [HOCON](https://github.com/lightbend/config#using-hocon-the-json-superset) config file section `pekko.connectors.jms.browse` in your `application.conf`, and settings may be tweaked in the code using the `withXyz` methods. On the second tab the section from `reference.conf` shows the structure to use for configuring multiple set-ups.
 
 Table
 : Setting               | Description                                                          | Default Value       | 

--- a/docs/src/main/paradox/jms/producer.md
+++ b/docs/src/main/paradox/jms/producer.md
@@ -163,7 +163,7 @@ Java
 
 There are two implementations: One envelope type containing a messages to send to Jms, and one
 envelope type containing only values to pass through. This allows messages to flow without producing any new messages 
-to Jms. This is primarily useful when committing offsets back to Kakfa, or when acknowledging Jms messages after sending
+to Jms. This is primarily useful when committing offsets back to Kafka, or when acknowledging Jms messages after sending
 the outcome of processing them back to Jms.
 
 Scala
@@ -228,7 +228,7 @@ With the default settings, we'll see retries after 100ms, 400ms, 900ms pauses, u
 
 Consumers, producers and browsers try to reconnect with the same retry characteristics if a connection fails mid-stream.
 
-All JMS settings support setting the `connectionRetrySettings` field using `.withConnectionRetrySettings(retrySettings)` on the given settings. The followings show how to create `ConnectionRetrySettings`:
+All JMS settings support setting the `connectionRetrySettings` field using `.withConnectionRetrySettings(retrySettings)` on the given settings. The following show how to create `ConnectionRetrySettings`:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala) { #retry-settings-case-class }
@@ -258,7 +258,7 @@ The retry time is calculated by:
 
 With the default settings, we'll see retries after 20ms, 57ms, 104ms pauses, until the pauses reach 500 ms and will stay with 500 ms intervals for any subsequent retries.
 
-JMS producer settings support configuring retries by using `.withSendRetrySettings(retrySettings)`. The followings show how to create `SendRetrySettings`:
+JMS producer settings support configuring retries by using `.withSendRetrySettings(retrySettings)`. The following show how to create `SendRetrySettings`:
 
 Scala
 : @@snip [snip](/jms/src/test/scala/docs/scaladsl/JmsSettingsSpec.scala) { #send-retry-settings }

--- a/docs/src/main/paradox/release-notes/releases-1.2.md
+++ b/docs/src/main/paradox/release-notes/releases-1.2.md
@@ -17,7 +17,7 @@ With OrientDB Connector, it appears that the latest OrientDB client only works w
 
 ### Fixes
 
-* Properly propogate GoogleSettings in addStandardQuery ([PR1026](https://github.com/apache/pekko-connectors/pull/1026)).
+* Properly propagate GoogleSettings in addStandardQuery ([PR1026](https://github.com/apache/pekko-connectors/pull/1026)).
 * Fix ClassCastException in Google Cloud StorageObject ([PR1031](https://github.com/apache/pekko-connectors/pull/1031)).
 * Fix metadata not working with GCStorage ([PR1045](https://github.com/apache/pekko-connectors/pull/1045)).
 

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/OpensearchParams.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/OpensearchParams.scala
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.connectors.elasticsearch
 
 /**
  * Opensearch 1.x is fully compatible with Elasticsearch 7.x release line, so we could
- * reuse the Elasticsearch V7 compatibile implementation.
+ * reuse the Elasticsearch V7 compatible implementation.
  */
 object OpensearchParams {
   def V1(indexName: String): ElasticsearchParams = ElasticsearchParams.V7(indexName)

--- a/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
+++ b/google-cloud-storage/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/storage/impl/GCStorageStreamIntegrationSpec.scala
@@ -212,7 +212,7 @@ trait GCStorageStreamIntegrationSpec
       bs.futureValue shouldBe content
     }
 
-    "get a None when downloading a non extisting file" in {
+    "get a None when downloading a non existing file" in {
       val fileName = testFileName("non-existing-file")
       val download = GCStorageStream
         .download(bucket, fileName)

--- a/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSourceSpec.scala
+++ b/kinesis/src/test/scala/org/apache/pekko/stream/connectors/kinesis/KinesisSourceSpec.scala
@@ -64,7 +64,7 @@ class KinesisSourceSpec extends AnyWordSpec with Matchers with KinesisMock with 
       }
     }
 
-    "poll for records with mutliple requests" in assertAllStagesStopped {
+    "poll for records with multiple requests" in assertAllStagesStopped {
       new KinesisSpecContext with WithGetShardIteratorSuccess with WithGetRecordsSuccess {
         override def shards: util.List[Shard] = util.Arrays.asList(Shard.builder().shardId("id").build())
 

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/model.scala
@@ -1218,7 +1218,7 @@ object DecodeErrorOrEvent {
    * JAVA API
    *
    * Return a Class object representing the carry's type. Java's
-   * `.class` method does not do this, and there are many occassions
+   * `.class` method does not do this, and there are many occasions
    * where the generic type needs to be retained.
    * @tparam A The type of the carry
    * @return The `DecodeErrorOrEvent` class including the carry type

--- a/pravega/src/main/resources/reference.conf
+++ b/pravega/src/main/resources/reference.conf
@@ -81,7 +81,7 @@ pekko.connectors.pravega {
   table {
     client-config = ${pekko.connectors.pravega.defaults.client-config}
     maximum-inflight-messages = 10
-    # Max entries retrived by iterator.
+    # Max entries retrieved by iterator.
     max-entries-at-once = 100 
   }
 

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
@@ -141,7 +141,7 @@ import scala.util.{ Failure, Success, Try }
   /**
    * There is an exception for the ListPartsApi when you reach the last page of pagination, typically the
    * continuationToken (in this case `nextPartNumberMarker`) would be `None`. However specifically for ListPartResult
-   * on the last page the `nextPartNumberMarker` is 0. Ontop of this the `parts` will be empty so we use these
+   * on the last page the `nextPartNumberMarker` is 0. On top of this the `parts` will be empty so we use these
    * conditions to check if we are on the last page.
    */
   def continuationToken: Option[Int] =

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/MemoryBufferSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/MemoryBufferSpec.scala
@@ -40,7 +40,7 @@ class MemoryBufferSpec(_system: ActorSystem)
 
   override protected def afterAll(): Unit = TestKit.shutdownActorSystem(system)
 
-  "MemoryBuffer" should "emit a chunk on its output containg the concatenation of all input values" in {
+  "MemoryBuffer" should "emit a chunk on its output containing the concatenation of all input values" in {
     val result = Source(Vector(ByteString(1, 2, 3, 4, 5), ByteString(6, 7, 8, 9, 10, 11, 12), ByteString(13, 14)))
       .via(new MemoryBuffer(200))
       .runWith(Sink.seq)

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
@@ -555,7 +555,7 @@ trait S3IntegrationSpec
 
       val results =
         for {
-          // Clean the bucket just incase there is residual data in there
+          // Clean the bucket just in case there is residual data in there
           _ <- S3
             .deleteBucketContents(bucketWithVersioning, deleteAllVersions = true)
             .withAttributes(attributes)
@@ -703,7 +703,7 @@ trait S3IntegrationSpec
    * Creates a `List` of `ByteString` where the size of each ByteString is guaranteed to be at least `S3.MinChunkSize`
    * in size.
    *
-   * This is useful for tests that deal with multipart uploads, since S3 persists a part everytime it receives
+   * This is useful for tests that deal with multipart uploads, since S3 persists a part every time it receives
    * `S3.MinChunkSize` bytes
    * @param numberOfChunks The number of chunks to create
    * @return A List of `ByteString` where each element is at least `S3.MinChunkSize` in size
@@ -934,7 +934,7 @@ trait S3IntegrationSpec
    * Creates a `List` of `List[(ByteString, BigInt)]` where the accumulated size of each ByteString in the list is
    * guaranteed to be at least `S3.MinChunkSize` in size.
    *
-   * This is useful for tests that deal with multipart uploads, since S3 persists a part everytime it receives
+   * This is useful for tests that deal with multipart uploads, since S3 persists a part every time it receives
    * `S3.MinChunkSize` bytes. Unlike `createStringCollectionWithMinChunkSizeRec` this version also adds an index
    * to each individual `ByteString` which is helpful when dealing with testing for context
    * @param numberOfChunks The number of chunks to create

--- a/sns/src/test/travis/goaws.yaml
+++ b/sns/src/test/travis/goaws.yaml
@@ -4,7 +4,7 @@ Local:                              # Environment name that can be passed on the
 # you can now use either 1 port for both sns and sqs or alternatively you can comment out Port and use SqsPort + SnsPort for compatibilyt with
 # yopa and (fage-sns + face-sqs).  If both ways are in the config file on the one "Port" will be used by GoAws
   Port: 4100                        # port to listen on.
-# SqsPort: 9324                     # alterante Sqs Port
+# SqsPort: 9324                     # alternate Sqs Port
 # SnsPort: 9292                     # alternate Sns Port
   Region: local-01
   LogMessages: true                 # Log messages (true/false)

--- a/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/MessageAttributeNameSpec.scala
+++ b/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/MessageAttributeNameSpec.scala
@@ -39,7 +39,7 @@ class MessageAttributeNameSpec extends AnyFlatSpec with Matchers with LogCapturi
       MessageAttributeName(
         "A.really.really.long.attribute.name.that.is.longer.than.what.is.allowed.256.characters.are.allowed." +
         "however.they.cannot.contain.anything.other.than.alphanumerics.hyphens.underscores.and.periods.though" +
-        "you.can't.have.more.than.one.consecutive.period.they.are.also.case.sensitive")
+        "you.cannot.have.more.than.one.consecutive.period.they.are.also.case.sensitive")
     }
   }
   it should "reject names with multiple sequential periods" in {

--- a/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/MessageAttributeNameSpec.scala
+++ b/sqs/src/test/scala/org/apache/pekko/stream/connectors/sqs/scaladsl/MessageAttributeNameSpec.scala
@@ -37,9 +37,9 @@ class MessageAttributeNameSpec extends AnyFlatSpec with Matchers with LogCapturi
   it should "reject names which are longer than 256 characters" in {
     a[IllegalArgumentException] should be thrownBy {
       MessageAttributeName(
-        "A.really.realy.long.attribute.name.that.is.longer.than.what.is.allowed.256.characters.are.allowed." +
-        "however.they.cannot.contain.anything.other.than.alphanumerics.hypens.underscores.and.periods.though" +
-        "you.cant.have.more.than.one.consecutive.period.they.are.also.case.sensitive")
+        "A.really.really.long.attribute.name.that.is.longer.than.what.is.allowed.256.characters.are.allowed." +
+        "however.they.cannot.contain.anything.other.than.alphanumerics.hyphens.underscores.and.periods.though" +
+        "you.can't.have.more.than.one.consecutive.period.they.are.also.case.sensitive")
     }
   }
   it should "reject names with multiple sequential periods" in {


### PR DESCRIPTION
### Motivation
Several typos were found in comments, strings, docs, config files, and source code across pekko-connectors modules.

### Modification
Fixed 23 typos across multiple modules including docs, configs, test files, and source code. Key fixes: `Compatibilty`→`Compatibility`, `Kakfa`→`Kafka`, `propogate`→`propagate`, `occassions`→`occasions`, `compatibile`→`compatible`, and more.

### Result
Cleaner codebase with corrected spelling.

### Tests
Not run - typo fixes only (comments, strings, docs, config values)

### References
None - typo cleanup