### PR TITLE
refactor: replace .collect(Collectors.toList()) with .toList()

### DIFF
--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -44,7 +44,6 @@ import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -115,7 +114,7 @@ public class AmqpDocsTest {
         input,
         result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream()
             .map(m -> m.bytes().utf8String())
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   @Test
@@ -285,7 +284,7 @@ public class AmqpDocsTest {
         input,
         result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream()
             .map(m -> m.bytes().utf8String())
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   @Test
@@ -339,7 +338,7 @@ public class AmqpDocsTest {
         input,
         result2.toCompletableFuture().get(10, TimeUnit.SECONDS).stream()
             .map(m -> m.message().bytes().utf8String())
-            .collect(Collectors.toList()));
+            .toList());
 
     // See https://github.com/akka/akka/issues/26410
     // extra wait before assertAllStagesStopped kicks in
@@ -374,7 +373,7 @@ public class AmqpDocsTest {
     // #create-flow
 
     final List<WriteResult> expectedResult =
-        input.stream().map(s -> WriteResult.create(true)).collect(Collectors.toList());
+        input.stream().map(s -> WriteResult.create(true)).toList();
 
     assertEquals(result, expectedResult);
   }

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
@@ -41,7 +41,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -123,7 +122,7 @@ public class AmqpConnectorsTest {
       throw e.getCause();
     }
     // assertEquals(input, result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().map(m ->
-    // m.bytes().utf8String()).collect(Collectors.toList()));
+    // m.bytes().utf8String()).toList());
   }
 
   @Test
@@ -172,8 +171,7 @@ public class AmqpConnectorsTest {
         JavaConverters.seqAsJavaListConverter(
                 result.second().toStrict(Duration.create(3, TimeUnit.SECONDS)))
             .asJava();
-    assertEquals(
-        probeResult.stream().map(s -> s.bytes().utf8String()).collect(Collectors.toList()), input);
+    assertEquals(probeResult.stream().map(s -> s.bytes().utf8String()).toList(), input);
     sourceToSink.shutdown();
   }
 
@@ -245,8 +243,7 @@ public class AmqpConnectorsTest {
             bufferSize);
 
     final List<String> input = List.of("one", "two", "three", "four", "five");
-    final List<String> routingKeys =
-        input.stream().map(s -> "key." + s).collect(Collectors.toList());
+    final List<String> routingKeys = input.stream().map(s -> "key." + s).toList();
     Source.from(input)
         .map(s -> WriteMessage.create(ByteString.fromString(s)).withRoutingKey("key." + s))
         .runWith(amqpSink, system);
@@ -258,10 +255,7 @@ public class AmqpConnectorsTest {
             .toCompletableFuture()
             .get(3, TimeUnit.SECONDS);
 
-    assertEquals(
-        routingKeys,
-        result.stream().map(m -> m.envelope().getRoutingKey()).collect(Collectors.toList()));
-    assertEquals(
-        input, result.stream().map(m -> m.bytes().utf8String()).collect(Collectors.toList()));
+    assertEquals(routingKeys, result.stream().map(m -> m.envelope().getRoutingKey()).toList());
+    assertEquals(input, result.stream().map(m -> m.bytes().utf8String()).toList());
   }
 }

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
@@ -16,7 +16,6 @@ package org.apache.pekko.stream.connectors.amqp.javadsl;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 import scala.collection.JavaConverters;
 
@@ -98,7 +97,7 @@ public class AmqpFlowTest {
 
     final List<String> input = List.of("one", "two", "three", "four", "five");
     final List<WriteResult> expectedOutput =
-        input.stream().map(pt -> WriteResult.create(true)).collect(Collectors.toList());
+        input.stream().map(pt -> WriteResult.create(true)).toList();
 
     final TestSubscriber.Probe<WriteResult> result =
         Source.from(input)
@@ -128,9 +127,7 @@ public class AmqpFlowTest {
 
     final List<String> input = List.of("one", "two", "three", "four", "five");
     final List<Pair<WriteResult, String>> expectedOutput =
-        input.stream()
-            .map(pt -> Pair.create(WriteResult.create(true), pt))
-            .collect(Collectors.toList());
+        input.stream().map(pt -> Pair.create(WriteResult.create(true), pt)).toList();
 
     final TestSubscriber.Probe<Pair<WriteResult, String>> result =
         Source.from(input)
@@ -153,9 +150,7 @@ public class AmqpFlowTest {
 
     final List<String> input = List.of("one", "two", "three", "four", "five");
     final List<Pair<WriteResult, String>> expectedOutput =
-        input.stream()
-            .map(pt -> Pair.create(WriteResult.create(true), pt))
-            .collect(Collectors.toList());
+        input.stream().map(pt -> Pair.create(WriteResult.create(true), pt)).toList();
 
     final TestSubscriber.Probe<Pair<WriteResult, String>> result =
         Source.from(input)

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import static docs.javadsl.CassandraTestHelper.await;
 import static org.hamcrest.CoreMatchers.*;
@@ -71,9 +70,7 @@ public class CassandraSourceTest {
                         "CREATE TABLE IF NOT EXISTS " + idtable + " (id int PRIMARY KEY);")));
     await(
         helper.cassandraAccess.executeCqlList(
-            data.stream()
-                .map(i -> "INSERT INTO " + idtable + "(id) VALUES (" + i + ")")
-                .collect(Collectors.toList())));
+            data.stream().map(i -> "INSERT INTO " + idtable + "(id) VALUES (" + i + ")").toList()));
   }
 
   @AfterClass

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -63,7 +63,6 @@ import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSession;
 // #session
 // #registry
-import java.util.stream.Collectors;
 // #sessionFromBucket
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.CouchbaseCluster;
@@ -302,7 +301,7 @@ public class CouchbaseExamplesTest {
         writeResults.stream()
             .filter(CouchbaseWriteResult::isFailure)
             .map(res -> (CouchbaseWriteFailure<StringDocument>) res)
-            .collect(Collectors.toList());
+            .toList();
     // #upsertDocWithResult
 
     assertThat(writeResults.size(), is(sampleSequence.size()));
@@ -404,7 +403,7 @@ public class CouchbaseExamplesTest {
         writeResults.stream()
             .filter(CouchbaseWriteResult::isFailure)
             .map(res -> (CouchbaseWriteFailure<StringDocument>) res)
-            .collect(Collectors.toList());
+            .toList();
     // #replaceDocWithResult
 
     assertThat(writeResults.size(), is(list.size()));

--- a/csv/src/test/java/docs/javadsl/CsvParsingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvParsingTest.java
@@ -35,7 +35,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -79,7 +78,7 @@ public class CsvParsingTest {
         // #line-scanner-string
         Source.single(ByteString.fromString("eins,zwei,drei\n"))
             .via(CsvParsing.lineScanner())
-            .map(line -> line.stream().map(ByteString::utf8String).collect(Collectors.toList()))
+            .map(line -> line.stream().map(ByteString::utf8String).toList())
             .runWith(Sink.head(), system);
     // #line-scanner-string
     List<String> res = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
@@ -111,7 +110,7 @@ public class CsvParsingTest {
     CompletionStage<List<String>> completionStage =
         Source.single(ByteString.fromString("a,b,\\c"))
             .via(CsvParsing.lineScanner())
-            .map(line -> line.stream().map(ByteString::utf8String).collect(Collectors.toList()))
+            .map(line -> line.stream().map(ByteString::utf8String).toList())
             .runWith(Sink.head(), system);
     List<String> res = completionStage.toCompletableFuture().get(5, TimeUnit.SECONDS);
     assertThat(res.get(0), equalTo("a"));

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -375,8 +374,8 @@ public class ElasticsearchV5Test extends ElasticsearchTestBase {
             .get(); // Wait for it to complete
 
     assertEquals(
-        messagesFromKafka.stream().map(m -> m.book.title).sorted().collect(Collectors.toList()),
-        result2.stream().sorted().collect(Collectors.toList()));
+        messagesFromKafka.stream().map(m -> m.book.title).sorted().toList(),
+        result2.stream().sorted().toList());
   }
 
   @Test
@@ -439,7 +438,7 @@ public class ElasticsearchV5Test extends ElasticsearchTestBase {
                 d -> {
                   return d.a != null && d.b == null;
                 })
-            .collect(Collectors.toList())
+            .toList()
             .size());
   }
 }

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -365,8 +364,8 @@ public class ElasticsearchV7Test extends ElasticsearchTestBase {
             .get(); // Wait for it to complete
 
     assertEquals(
-        messagesFromKafka.stream().map(m -> m.book.title).sorted().collect(Collectors.toList()),
-        result2.stream().sorted().collect(Collectors.toList()));
+        messagesFromKafka.stream().map(m -> m.book.title).sorted().toList(),
+        result2.stream().sorted().toList());
   }
 
   @Test
@@ -428,7 +427,7 @@ public class ElasticsearchV7Test extends ElasticsearchTestBase {
                 d -> {
                   return d.a != null && d.b == null;
                 })
-            .collect(Collectors.toList())
+            .toList()
             .size());
   }
 }

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -375,8 +374,8 @@ public class OpensearchV1Test extends ElasticsearchTestBase {
             .get(); // Wait for it to complete
 
     assertEquals(
-        messagesFromKafka.stream().map(m -> m.book.title).sorted().collect(Collectors.toList()),
-        result2.stream().sorted().collect(Collectors.toList()));
+        messagesFromKafka.stream().map(m -> m.book.title).sorted().toList(),
+        result2.stream().sorted().toList());
   }
 
   @Test
@@ -439,7 +438,7 @@ public class OpensearchV1Test extends ElasticsearchTestBase {
                 d -> {
                   return d.a != null && d.b == null;
                 })
-            .collect(Collectors.toList())
+            .toList()
             .size());
   }
 }

--- a/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
+++ b/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
@@ -38,7 +38,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 public class NestedTarReaderTest {
   private static final Logger logger = LoggerFactory.getLogger(NestedTarReaderTest.class);
@@ -71,8 +70,7 @@ public class NestedTarReaderTest {
         tempDir.toAbsolutePath().toString());
     List<TarArchiveMetadata> metadata =
         process(file, tempDir, system).toCompletableFuture().get(1, TimeUnit.MINUTES);
-    List<String> names =
-        metadata.stream().map(md -> md.filePathName()).collect(Collectors.toList());
+    List<String> names = metadata.stream().map(md -> md.filePathName()).toList();
     assertThat(names.size(), is(1281));
   }
 

--- a/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
+++ b/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
@@ -59,7 +59,6 @@ import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 // #imports
 
@@ -226,8 +225,7 @@ public class BigQueryDoc {
     CompletionStage<List<Job>> jobs =
         Source.from(people).via(peopleLoadFlow).runWith(Sink.<Job>seq(), system);
     CompletionStage<List<JobReference>> jobReferences =
-        jobs.thenApply(
-            js -> js.stream().map(j -> j.getJobReference().get()).collect(Collectors.toList()));
+        jobs.thenApply(js -> js.stream().map(j -> j.getJobReference().get()).toList());
     CompletionStage<Boolean> isDone = jobReferences.thenCompose(checkIfJobsDone);
     // #job-status
 

--- a/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -57,7 +57,6 @@ import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -235,7 +234,7 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
   }
 
   private <T> List<T> sorted(List<T> list) {
-    return list.stream().sorted(Comparator.comparingInt(T::hashCode)).collect(Collectors.toList());
+    return list.stream().sorted(Comparator.comparingInt(T::hashCode)).toList();
   }
 
   @Test
@@ -263,7 +262,7 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
         getRows().stream()
             .filter(A::getBoolean)
             .map(a -> new Tuple3<>(a.getString(), a.getRecord(), a.getInteger()))
-            .collect(Collectors.toList());
+            .toList();
     List<Tuple3<String, B, Integer>> results =
         BigQuery.query(
                 query, false, false, BigQueryMarshallers.queryResponseUnmarshaller(JsonNode.class))

--- a/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
@@ -39,7 +39,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -74,8 +73,7 @@ public class HdfsReaderTest {
       ArrayList<ByteString> result =
           new ArrayList<>(source.runWith(Sink.seq(), system).toCompletableFuture().get());
       for (ByteString bs : result) {
-        readData.addAll(
-            bs.utf8String().chars().mapToObj(i -> (char) i).collect(Collectors.toList()));
+        readData.addAll(bs.utf8String().chars().mapToObj(i -> (char) i).toList());
       }
     }
 
@@ -110,8 +108,7 @@ public class HdfsReaderTest {
       ArrayList<ByteString> result =
           new ArrayList<>(source.runWith(Sink.seq(), system).toCompletableFuture().get());
       for (ByteString bs : result) {
-        readData.addAll(
-            bs.utf8String().chars().mapToObj(i -> (char) i).collect(Collectors.toList()));
+        readData.addAll(bs.utf8String().chars().mapToObj(i -> (char) i).toList());
       }
     }
 

--- a/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
@@ -41,12 +41,10 @@ import scala.concurrent.duration.Duration;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -280,10 +278,8 @@ public class HdfsWriterTest {
     assertEquals(logs, expect);
     JavaTestUtils.verifyOutputFileSize(fs, logs);
     assertEquals(
-        JavaTestUtils.readLogs(fs, logs).stream()
-            .flatMap(String::lines)
-            .collect(Collectors.toList()),
-        messagesFromKafka.stream().map(message -> message.book.title).collect(Collectors.toList()));
+        JavaTestUtils.readLogs(fs, logs).stream().flatMap(String::lines).toList(),
+        messagesFromKafka.stream().map(message -> message.book.title).toList());
   }
 
   @Test

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.influxdb.InfluxDB;
@@ -252,11 +251,8 @@ public class InfluxDbTest {
             .get(10, TimeUnit.SECONDS);
 
     assertEquals(
-        messageFromKafka.stream()
-            .map(m -> m.influxDbCpu.getHostname())
-            .sorted()
-            .collect(Collectors.toList()),
-        result2.stream().sorted().collect(Collectors.toList()));
+        messageFromKafka.stream().map(m -> m.influxDbCpu.getHostname()).sorted().toList(),
+        result2.stream().sorted().toList());
   }
 
   private List<InfluxDbWriteMessage<Point, NotUsed>> points(QueryResult queryResult) {

--- a/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
+++ b/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
@@ -26,7 +26,6 @@ import org.junit.Rule;
 
 import java.util.List;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static scala.jdk.javaapi.FutureConverters.*;
@@ -98,9 +97,7 @@ public abstract class UnitTest {
   protected Message.Ids givenMessages(String queueName, int n) {
 
     List<PushMessage> messages =
-        IntStream.rangeClosed(1, n)
-            .mapToObj(i -> PushMessage.create("test-" + i))
-            .collect(Collectors.toList());
+        IntStream.rangeClosed(1, n).mapToObj(i -> PushMessage.create("test-" + i)).toList();
 
     try {
       return asJava(

--- a/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -42,7 +42,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -190,7 +189,7 @@ public class JmsBufferedAckConnectorsTest {
                       jmsTextMessage ->
                           jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
                   .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                  .collect(Collectors.toList());
+                  .toList();
 
           Source.from(msgsIn).runWith(jmsSink, system);
 
@@ -260,9 +259,7 @@ public class JmsBufferedAckConnectorsTest {
                       .withSelector("IsOdd = TRUE"));
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.valueOf(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -308,8 +305,7 @@ public class JmsBufferedAckConnectorsTest {
     withConnectionFactory(
         connectionFactory -> {
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -340,7 +336,7 @@ public class JmsBufferedAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
                   .take(in.size() + inNumbers.size())
@@ -350,7 +346,7 @@ public class JmsBufferedAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -358,10 +354,10 @@ public class JmsBufferedAckConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }

--- a/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -51,7 +51,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -348,7 +347,7 @@ public class JmsConnectorsTest {
                               .withHeader(JmsTimeToLive.create(999, TimeUnit.SECONDS))
                               .withHeader(JmsPriority.create(2))
                               .withHeader(JmsDeliveryMode.create(DeliveryMode.NON_PERSISTENT)))
-                  .collect(Collectors.toList());
+                  .toList();
           // #create-messages-with-headers
 
           Source.from(msgsIn).runWith(jmsSink, system);
@@ -446,9 +445,7 @@ public class JmsConnectorsTest {
           // #source-with-selector
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.valueOf(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -477,8 +474,7 @@ public class JmsConnectorsTest {
     withConnectionFactory(
         connectionFactory -> {
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -500,13 +496,13 @@ public class JmsConnectorsTest {
               jmsTopicSource
                   .take(in.size() + inNumbers.size())
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
                   .take(in.size() + inNumbers.size())
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -514,10 +510,10 @@ public class JmsConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }
@@ -636,7 +632,7 @@ public class JmsConnectorsTest {
           List<String> resultText =
               result.toCompletableFuture().get().stream()
                   .map(message -> ((ActiveMQTextMessage) message).getText())
-                  .collect(Collectors.toList());
+                  .toList();
 
           assertEquals(in, resultText);
         });

--- a/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -43,7 +43,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -190,7 +189,7 @@ public class JmsTxConnectorsTest {
                       jmsTextMessage ->
                           jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
                   .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                  .collect(Collectors.toList());
+                  .toList();
 
           Source.from(msgsIn).runWith(jmsSink, system);
 
@@ -259,9 +258,7 @@ public class JmsTxConnectorsTest {
                       .withSelector("IsOdd = TRUE"));
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.valueOf(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -307,8 +304,7 @@ public class JmsTxConnectorsTest {
     withConnectionFactory(
         connectionFactory -> {
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -339,7 +335,7 @@ public class JmsTxConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
@@ -350,7 +346,7 @@ public class JmsTxConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -359,10 +355,10 @@ public class JmsTxConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }

--- a/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
+++ b/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -183,7 +182,7 @@ public class JmsAckConnectorsTest {
                       jmsTextMessage ->
                           jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
                   .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                  .collect(Collectors.toList());
+                  .toList();
 
           Source.from(msgsIn).runWith(jmsSink, system);
 
@@ -254,9 +253,7 @@ public class JmsAckConnectorsTest {
                       .withSelector("IsOdd = TRUE"));
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.parseInt(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.parseInt(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -302,8 +299,7 @@ public class JmsAckConnectorsTest {
     withConnectionFactory(
         connectionFactory -> {
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -334,7 +330,7 @@ public class JmsAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
                   .take(in.size() + inNumbers.size())
@@ -344,7 +340,7 @@ public class JmsAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -352,10 +348,10 @@ public class JmsAckConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }

--- a/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -39,7 +39,6 @@ import javax.jms.TextMessage;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -193,7 +192,7 @@ public class JmsBufferedAckConnectorsTest {
                       jmsTextMessage ->
                           jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
                   .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                  .collect(Collectors.toList());
+                  .toList();
 
           Source.from(msgsIn).runWith(jmsSink, system);
 
@@ -265,9 +264,7 @@ public class JmsBufferedAckConnectorsTest {
                       .withSelector("IsOdd = TRUE"));
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.valueOf(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -315,8 +312,7 @@ public class JmsBufferedAckConnectorsTest {
           ConnectionFactory connectionFactory = server.createConnectionFactory();
 
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -347,7 +343,7 @@ public class JmsBufferedAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
                   .take(in.size() + inNumbers.size())
@@ -357,7 +353,7 @@ public class JmsBufferedAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -365,10 +361,10 @@ public class JmsBufferedAckConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -51,7 +51,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -364,7 +363,7 @@ public class JmsConnectorsTest {
                               .withHeader(JmsTimeToLive.create(999, TimeUnit.SECONDS))
                               .withHeader(JmsPriority.create(2))
                               .withHeader(JmsDeliveryMode.create(DeliveryMode.NON_PERSISTENT)))
-                  .collect(Collectors.toList());
+                  .toList();
           // #create-messages-with-headers
 
           Source.from(msgsIn).runWith(jmsSink, system);
@@ -465,9 +464,7 @@ public class JmsConnectorsTest {
           // #source-with-selector
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.valueOf(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -498,8 +495,7 @@ public class JmsConnectorsTest {
           ConnectionFactory connectionFactory = server.createConnectionFactory();
 
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -521,13 +517,13 @@ public class JmsConnectorsTest {
               jmsTopicSource
                   .take(in.size() + inNumbers.size())
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
                   .take(in.size() + inNumbers.size())
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -535,10 +531,10 @@ public class JmsConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }
@@ -673,7 +669,7 @@ public class JmsConnectorsTest {
                           throw new RuntimeException(e);
                         }
                       })
-                  .collect(Collectors.toList());
+                  .toList();
 
           assertEquals(in, resultText);
         });

--- a/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -40,7 +40,6 @@ import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -194,7 +193,7 @@ public class JmsTxConnectorsTest {
                       jmsTextMessage ->
                           jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
                   .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                  .collect(Collectors.toList());
+                  .toList();
 
           Source.from(msgsIn).runWith(jmsSink, system);
 
@@ -265,9 +264,7 @@ public class JmsTxConnectorsTest {
                       .withSelector("IsOdd = TRUE"));
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.valueOf(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.valueOf(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -315,8 +312,7 @@ public class JmsTxConnectorsTest {
           ConnectionFactory connectionFactory = server.createConnectionFactory();
 
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -347,7 +343,7 @@ public class JmsTxConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
@@ -358,7 +354,7 @@ public class JmsTxConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -367,10 +363,10 @@ public class JmsTxConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }

--- a/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
@@ -36,7 +36,6 @@ import javax.jms.TextMessage;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -188,7 +187,7 @@ public class JmsAckConnectorsTest {
                       jmsTextMessage ->
                           jmsTextMessage.withHeader(JmsCorrelationId.create("correlationId")))
                   .map(jmsTextMessage -> jmsTextMessage.withHeader(JmsReplyTo.queue("test-reply")))
-                  .collect(Collectors.toList());
+                  .toList();
 
           Source.from(msgsIn).runWith(jmsSink, system);
 
@@ -261,9 +260,7 @@ public class JmsAckConnectorsTest {
                       .withSelector("IsOdd = TRUE"));
 
           List<JmsTextMessage> oddMsgsIn =
-              msgsIn.stream()
-                  .filter(msg -> Integer.parseInt(msg.body()) % 2 == 1)
-                  .collect(Collectors.toList());
+              msgsIn.stream().filter(msg -> Integer.parseInt(msg.body()) % 2 == 1).toList();
           assertEquals(5, oddMsgsIn.size());
 
           CompletionStage<List<Message>> result =
@@ -311,8 +308,7 @@ public class JmsAckConnectorsTest {
           ConnectionFactory connectionFactory = server.createConnectionFactory();
 
           List<String> in = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k");
-          List<String> inNumbers =
-              IntStream.range(0, 10).boxed().map(String::valueOf).collect(Collectors.toList());
+          List<String> inNumbers = IntStream.range(0, 10).boxed().map(String::valueOf).toList();
 
           Sink<String, CompletionStage<Done>> jmsTopicSink =
               JmsProducer.textSink(
@@ -343,7 +339,7 @@ public class JmsAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
           CompletionStage<List<String>> result2 =
               jmsTopicSource2
                   .take(in.size() + inNumbers.size())
@@ -353,7 +349,7 @@ public class JmsAckConnectorsTest {
                         return ((TextMessage) env.message()).getText();
                       })
                   .runWith(Sink.seq(), system)
-                  .thenApply(l -> l.stream().sorted().collect(Collectors.toList()));
+                  .thenApply(l -> l.stream().sorted().toList());
 
           Thread.sleep(500);
 
@@ -361,10 +357,10 @@ public class JmsAckConnectorsTest {
           Source.from(inNumbers).runWith(jmsTopicSink2, system);
 
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result.toCompletableFuture().get(5, TimeUnit.SECONDS));
           assertEquals(
-              Stream.concat(in.stream(), inNumbers.stream()).sorted().collect(Collectors.toList()),
+              Stream.concat(in.stream(), inNumbers.stream()).sorted().toList(),
               result2.toCompletableFuture().get(5, TimeUnit.SECONDS));
         });
   }

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -45,7 +45,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-import static java.util.stream.Collectors.toList;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.junit.Assert.assertEquals;
@@ -63,7 +62,7 @@ public class MongoSinkTest {
   private final MongoCollection<Document> domainObjectsDocumentColl;
   private final MongoCollection<DomainObject> domainObjectsColl;
 
-  private final List<Integer> testRange = IntStream.range(1, 10).boxed().collect(toList());
+  private final List<Integer> testRange = IntStream.range(1, 10).boxed().toList();
 
   public MongoSinkTest() {
     system = ActorSystem.create();
@@ -154,13 +153,13 @@ public class MongoSinkTest {
         testRange,
         found.toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(n -> n.getInteger("value"))
-            .collect(toList()));
+            .toList());
   }
 
   @Test
   public void saveWithInsertOneAndCodecSupport() throws Exception {
     // #insert-one
-    List<Number> testRangeObjects = testRange.stream().map(Number::new).collect(toList());
+    List<Number> testRangeObjects = testRange.stream().map(Number::new).toList();
     final CompletionStage<Done> completion =
         Source.from(testRangeObjects).runWith(MongoSink.insertOne(numbersColl), system);
     // #insert-one
@@ -187,13 +186,13 @@ public class MongoSinkTest {
         testRange,
         found.toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(n -> n.getInteger("value"))
-            .collect(toList()));
+            .toList());
   }
 
   @Test
   public void saveWithInsertManyAndCodecSupport() throws Exception {
     // #insert-many
-    final List<Number> testRangeObjects = testRange.stream().map(Number::new).collect(toList());
+    final List<Number> testRangeObjects = testRange.stream().map(Number::new).toList();
     final CompletionStage<Done> completion =
         Source.from(testRangeObjects).grouped(2).runWith(MongoSink.insertMany(numbersColl), system);
     // #insert-many
@@ -224,12 +223,12 @@ public class MongoSinkTest {
         testRange,
         found.toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(n -> n.getInteger("value"))
-            .collect(toList()));
+            .toList());
   }
 
   @Test
   public void saveWithInsertManyWithOptionsAndCodecSupport() throws Exception {
-    List<Number> testRangeObjects = testRange.stream().map(Number::new).collect(toList());
+    List<Number> testRangeObjects = testRange.stream().map(Number::new).toList();
     final CompletionStage<Done> completion =
         Source.from(testRangeObjects)
             .grouped(2)
@@ -264,10 +263,10 @@ public class MongoSinkTest {
         Source.fromPublisher(numbersDocumentColl.find()).runWith(Sink.seq(), system);
 
     assertEquals(
-        testRange.stream().map(i -> Pair.create(i, i * -1)).collect(toList()),
+        testRange.stream().map(i -> Pair.create(i, i * -1)).toList(),
         found.toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(d -> Pair.create(d.getInteger("value"), d.getInteger("updateValue")))
-            .collect(toList()));
+            .toList());
   }
 
   @Test
@@ -287,10 +286,10 @@ public class MongoSinkTest {
         Source.fromPublisher(numbersDocumentColl.find()).runWith(Sink.seq(), system);
 
     assertEquals(
-        testRange.stream().map(i -> Pair.create(i, 0)).collect(toList()),
+        testRange.stream().map(i -> Pair.create(i, 0)).toList(),
         found.toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(d -> Pair.create(d.getInteger("value"), d.getInteger("updateValue")))
-            .collect(toList()));
+            .toList());
   }
 
   @Test
@@ -363,7 +362,7 @@ public class MongoSinkTest {
                         i,
                         String.format("updated-first-property-%s", i),
                         String.format("updated-second-property-%s", i)))
-            .collect(toList());
+            .toList();
 
     assertEquals(expected, found);
   }

--- a/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
@@ -33,7 +33,6 @@ import org.junit.*;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.junit.Assert.assertEquals;
@@ -101,12 +100,12 @@ public class MongoSourceTest {
         data,
         rows.toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(n -> n.getInteger("_id"))
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   @Test
   public void supportCodecRegistryToReadClassObjects() throws Exception {
-    List<Number> data = seed().stream().map(Number::new).collect(Collectors.toList());
+    List<Number> data = seed().stream().map(Number::new).toList();
 
     // #create-source
     final Source<Number, NotUsed> source = MongoSource.create(numbersColl.find(Number.class));
@@ -129,12 +128,12 @@ public class MongoSourceTest {
         data,
         source.runWith(Sink.seq(), system).toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(n -> n.getInteger("_id"))
-            .collect(Collectors.toList()));
+            .toList());
     assertEquals(
         data,
         source.runWith(Sink.seq(), system).toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(n -> n.getInteger("_id"))
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   @Test
@@ -151,10 +150,10 @@ public class MongoSourceTest {
   }
 
   private List<Integer> seed() throws Exception {
-    final List<Integer> numbers = IntStream.range(1, 10).boxed().collect(Collectors.toList());
+    final List<Integer> numbers = IntStream.range(1, 10).boxed().toList();
 
     final List<Document> documents =
-        numbers.stream().map(i -> Document.parse("{_id:" + i + "}")).collect(Collectors.toList());
+        numbers.stream().map(i -> Document.parse("{_id:" + i + "}")).toList();
 
     final CompletionStage<InsertManyResult> completion =
         Source.fromPublisher(numbersDocumentColl.insertMany(documents))

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -66,7 +66,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -219,9 +218,7 @@ public class MqttFlowTest {
                                 JavaConverters.asJavaCollectionConverter(subscribe.topicFilters())
                                     .asJavaCollection();
                             List<Integer> flags =
-                                topicFilters.stream()
-                                    .map(x -> x._2().underlying())
-                                    .collect(Collectors.toList());
+                                topicFilters.stream().map(x -> x._2().underlying()).toList();
                             queue.offer(
                                 new Command<>(
                                     new SubAck(subscribe.packetId(), flags),

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -136,7 +136,7 @@ public class MqttSourceTest {
         input,
         unackedResult.second().toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(m -> m.message().payload().utf8String())
-            .collect(Collectors.toList()));
+            .toList());
 
     Flow<MqttMessageWithAck, MqttMessageWithAck, NotUsed> businessLogic = Flow.create();
 
@@ -156,7 +156,7 @@ public class MqttSourceTest {
         input,
         result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream()
             .map(m -> m.payload().utf8String())
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   @Test
@@ -246,7 +246,7 @@ public class MqttSourceTest {
                     Stream.of(
                         MqttMessage.create(topic1, ByteString.fromString("msg" + i.toString())),
                         MqttMessage.create(topic2, ByteString.fromString("msg" + i.toString()))))
-            .collect(Collectors.toList());
+            .toList();
 
     // #run-sink
     Sink<MqttMessage, CompletionStage<Done>> mqttSink =

--- a/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -139,7 +139,7 @@ public class MqttSourceTest {
         input,
         unackedResult.second().toCompletableFuture().get(5, TimeUnit.SECONDS).stream()
             .map(m -> m.message().payload().utf8String())
-            .collect(Collectors.toList()));
+            .toList());
 
     Flow<MqttMessageWithAck, MqttMessageWithAck, NotUsed> businessLogic = Flow.create();
 
@@ -159,7 +159,7 @@ public class MqttSourceTest {
         input,
         result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream()
             .map(m -> m.payload().utf8String())
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   @Test
@@ -249,7 +249,7 @@ public class MqttSourceTest {
                     Stream.of(
                         MqttMessage.create(topic1, ByteString.fromString("msg" + i.toString())),
                         MqttMessage.create(topic2, ByteString.fromString("msg" + i.toString()))))
-            .collect(Collectors.toList());
+            .toList();
 
     // #run-sink
     Sink<MqttMessage, CompletionStage<Done>> mqttSink =

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 
@@ -372,11 +371,8 @@ public class OrientDbTest {
             .get(10, TimeUnit.SECONDS);
 
     assertEquals(
-        messagesFromKafkas.stream()
-            .map(m -> m.getBook_title())
-            .sorted()
-            .collect(Collectors.toList()),
-        result2.stream().sorted().collect(Collectors.toList()));
+        messagesFromKafkas.stream().map(m -> m.getBook_title()).sorted().toList(),
+        result2.stream().sorted().toList());
   }
 
   @Test

--- a/reference/src/test/java/docs/javadsl/ReferenceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceTest.java
@@ -35,7 +35,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 /** Append "Test" to every Java test suite. */
 public class ReferenceTest {
@@ -134,9 +133,7 @@ public class ReferenceTest {
     final List<ReferenceWriteResult> result = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
     final List<ByteString> bytes =
-        result.stream()
-            .flatMap(m -> m.getMessage().getData().stream())
-            .collect(Collectors.toList());
+        result.stream().flatMap(m -> m.getMessage().getData().stream()).toList();
 
     Assert.assertEquals(
         List.of(
@@ -165,7 +162,7 @@ public class ReferenceTest {
         result.stream()
             .flatMap(m -> m.getMessage().getData().stream())
             .map(ByteString::utf8String)
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   @Test
@@ -187,7 +184,7 @@ public class ReferenceTest {
         result.stream()
             .flatMap(m -> m.getMessage().getData().stream())
             .map(ByteString::utf8String)
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   /** Called after every test. */

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
@@ -23,7 +23,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class DocSnippetFlow {
@@ -35,10 +34,7 @@ public class DocSnippetFlow {
     system.registerOnTermination(session::close);
 
     final List<User> users =
-        IntStream.range(0, 42)
-            .boxed()
-            .map((i) -> new User(i, "Name" + i))
-            .collect(Collectors.toList());
+        IntStream.range(0, 42).boxed().map((i) -> new User(i, "Name" + i)).toList();
 
     int parallelism = 1;
 

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 // We're going to pretend we got messages from kafka.
@@ -68,15 +67,12 @@ public class DocSnippetFlowWithPassThrough {
     system.registerOnTermination(session::close);
 
     final List<User> users =
-        IntStream.range(0, 42)
-            .boxed()
-            .map((i) -> new User(i, "Name" + i))
-            .collect(Collectors.toList());
+        IntStream.range(0, 42).boxed().map((i) -> new User(i, "Name" + i)).toList();
 
     List<KafkaMessage<User>> messagesFromKafka =
         users.stream()
             .map(user -> new KafkaMessage<>(user, new CommittableOffset(users.indexOf(user))))
-            .collect(Collectors.toList());
+            .toList();
 
     // #flowWithPassThrough-example
     final CompletionStage<Done> done =

--- a/slick/src/test/java/docs/javadsl/DocSnippetSink.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetSink.java
@@ -22,7 +22,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 public class DocSnippetSink {
@@ -33,10 +32,7 @@ public class DocSnippetSink {
     system.registerOnTermination(session::close);
 
     final List<User> users =
-        IntStream.range(0, 42)
-            .boxed()
-            .map((i) -> new User(i, "Name" + i))
-            .collect(Collectors.toList());
+        IntStream.range(0, 42).boxed().map((i) -> new User(i, "Name" + i)).toList();
 
     // #sink-example
     final CompletionStage<Done> done =

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -307,7 +307,7 @@ public class SlickTest {
     final List<KafkaMessage<User>> messagesFromKafka =
         usersList.stream()
             .map(user -> new KafkaMessage<>(user, new KafkaOffset(usersList.indexOf(user))))
-            .collect(Collectors.toList());
+            .toList();
 
     final Function<KafkaMessage<User>, String> insertUserInKafkaMessage =
         insertUser.compose((KafkaMessage<User> kafkaMessage) -> kafkaMessage.msg);

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -63,7 +63,6 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -380,7 +379,7 @@ public class SolrTest {
                               }
                               return result.passThrough();
                             })
-                        .collect(Collectors.toList()))
+                        .toList())
             .map(ConsumerMessage::createCommittableOffsetBatch)
             .mapAsync(1, CommittableOffsetBatch::commitJavadsl)
             .runWith(Sink.ignore(), system);
@@ -391,9 +390,7 @@ public class SolrTest {
     // Make sure all messages was committed to kafka
     assertEquals(
         List.of(0, 1, 2),
-        CommittableOffsetBatch.committedOffsets.stream()
-            .map(o -> o.offset)
-            .collect(Collectors.toList()));
+        CommittableOffsetBatch.committedOffsets.stream().map(o -> o.offset).toList());
 
     TupleStream stream = getTupleStream(collectionName);
 
@@ -405,8 +402,8 @@ public class SolrTest {
     List<String> result = new ArrayList<>(resultOf(res2));
 
     assertEquals(
-        messagesFromKafka.stream().map(m -> m.book.title).sorted().collect(Collectors.toList()),
-        result.stream().sorted().collect(Collectors.toList()));
+        messagesFromKafka.stream().map(m -> m.book.title).sorted().toList(),
+        result.stream().sorted().toList());
   }
 
   @Test
@@ -749,7 +746,7 @@ public class SolrTest {
                               }
                               return result.passThrough();
                             })
-                        .collect(Collectors.toList()))
+                        .toList())
             .map(ConsumerMessage::createCommittableOffsetBatch)
             .mapAsync(1, CommittableOffsetBatch::commitJavadsl)
             .runWith(Sink.ignore(), system);
@@ -760,9 +757,7 @@ public class SolrTest {
     // Make sure all messages was committed to kafka
     assertEquals(
         List.of(0, 1, 2),
-        CommittableOffsetBatch.committedOffsets.stream()
-            .map(o -> o.offset)
-            .collect(Collectors.toList()));
+        CommittableOffsetBatch.committedOffsets.stream().map(o -> o.offset).toList());
   }
 
   @BeforeClass

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -196,7 +195,7 @@ public class SqsAckTest extends BaseSqsTest {
     List<DeleteMessageBatchResultEntry> entries =
         IntStream.range(0, messages.size())
             .mapToObj(i -> DeleteMessageBatchResultEntry.builder().id(Integer.toString(i)).build())
-            .collect(Collectors.toList());
+            .toList();
     DeleteMessageBatchResponse response =
         DeleteMessageBatchResponse.builder().successful(entries).build();
 
@@ -241,7 +240,7 @@ public class SqsAckTest extends BaseSqsTest {
                     ChangeMessageVisibilityBatchResultEntry.builder()
                         .id(Integer.toString(i))
                         .build())
-            .collect(Collectors.toList());
+            .toList();
     ChangeMessageVisibilityBatchResponse response =
         ChangeMessageVisibilityBatchResponse.builder().successful(entries).build();
 

--- a/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
+++ b/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -60,7 +59,7 @@ public class CharsetCodingFlowsDoc {
     List<String> strings =
         properties.stringPropertyNames().stream()
             .map(p -> p + " -> " + properties.getProperty(p))
-            .collect(Collectors.toList());
+            .toList();
     // #encoding
     Source<String, ?> stringSource = // ...
         // #encoding

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
@@ -238,7 +237,7 @@ public class XmlParsingTest {
         .thenAccept(
             (list) -> {
               assertThat(
-                  list.stream().map(e -> XmlHelper.asString(e).trim()).collect(Collectors.toList()),
+                  list.stream().map(e -> XmlHelper.asString(e).trim()).toList(),
                   hasItems("<item>i1</item>", "<item><sub>i2</sub></item>", "<item>i3</item>"));
             })
         .toCompletableFuture()


### PR DESCRIPTION
### Motivation
Java 16+ `Stream.toList()` provides a concise way to collect stream elements into an unmodifiable list.

### Modification
Replace `.collect(Collectors.toList())` with `.toList()` across 39 files. Remove unused `Collectors` imports.

### Result
Cleaner stream collection code using Java 17 API.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization