### PR TITLE
refactor: migrate String.format to String.formatted (Java 15+)

### DIFF
--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -68,7 +68,7 @@ public class ElasticsearchTestBase {
       int port, org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase version)
       throws IOException {
     connectionSettings =
-        ElasticsearchConnectionSettings.create(String.format("http://localhost:%d", port));
+        ElasticsearchConnectionSettings.create("http://localhost:%d".formatted(port));
 
     register("source", "Akka in Action");
     register("source", "Programming in Scala");
@@ -82,24 +82,24 @@ public class ElasticsearchTestBase {
 
   protected static void cleanIndex() throws IOException {
     HttpRequest request =
-        HttpRequest.DELETE(String.format("%s/_all", connectionSettings.baseUrl()));
+        HttpRequest.DELETE("%s/_all".formatted(connectionSettings.baseUrl()));
     http.singleRequest(request).toCompletableFuture().join();
   }
 
   protected static void flushAndRefresh(String indexName) throws IOException {
     HttpRequest flushRequest =
-        HttpRequest.POST(String.format("%s/%s/_flush", connectionSettings.baseUrl(), indexName));
+        HttpRequest.POST("%s/%s/_flush".formatted(connectionSettings.baseUrl(), indexName));
     http.singleRequest(flushRequest).toCompletableFuture().join();
 
     HttpRequest refreshRequest =
-        HttpRequest.POST(String.format("%s/%s/_refresh", connectionSettings.baseUrl(), indexName));
+        HttpRequest.POST("%s/%s/_refresh".formatted(connectionSettings.baseUrl(), indexName));
     http.singleRequest(refreshRequest).toCompletableFuture().join();
   }
 
   protected static void register(String indexName, String title) {
     HttpRequest request =
-        HttpRequest.POST(String.format("%s/%s/_doc", connectionSettings.baseUrl(), indexName))
-            .withEntity(ContentTypes.APPLICATION_JSON, String.format("{\"title\": \"%s\"}", title));
+        HttpRequest.POST("%s/%s/_doc".formatted(connectionSettings.baseUrl(), indexName))
+            .withEntity(ContentTypes.APPLICATION_JSON, "{\"title\": \"%s\"}".formatted(title));
 
     http.singleRequest(request).toCompletableFuture().join();
   }

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -81,8 +81,7 @@ public class ElasticsearchTestBase {
   }
 
   protected static void cleanIndex() throws IOException {
-    HttpRequest request =
-        HttpRequest.DELETE("%s/_all".formatted(connectionSettings.baseUrl()));
+    HttpRequest request = HttpRequest.DELETE("%s/_all".formatted(connectionSettings.baseUrl()));
     http.singleRequest(request).toCompletableFuture().join();
   }
 

--- a/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
@@ -60,12 +60,12 @@ public class GeodeBaseTestCase {
 
   static Source<Person, NotUsed> buildPersonsSource(Integer... ids) {
     return Source.from(List.of(ids))
-        .map((i) -> new Person(i, String.format("Person Java %d", i), new Date()));
+        .map((i) -> new Person(i, "Person Java %d".formatted(i), new Date()));
   }
 
   static Source<Animal, NotUsed> buildAnimalsSource(Integer... ids) {
     return Source.from(List.of(ids))
-        .map((i) -> new Animal(i, String.format("Animal Java %d", i), 1));
+        .map((i) -> new Animal(i, "Animal Java %d".formatted(i), 1));
   }
 
   protected Geode createGeodeClient() {

--- a/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
@@ -64,8 +64,7 @@ public class GeodeBaseTestCase {
   }
 
   static Source<Animal, NotUsed> buildAnimalsSource(Integer... ids) {
-    return Source.from(List.of(ids))
-        .map((i) -> new Animal(i, "Animal Java %d".formatted(i), 1));
+    return Source.from(List.of(ids)).map((i) -> new Animal(i, "Animal Java %d".formatted(i), 1));
   }
 
   protected Geode createGeodeClient() {

--- a/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
@@ -58,7 +58,7 @@ public class GeodeContinuousSourceTestCase extends GeodeBaseTestCase {
 
     Pair<NotUsed, CompletionStage<List<Person>>> run =
         Source.from(List.of(120))
-            .map((i) -> new Person(i, String.format("Java flow %d", i), new Date()))
+            .map((i) -> new Person(i, "Java flow %d".formatted(i), new Date()))
             .via(flow)
             .toMat(Sink.seq(), Keep.both())
             .run(system);

--- a/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
+++ b/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
@@ -156,7 +156,7 @@ public class BigQueryDoc {
 
     // #run-query
     String sqlQuery =
-        String.format("SELECT name, addresses FROM %s.%s WHERE age >= 100", datasetId, tableId);
+        "SELECT name, addresses FROM %s.%s WHERE age >= 100".formatted(datasetId, tableId);
     Unmarshaller<HttpEntity, QueryResponse<NameAddressesPair>> queryResponseUnmarshaller =
         BigQueryMarshallers.queryResponseUnmarshaller(NameAddressesPair.class);
     Source<NameAddressesPair, CompletionStage<QueryResponse<NameAddressesPair>>> centenarians =

--- a/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -256,8 +256,8 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
   @Test
   public void runQuery() throws ExecutionException, InterruptedException {
     String query =
-        String.format(
-            "SELECT string, record, integer FROM %s.%s WHERE boolean;", datasetId(), tableId());
+        "SELECT string, record, integer FROM %s.%s WHERE boolean;"
+            .formatted(datasetId(), tableId());
     List<Tuple3<String, B, Integer>> expectedResults =
         getRows().stream()
             .filter(A::getBoolean)
@@ -281,8 +281,8 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
   @Test
   public void dryRunQuery() throws ExecutionException, InterruptedException {
     String query =
-        String.format(
-            "SELECT string, record, integer FROM %s.%s WHERE boolean;", datasetId(), tableId());
+        "SELECT string, record, integer FROM %s.%s WHERE boolean;"
+            .formatted(datasetId(), tableId());
     QueryResponse<JsonNode> response =
         BigQuery.query(
                 query, true, false, BigQueryMarshallers.queryResponseUnmarshaller(JsonNode.class))

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -64,7 +64,7 @@ public class HBaseStageTest {
   Function<Person, List<Mutation>> hBaseConverter =
       person -> {
         try {
-          Put put = new Put(String.format("id_%d", person.id).getBytes("UTF-8"));
+          Put put = new Put("id_%d".formatted(person.id).getBytes("UTF-8"));
           put.addColumn(
               "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
 
@@ -80,7 +80,7 @@ public class HBaseStageTest {
   Function<Person, List<Mutation>> appendHBaseConverter =
       person -> {
         try {
-          Append append = new Append(String.format("id_%d", person.id).getBytes("UTF-8"));
+          Append append = new Append("id_%d".formatted(person.id).getBytes("UTF-8"));
           append.add(
               "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
 
@@ -96,7 +96,7 @@ public class HBaseStageTest {
   Function<Person, List<Mutation>> deleteHBaseConverter =
       person -> {
         try {
-          Delete delete = new Delete(String.format("id_%d", person.id).getBytes("UTF-8"));
+          Delete delete = new Delete("id_%d".formatted(person.id).getBytes("UTF-8"));
 
           return List.of(delete);
         } catch (UnsupportedEncodingException e) {
@@ -110,7 +110,7 @@ public class HBaseStageTest {
   Function<Person, List<Mutation>> incrementHBaseConverter =
       person -> {
         try {
-          Increment increment = new Increment(String.format("id_%d", person.id).getBytes("UTF-8"));
+          Increment increment = new Increment("id_%d".formatted(person.id).getBytes("UTF-8"));
           increment.addColumn("info".getBytes("UTF-8"), "numberOfChanges".getBytes("UTF-8"), 1);
 
           return List.of(increment);
@@ -125,7 +125,7 @@ public class HBaseStageTest {
   Function<Person, List<Mutation>> complexHBaseConverter =
       person -> {
         try {
-          byte[] id = String.format("id_%d", person.id).getBytes("UTF-8");
+          byte[] id = "id_%d".formatted(person.id).getBytes("UTF-8");
           byte[] infoFamily = "info".getBytes("UTF-8");
 
           if (person.id != 0 && person.name.isEmpty()) {
@@ -166,7 +166,7 @@ public class HBaseStageTest {
     final Sink<Person, CompletionStage<Done>> sink = HTableStage.sink(tableSettings);
     CompletionStage<Done> o =
         Source.from(List.of(100, 101, 102, 103, 104))
-            .map((i) -> new Person(i, String.format("name %d", i)))
+            .map((i) -> new Person(i, "name %d".formatted(i)))
             .runWith(sink, system);
     // #sink
 
@@ -187,7 +187,7 @@ public class HBaseStageTest {
     Flow<Person, Person, NotUsed> flow = HTableStage.flow(tableSettings);
     Pair<NotUsed, CompletionStage<List<Person>>> run =
         Source.from(List.of(200, 201, 202, 203, 204))
-            .map((i) -> new Person(i, String.format("name_%d", i)))
+            .map((i) -> new Person(i, "name_%d".formatted(i)))
             .via(flow)
             .toMat(Sink.seq(), Keep.both())
             .run(system);

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -98,7 +98,7 @@ public class KuduTableTest {
 
     CompletionStage<Done> o =
         Source.from(List.of(100, 101, 102, 103, 104))
-            .map((i) -> new Person(i, String.format("name %d", i)))
+            .map((i) -> new Person(i, "name %d".formatted(i)))
             .runWith(sink, system);
     // #sink
     assertEquals(Done.getInstance(), o.toCompletableFuture().get(5, TimeUnit.SECONDS));
@@ -111,7 +111,7 @@ public class KuduTableTest {
 
     CompletionStage<List<Person>> run =
         Source.from(List.of(200, 201, 202, 203, 204))
-            .map((i) -> new Person(i, String.format("name_%d", i)))
+            .map((i) -> new Person(i, "name_%d".formatted(i)))
             .via(flow)
             .toMat(Sink.seq(), Keep.right())
             .run(system);
@@ -140,7 +140,7 @@ public class KuduTableTest {
 
     CompletionStage<List<Person>> run =
         Source.from(List.of(200, 201, 202, 203, 204))
-            .map((i) -> new Person(i, String.format("name_%d", i)))
+            .map((i) -> new Person(i, "name_%d".formatted(i)))
             .via(flow)
             .toMat(Sink.seq(), Keep.right())
             .run(system);

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -97,9 +97,9 @@ public class MongoSinkTest {
               DomainObject domainObject =
                   new DomainObject(
                       i,
-                      String.format("first-property-%s", i),
-                      String.format("second-property-%s", i));
-              System.out.println(String.format("%s inserting %s", i, domainObject));
+                      "first-property-%s".formatted(i),
+                      "second-property-%s".formatted(i));
+              System.out.println("%s inserting %s".formatted(i, domainObject));
               return domainObject;
             })
         .runWith(MongoSink.insertOne(domainObjectsColl), system)
@@ -340,8 +340,8 @@ public class MongoSinkTest {
                         Filters.eq("_id", i),
                         new DomainObject(
                             i,
-                            String.format("updated-first-property-%s", i),
-                            String.format("updated-second-property-%s", i))));
+                            "updated-first-property-%s".formatted(i),
+                            "updated-second-property-%s".formatted(i))));
     final CompletionStage<Done> completion =
         source.runWith(MongoSink.replaceOne(domainObjectsColl), system);
     // #replace-one
@@ -361,8 +361,8 @@ public class MongoSinkTest {
                 i ->
                     new DomainObject(
                         i,
-                        String.format("updated-first-property-%s", i),
-                        String.format("updated-second-property-%s", i)))
+                        "updated-first-property-%s".formatted(i),
+                        "updated-second-property-%s".formatted(i)))
             .toList();
 
     assertEquals(expected, found);

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -96,9 +96,7 @@ public class MongoSinkTest {
             i -> {
               DomainObject domainObject =
                   new DomainObject(
-                      i,
-                      "first-property-%s".formatted(i),
-                      "second-property-%s".formatted(i));
+                      i, "first-property-%s".formatted(i), "second-property-%s".formatted(i));
               System.out.println("%s inserting %s".formatted(i, domainObject));
               return domainObject;
             })

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
@@ -105,7 +105,7 @@ public class PravegaKVTableTestCase extends PravegaBaseTestCase {
 
     String result = readingDone.toCompletableFuture().get(timeoutSeconds, TimeUnit.SECONDS);
     Assertions.assertTrue(
-        result.equals("One, Two, Three, Four"), String.format("Read 2 elements [%s]", result));
+        result.equals("One, Two, Three, Four"), "Read 2 elements [%s]".formatted(result));
 
     Flow<Integer, Optional<String>, NotUsed> readFlow =
         PravegaTable.readFlow(scope, tableName, tableReaderSettings);

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -887,7 +887,7 @@ public class SolrTest {
     streamContext.setSolrClientCache(solrClientCache);
 
     String expressionStr =
-        String.format("search(%s, q=*:*, fl=\"title,comment\", sort=\"title asc\")", collection);
+        "search(%s, q=*:*, fl=\"title,comment\", sort=\"title asc\")".formatted(collection);
     StreamExpression expression = StreamExpressionParser.parse(expressionStr);
     TupleStream stream = new CloudSolrStream(expression, factory);
     stream.setStreamContext(streamContext);

--- a/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/SpringWebPekkoStreamsConfiguration.java
+++ b/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/SpringWebPekkoStreamsConfiguration.java
@@ -57,9 +57,8 @@ public class SpringWebPekkoStreamsConfiguration {
   private String getActorSystemName(final SpringWebPekkoStreamsProperties properties) {
     Objects.requireNonNull(
         properties,
-        String.format(
-            "%s is not present in application context",
-            SpringWebPekkoStreamsProperties.class.getSimpleName()));
+        "%s is not present in application context"
+            .formatted(SpringWebPekkoStreamsProperties.class.getSimpleName()));
 
     if (isBlank(properties.getActorSystemName())) {
       return DEFAULT_FACTORY_SYSTEM_NAME;

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -378,6 +378,6 @@ public class SqsPublishTest extends BaseSqsTest {
   private String toMd5(String s) throws Exception {
     MessageDigest m = MessageDigest.getInstance("MD5");
     BigInteger bigInt = new BigInteger(1, m.digest(s.getBytes()));
-    return String.format("%032x", bigInt);
+    return "%032x".formatted(bigInt);
   }
 }

--- a/sqs/src/test/java/org/apache/pekko/stream/connectors/sqs/javadsl/BaseSqsTest.java
+++ b/sqs/src/test/java/org/apache/pekko/stream/connectors/sqs/javadsl/BaseSqsTest.java
@@ -100,7 +100,7 @@ public abstract class BaseSqsTest {
     return sqsClient
         .createQueue(
             CreateQueueRequest.builder()
-                .queueName(String.format("queue-%s", new Random().nextInt()))
+                .queueName("queue-%s".formatted(new Random().nextInt()))
                 .build())
         .get(2, TimeUnit.SECONDS)
         .queueUrl();

--- a/sse/src/test/java/docs/javadsl/EventSourceTest.java
+++ b/sse/src/test/java/docs/javadsl/EventSourceTest.java
@@ -51,7 +51,7 @@ public class EventSourceTest {
     Function<HttpRequest, CompletionStage<HttpResponse>> send =
         (request) -> http.singleRequest(request);
 
-    final Uri targetUri = Uri.create(String.format("http://%s:%d", host, port));
+    final Uri targetUri = Uri.create("http://%s:%d".formatted(host, port));
     final Optional<String> lastEventId = Optional.of("2");
     Source<ServerSentEvent, NotUsed> eventSource =
         EventSource.create(targetUri, send, lastEventId, system);


### PR DESCRIPTION
## Summary
- Migrate `String.format("literal", args)` to `"literal".formatted(args)` (Java 15+ API)
- 14 files updated across elasticsearch, geode, google-cloud-bigquery, hbase, kudu, mongodb, pravega, solr, spring-web, sqs, and sse modules
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17