### PR TITLE
refactor: migrate switch statements to modern switch syntax (Java 14+)

### DIFF
--- a/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -139,18 +139,13 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
         .settings()
         .config()
         .getString("pekko.connectors.google.bigquery.test.e2e-mode")) {
-      case "simulate":
-        hoverfly.simulate(
-            SimulationSource.url(
-                BigQueryEndToEndTest.class
-                    .getClassLoader()
-                    .getResource("BigQueryEndToEndSpec.json")));
-        break;
-      case "capture":
-        hoverfly.resetMode(HoverflyMode.CAPTURE);
-        break;
-      default:
-        throw new IllegalArgumentException();
+      case "simulate" -> hoverfly.simulate(
+          SimulationSource.url(
+              BigQueryEndToEndTest.class
+                  .getClassLoader()
+                  .getResource("BigQueryEndToEndSpec.json")));
+      case "capture" -> hoverfly.resetMode(HoverflyMode.CAPTURE);
+      default -> throw new IllegalArgumentException();
     }
   }
 

--- a/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -139,11 +139,12 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
         .settings()
         .config()
         .getString("pekko.connectors.google.bigquery.test.e2e-mode")) {
-      case "simulate" -> hoverfly.simulate(
-          SimulationSource.url(
-              BigQueryEndToEndTest.class
-                  .getClassLoader()
-                  .getResource("BigQueryEndToEndSpec.json")));
+      case "simulate" ->
+          hoverfly.simulate(
+              SimulationSource.url(
+                  BigQueryEndToEndTest.class
+                      .getClassLoader()
+                      .getResource("BigQueryEndToEndSpec.json")));
       case "capture" -> hoverfly.resetMode(HoverflyMode.CAPTURE);
       default -> throw new IllegalArgumentException();
     }

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -103,27 +103,28 @@ public class XmlParsingTest {
                 StringBuilder::new,
                 (textBuffer, parseEvent) -> {
                   // aggregation function
-                  switch (parseEvent.marker()) {
-                    case XMLStartElement:
+                  return switch (parseEvent.marker()) {
+                    case XMLStartElement -> {
                       textBuffer.delete(0, textBuffer.length());
-                      return Pair.create(textBuffer, Optional.<String>empty());
-                    case XMLEndElement:
+                      yield Pair.create(textBuffer, Optional.<String>empty());
+                    }
+                    case XMLEndElement -> {
                       EndElement s = (EndElement) parseEvent;
-                      switch (s.localName()) {
-                        case "elem":
+                      yield switch (s.localName()) {
+                        case "elem" -> {
                           String text = textBuffer.toString();
-                          return Pair.create(textBuffer, Optional.of(text));
-                        default:
-                          return Pair.create(textBuffer, Optional.<String>empty());
-                      }
-                    case XMLCharacters:
-                    case XMLCData:
+                          yield Pair.create(textBuffer, Optional.of(text));
+                        }
+                        default -> Pair.create(textBuffer, Optional.<String>empty());
+                      };
+                    }
+                    case XMLCharacters, XMLCData -> {
                       TextEvent t = (TextEvent) parseEvent;
                       textBuffer.append(t.text());
-                      return Pair.create(textBuffer, Optional.<String>empty());
-                    default:
-                      return Pair.create(textBuffer, Optional.<String>empty());
-                  }
+                      yield Pair.create(textBuffer, Optional.<String>empty());
+                    }
+                    default -> Pair.create(textBuffer, Optional.<String>empty());
+                  };
                 },
                 textBuffer -> Optional.of(Optional.of(textBuffer.toString())))
             .via(Flow.flattenOptional())


### PR DESCRIPTION
## Summary
- Migrate switch statements to enhanced switch syntax and switch expressions (Java 14+ API)
- 2 files updated: XmlParsingTest (nested switch expressions with yield), BigQueryEndToEndTest (enhanced switch)
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17