### PR TITLE
refactor: use pattern matching instanceof (Java 16+)

### DIFF
--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -214,8 +214,7 @@ public class MqttFlowTest {
                                     new ConnAck(
                                         ConnAckFlags.None(),
                                         ConnAckReturnCode.ConnectionAccepted())));
-                          } else if (cp instanceof Subscribe) {
-                            Subscribe subscribe = (Subscribe) cp;
+                          } else if (cp instanceof Subscribe subscribe) {
                             Collection<Tuple2<String, ControlPacketFlags>> topicFilters =
                                 JavaConverters.asJavaCollectionConverter(subscribe.topicFilters())
                                     .asJavaCollection();


### PR DESCRIPTION
## Summary
- Migrate old-style `instanceof` checks with explicit casts to Java 16+ pattern matching instanceof
- 1 file updated: MqttFlowTest (1 instanceof + cast pattern migrated)
- Most files already used pattern matching; remaining instanceof checks were pure boolean tests (no cast)

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17