### PR TITLE
refactor: migrate .toArray() to .toArray(T[]::new) (Java 11+)

### DIFF
--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -95,7 +95,7 @@ public class CassandraFlowTest {
             .map(row -> row.getInt("id"))
             .runWith(Sink.seq(), system);
     List<Integer> rows = await(select);
-    assertThat(new ArrayList<>(rows), hasItems(data.toArray()));
+    assertThat(new ArrayList<>(rows), hasItems(data.toArray(Integer[]::new)));
   }
 
   @Test
@@ -140,7 +140,7 @@ public class CassandraFlowTest {
             .map(row -> new Person(row.getInt("id"), row.getString("name"), row.getString("city")))
             .runWith(Sink.seq(), system);
     List<Person> rows = await(select);
-    assertThat(new ArrayList<>(rows), hasItems(persons.toArray()));
+    assertThat(new ArrayList<>(rows), hasItems(persons.toArray(Person[]::new)));
   }
 
   @Test
@@ -187,7 +187,9 @@ public class CassandraFlowTest {
             .map(row -> new Person(row.getInt("id"), row.getString("name"), row.getString("city")))
             .runWith(Sink.seq(), system);
     List<Person> rows = await(select);
-    assertThat(new ArrayList<>(rows), hasItems(persons.stream().map(p -> p.first()).toArray()));
+    assertThat(
+        new ArrayList<>(rows),
+        hasItems(persons.stream().map(p -> p.first()).toArray(Person[]::new)));
   }
 
   public record Person(int id, String name, String city) {}

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -118,7 +118,7 @@ public class CassandraSourceTest {
     // #cql
     List<Integer> rows = await(select);
 
-    assertThat(new ArrayList<>(rows), hasItems(data.toArray()));
+    assertThat(new ArrayList<>(rows), hasItems(data.toArray(Integer[]::new)));
   }
 
   @Test
@@ -150,7 +150,7 @@ public class CassandraSourceTest {
             .map(r -> r.getInt("id"))
             .runWith(Sink.seq(), system);
     // #statement
-    assertThat(new ArrayList<>(await(select)), hasItems(data.toArray()));
+    assertThat(new ArrayList<>(await(select)), hasItems(data.toArray(Integer[]::new)));
   }
 
   public void compileOnlyDiscovery() {

--- a/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
@@ -42,6 +42,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 public class HdfsReaderTest {
   @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
@@ -80,8 +81,10 @@ public class HdfsReaderTest {
     }
 
     assertArrayEquals(
-        readData.toArray(),
-        data.stream().flatMap(bs -> bs.utf8String().chars().mapToObj(i -> (char) i)).toArray());
+        readData.toArray(Character[]::new),
+        data.stream()
+            .flatMap(bs -> bs.utf8String().chars().mapToObj(i -> (char) i))
+            .toArray(Character[]::new));
   }
 
   @Test
@@ -116,8 +119,10 @@ public class HdfsReaderTest {
     }
 
     assertArrayEquals(
-        readData.toArray(),
-        content.stream().flatMap(bs -> bs.utf8String().chars().mapToObj(i -> (char) i)).toArray());
+        readData.toArray(Character[]::new),
+        content.stream()
+            .flatMap(bs -> bs.utf8String().chars().mapToObj(i -> (char) i))
+            .toArray(Character[]::new));
   }
 
   @Test
@@ -151,7 +156,7 @@ public class HdfsReaderTest {
       readData.addAll(result);
     }
 
-    assertArrayEquals(readData.toArray(), content.toArray());
+    assertEquals(readData, content);
   }
 
   @BeforeClass


### PR DESCRIPTION
## Summary
- Migrate `.toArray()` → `.toArray(Character[]::new)` in `HdfsReaderTest.java` (4 occurrences)
- Replace `assertArrayEquals(readData.toArray(), content.toArray())` with `assertEquals(readData, content)` in `HdfsReaderTest.java` (avoids generic array creation)
- Migrate `.toArray()` → `.toArray(Integer[]::new)` in `CassandraSourceTest.java` (2 occurrences) and `CassandraFlowTest.java` (1 occurrence)
- Migrate `.toArray()` → `.toArray(Person[]::new)` in `CassandraFlowTest.java` (2 occurrences)

Java 11 added `Collection.toArray(IntFunction<T[]>)` and `Stream.toArray(IntFunction<T[]>)` which produce type-safe arrays instead of `Object[]`.

## Test plan
- [x] `sbt javafmtAll` — formatted
- [x] Both `hdfs` and `cassandra` modules compile successfully
- [ ] CI validates full test suite

Part of the Java 17 modernization effort.