### PR TITLE
refactor: migrate JUnit 4 to JUnit 6.1.0

### DIFF
--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -26,7 +26,8 @@ import org.apache.pekko.stream.connectors.amqp.javadsl.AmqpRpcFlow;
 import org.apache.pekko.stream.connectors.amqp.javadsl.AmqpSink;
 import org.apache.pekko.stream.connectors.amqp.javadsl.AmqpSource;
 import org.apache.pekko.stream.connectors.amqp.javadsl.CommittableReadResult;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -37,7 +38,7 @@ import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.time.Duration;
 import java.util.*;
@@ -45,26 +46,25 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /** Needs a local running AMQP server on the default port with no password. */
+@ExtendWith(LogCapturingExtension.class)
 public class AmqpDocsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
   }

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -15,23 +15,23 @@ package org.apache.pekko.stream.connectors.amqp.javadsl;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.pekko.stream.connectors.amqp.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.ConnectException;
 
+@ExtendWith(LogCapturingExtension.class)
 public class AmqpConnectionProvidersTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void LocalAmqpConnectionCreatesNewConnection() throws Exception {

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
@@ -21,7 +21,8 @@ import org.apache.pekko.stream.KillSwitches;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.UniqueKillSwitch;
 import org.apache.pekko.stream.connectors.amqp.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -32,7 +33,7 @@ import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import com.rabbitmq.client.AuthenticationFailureException;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import scala.collection.JavaConverters;
 import scala.concurrent.duration.Duration;
 
@@ -42,35 +43,34 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /** Needs a local running AMQP server on the default port with no password. */
+@ExtendWith(LogCapturingExtension.class)
 public class AmqpConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
   }
 
   private AmqpConnectionProvider connectionProvider = AmqpLocalConnectionProvider.getInstance();
 
-  @Test(expected = ConnectException.class)
-  public void throwIfCanNotConnect() throws Throwable {
+  @Test
+  public void throwIfCanNotConnect() {
     final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
@@ -88,15 +88,19 @@ public class AmqpConnectorsTest {
     final CompletionStage<Done> result =
         Source.from(input).map(ByteString::fromString).runWith(amqpSink, system);
 
-    try {
-      result.toCompletableFuture().get();
-    } catch (ExecutionException e) {
-      throw e.getCause();
-    }
+    Assertions.assertThrows(
+        ConnectException.class,
+        () -> {
+          try {
+            result.toCompletableFuture().get();
+          } catch (ExecutionException e) {
+            throw e.getCause();
+          }
+        });
   }
 
-  @Test(expected = AuthenticationFailureException.class)
-  public void throwWithWrongCredentials() throws Throwable {
+  @Test
+  public void throwWithWrongCredentials() {
     final String queueName = "amqp-conn-it-spec-simple-queue-" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
@@ -116,11 +120,15 @@ public class AmqpConnectorsTest {
     final CompletionStage<Done> result =
         Source.from(input).map(ByteString::fromString).runWith(amqpSink, system);
 
-    try {
-      result.toCompletableFuture().get();
-    } catch (ExecutionException e) {
-      throw e.getCause();
-    }
+    Assertions.assertThrows(
+        AuthenticationFailureException.class,
+        () -> {
+          try {
+            result.toCompletableFuture().get();
+          } catch (ExecutionException e) {
+            throw e.getCause();
+          }
+        });
     // assertEquals(input, result.toCompletableFuture().get(3, TimeUnit.SECONDS).stream().map(m ->
     // m.bytes().utf8String()).toList());
   }

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
@@ -21,7 +21,6 @@ import scala.collection.JavaConverters;
 
 import org.junit.jupiter.api.BeforeAll;
 
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -66,9 +65,10 @@ public class AmqpFlowTest {
         .withConfirmationTimeout(Duration.ofMillis(200));
   }
 
-  @Test
-  public void shouldEmitConfirmationForPublishedMessagesInSimpleFlow() {
-    shouldEmitConfirmationForPublishedMessages(AmqpFlow.create(settings(false)));
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void shouldEmitConfirmationForPublishedMessagesInSimpleFlow(boolean reuseByteArray) {
+    shouldEmitConfirmationForPublishedMessages(AmqpFlow.create(settings(reuseByteArray)));
   }
 
   @ParameterizedTest

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
@@ -19,13 +19,11 @@ import java.util.concurrent.CompletionStage;
 
 import scala.collection.JavaConverters;
 
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameter;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
@@ -35,7 +33,8 @@ import org.apache.pekko.stream.connectors.amqp.AmqpWriteSettings;
 import org.apache.pekko.stream.connectors.amqp.QueueDeclaration;
 import org.apache.pekko.stream.connectors.amqp.WriteMessage;
 import org.apache.pekko.stream.connectors.amqp.WriteResult;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Keep;
@@ -45,27 +44,17 @@ import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.util.ByteString;
 
 /** Needs a local running AMQP server on the default port with no password. */
-@RunWith(Parameterized.class)
+@ExtendWith(LogCapturingExtension.class)
 public class AmqpFlowTest {
-
-  @Parameters
-  public static Iterable<? extends Object> data() {
-    return List.of(false, true);
-  }
-
-  /** This value is initialized with values from data() array */
-  @Parameter public boolean reuseByteArray;
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
 
-  private AmqpWriteSettings settings() {
+  private AmqpWriteSettings settings(boolean reuseByteArray) {
     final String queueName = "amqp-flow-spec" + System.currentTimeMillis();
     final QueueDeclaration queueDeclaration = QueueDeclaration.create(queueName);
 
@@ -79,17 +68,22 @@ public class AmqpFlowTest {
 
   @Test
   public void shouldEmitConfirmationForPublishedMessagesInSimpleFlow() {
-    shouldEmitConfirmationForPublishedMessages(AmqpFlow.create(settings()));
+    shouldEmitConfirmationForPublishedMessages(AmqpFlow.create(settings(false)));
   }
 
-  @Test
-  public void shouldEmitConfirmationForPublishedMessagesInFlowWithConfirm() {
-    shouldEmitConfirmationForPublishedMessages(AmqpFlow.createWithConfirm(settings()));
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void shouldEmitConfirmationForPublishedMessagesInFlowWithConfirm(boolean reuseByteArray) {
+    shouldEmitConfirmationForPublishedMessages(
+        AmqpFlow.createWithConfirm(settings(reuseByteArray)));
   }
 
-  @Test
-  public void shouldEmitConfirmationForPublishedMessagesInFlowWithConfirmUnordered() {
-    shouldEmitConfirmationForPublishedMessages(AmqpFlow.createWithConfirmUnordered(settings()));
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void shouldEmitConfirmationForPublishedMessagesInFlowWithConfirmUnordered(
+      boolean reuseByteArray) {
+    shouldEmitConfirmationForPublishedMessages(
+        AmqpFlow.createWithConfirmUnordered(settings(reuseByteArray)));
   }
 
   private void shouldEmitConfirmationForPublishedMessages(
@@ -111,14 +105,16 @@ public class AmqpFlowTest {
         .expectNextN(JavaConverters.asScalaBufferConverter(expectedOutput).asScala().toList());
   }
 
-  @Test
-  public void shouldPropagateContextInSimpleFlow() {
-    shouldPropagateContext(AmqpFlowWithContext.create(settings()));
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void shouldPropagateContextInSimpleFlow(boolean reuseByteArray) {
+    shouldPropagateContext(AmqpFlowWithContext.create(settings(reuseByteArray)));
   }
 
-  @Test
-  public void shouldPropagateContextInFlowWithConfirm() {
-    shouldPropagateContext(AmqpFlowWithContext.createWithConfirm(settings()));
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void shouldPropagateContextInFlowWithConfirm(boolean reuseByteArray) {
+    shouldPropagateContext(AmqpFlowWithContext.createWithConfirm(settings(reuseByteArray)));
   }
 
   private void shouldPropagateContext(
@@ -143,10 +139,11 @@ public class AmqpFlowTest {
         .expectNextN(JavaConverters.asScalaBufferConverter(expectedOutput).asScala().toList());
   }
 
-  @Test
-  public void shouldPropagatePassThrough() {
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void shouldPropagatePassThrough(boolean reuseByteArray) {
     Flow<Pair<WriteMessage, String>, Pair<WriteResult, String>, CompletionStage<Done>> flow =
-        AmqpFlow.createWithConfirmAndPassThroughUnordered(settings());
+        AmqpFlow.createWithConfirmAndPassThroughUnordered(settings(reuseByteArray));
 
     final List<String> input = List.of("one", "two", "three", "four", "five");
     final List<Pair<WriteResult, String>> expectedOutput =

--- a/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
+++ b/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
@@ -17,7 +17,8 @@ import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.avroparquet.javadsl.AvroParquetSink;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
@@ -28,10 +29,10 @@ import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.avro.AvroReadSupport;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetReader;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -54,9 +55,8 @@ import org.apache.parquet.hadoop.util.HadoopInputFile;
 
 // #init-writer
 
+@ExtendWith(LogCapturingExtension.class)
 public class AvroParquetSinkTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Schema schema =
       new Schema.Parser()
@@ -68,7 +68,7 @@ public class AvroParquetSinkTest {
   private String folder = "target/javaTestFolder";
   private final String file = "./" + folder + "/test.parquet";
 
-  @Before
+  @BeforeEach
   public void setup() {
     system = ActorSystem.create();
     conf.setBoolean(AvroReadSupport.AVRO_COMPATIBILITY, true);
@@ -122,7 +122,7 @@ public class AvroParquetSinkTest {
     return expectedRecords.size();
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaksAndDeleteCreatedFiles() {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
     TestKit.shutdownActorSystem(system);

--- a/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
+++ b/avroparquet/src/test/java/docs/javadsl/AvroParquetSinkTest.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static junit.framework.TestCase.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // #init-writer
 import org.apache.parquet.hadoop.ParquetWriter;

--- a/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
+++ b/aws-event-bridge/src/test/java/docs/javadsl/EventBridgePublisherTest.java
@@ -31,9 +31,9 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.eventbridge.EventBridgeAsyncClient;
 // #init-client
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.eventbridge.model.CreateEventBusRequest;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
@@ -62,7 +62,7 @@ public class EventBridgePublisherTest {
     return PutEventsRequest.builder().entries(detailEntry(detail)).build();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws ExecutionException, InterruptedException {
     system = ActorSystem.create("EventBridgePublisherTest");
     eventBridgeClient = createEventBridgeClient();
@@ -76,7 +76,7 @@ public class EventBridgePublisherTest {
             .eventBusArn();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() {
     TestKit.shutdownActorSystem(system);
   }

--- a/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
+++ b/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
@@ -16,13 +16,14 @@ package docs.javadsl;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awslambda.javadsl.AwsLambdaFlow;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
@@ -32,30 +33,29 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@ExtendWith(LogCapturingExtension.class)
 public class AwsLambdaFlowTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static LambdaAsyncClient awsLambdaClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     awsLambdaClient = mock(LambdaAsyncClient.class);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(
         org.apache.pekko.stream.Materializer.matFromSystem(system));

--- a/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
+++ b/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
@@ -25,7 +25,8 @@ import org.apache.pekko.stream.connectors.azure.storagequeue.javadsl.AzureQueueS
 import org.apache.pekko.stream.connectors.azure.storagequeue.javadsl.AzureQueueWithTimeoutsSink;
 import org.apache.pekko.stream.connectors.azure.storagequeue.javadsl.MessageAndDeleteOrUpdate;
 import org.apache.pekko.stream.connectors.azure.storagequeue.javadsl.MessageWithTimeouts;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
@@ -41,10 +42,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JavaDslTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static final String storageConnectionString = System.getenv("AZURE_CONNECTION_STRING");
@@ -64,7 +65,7 @@ public class JavaDslTest {
 
   private static final CloudQueue queue = queueSupplier.get();
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws StorageException {
     system = ActorSystem.create();
 
@@ -73,7 +74,7 @@ public class JavaDslTest {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws StorageException {
     TestKit.shutdownActorSystem(system);
     if (queue != null) {
@@ -81,14 +82,14 @@ public class JavaDslTest {
     }
   }
 
-  @Before
+  @BeforeEach
   public void clearQueue() throws StorageException {
     if (queue != null) {
       queue.clear();
     }
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(
         org.apache.pekko.stream.Materializer.matFromSystem(system));
@@ -97,7 +98,7 @@ public class JavaDslTest {
   @Test
   public void testAzureQueueSink()
       throws StorageException, InterruptedException, ExecutionException, TimeoutException {
-    Assume.assumeNotNull(queue);
+    Assumptions.assumeTrue(queue != null);
     final Source<Integer, NotUsed> sourceInt = Source.range(1, 10);
     final Source<CloudQueueMessage, NotUsed> source =
         sourceInt.map(i -> new CloudQueueMessage("Java Azure Cloud Test " + i.toString()));
@@ -107,13 +108,13 @@ public class JavaDslTest {
 
     source.runWith(sink, system).toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-    Assert.assertNotNull(queue.retrieveMessage());
+    Assertions.assertNotNull(queue.retrieveMessage());
   }
 
   @Test
   public void testAzureQueueWithTimeoutsSink()
       throws StorageException, InterruptedException, ExecutionException, TimeoutException {
-    Assume.assumeNotNull(queue);
+    Assumptions.assumeTrue(queue != null);
     final Source<Integer, NotUsed> sourceInt = Source.range(1, 10);
     final Source<MessageWithTimeouts, NotUsed> source =
         sourceInt.map(
@@ -126,7 +127,7 @@ public class JavaDslTest {
 
     source.runWith(sink, system).toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-    Assert.assertNull(
+    Assertions.assertNull(
         queue
             .retrieveMessage()); // There should be no message because of initial visibility timeout
   }
@@ -134,7 +135,7 @@ public class JavaDslTest {
   @Test
   public void testAzureQueueSource()
       throws StorageException, InterruptedException, ExecutionException, TimeoutException {
-    Assume.assumeNotNull(queue);
+    Assumptions.assumeTrue(queue != null);
 
     // Queue 10 Messages
     for (int i = 0; i < 10; i++) {
@@ -152,7 +153,7 @@ public class JavaDslTest {
   @Test
   public void testAzureQueueDeleteSink()
       throws StorageException, InterruptedException, ExecutionException, TimeoutException {
-    Assume.assumeNotNull(queue);
+    Assumptions.assumeTrue(queue != null);
 
     // Queue 10 Messages
     for (int i = 0; i < 10; i++) {
@@ -172,13 +173,13 @@ public class JavaDslTest {
 
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-    Assert.assertNull(queue.retrieveMessage());
+    Assertions.assertNull(queue.retrieveMessage());
   }
 
   @Test
   public void testAzureQueueDeleteOrUpdateSink()
       throws StorageException, InterruptedException, ExecutionException, TimeoutException {
-    Assume.assumeNotNull(queue);
+    Assumptions.assumeTrue(queue != null);
 
     // Queue 10 Messages
     for (int i = 0; i < 10; i++) {
@@ -202,6 +203,6 @@ public class JavaDslTest {
 
     done.toCompletableFuture().get(10, TimeUnit.SECONDS);
 
-    Assert.assertNull(queue.retrieveMessage());
+    Assertions.assertNull(queue.retrieveMessage());
   }
 }

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@
  */
 
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
+import com.github.sbt.junit.jupiter.sbt.Import.JupiterKeys
 
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := false
@@ -18,6 +19,10 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 
 ThisBuild / evictionErrorLevel := Level.Info
+
+// JUnit 6.1.0 version overrides
+ThisBuild / JupiterKeys.junitJupiterVersion := "6.1.0"
+ThisBuild / JupiterKeys.junitPlatformVersion := "6.1.0"
 
 lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](
   amqp,

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,6 @@ ThisBuild / evictionErrorLevel := Level.Info
 
 // JUnit 6.1.0 version overrides
 ThisBuild / JupiterKeys.junitJupiterVersion := "6.1.0"
-ThisBuild / JupiterKeys.junitPlatformVersion := "6.1.0"
 
 lazy val userProjects: Seq[ProjectReference] = List[ProjectReference](
   amqp,

--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -21,7 +21,8 @@ import org.apache.pekko.japi.function.Function2;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.cassandra.CassandraWriteSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraFlow;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.SourceWithContext;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -31,10 +32,10 @@ import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSource;
 import org.apache.pekko.stream.connectors.cassandra.scaladsl.CassandraAccess;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,19 +46,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import static docs.javadsl.CassandraTestHelper.await;
 
+@ExtendWith(LogCapturingExtension.class)
 public class CassandraFlowTest {
   static final String TEST_NAME = "CassandraFlowTest";
 
   static CassandraTestHelper helper;
 
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
-
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     helper = new CassandraTestHelper(TEST_NAME);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     helper.shutdown();
   }

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -24,16 +24,17 @@ import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSessionRegi
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSource;
 // #cql
 import org.apache.pekko.stream.connectors.cassandra.scaladsl.CassandraAccess;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 // #statement
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 // #statement
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -45,6 +46,7 @@ import static docs.javadsl.CassandraTestHelper.await;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(LogCapturingExtension.class)
 public class CassandraSourceTest {
   static final String TEST_NAME = "CassandraSourceTest";
 
@@ -53,9 +55,7 @@ public class CassandraSourceTest {
   static String idtable;
   static final List<Integer> data = List.of(1, 2, 3, 4, 5, 6, 7, 8);
 
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
-
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws InterruptedException, ExecutionException, TimeoutException {
 
     helper = new CassandraTestHelper(TEST_NAME);
@@ -73,7 +73,7 @@ public class CassandraSourceTest {
             data.stream().map(i -> "INSERT INTO " + idtable + "(id) VALUES (" + i + ")").toList()));
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     helper.shutdown();
   }

--- a/cassandra/src/test/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraLifecycle.scala
+++ b/cassandra/src/test/scala/org/apache/pekko/stream/connectors/cassandra/scaladsl/CassandraLifecycle.scala
@@ -103,7 +103,7 @@ trait CassandraLifecycle extends BeforeAndAfterAll with TestKitBase with Cassand
     PatienceConfig(timeout = 4.seconds, interval = 50.millis)
 
   override protected def beforeAll(): Unit = {
-    createKeyspace(keyspaceName).futureValue
+    createKeyspace(keyspaceName).futureValue(PatienceConfiguration.Timeout(15.seconds))
     super.beforeAll()
   }
 

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -27,7 +27,8 @@ import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseFlow;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSource;
 import org.apache.pekko.stream.connectors.couchbase.testing.CouchbaseSupportClass;
 import org.apache.pekko.stream.connectors.couchbase.testing.TestObject;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
@@ -49,7 +50,7 @@ import com.couchbase.client.java.query.N1qlQuery;
 // #n1ql
 import com.couchbase.client.java.query.SimpleN1qlQuery;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -77,14 +78,13 @@ import scala.concurrent.duration.FiniteDuration;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class CouchbaseExamplesTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final CouchbaseSupportClass support = new CouchbaseSupportClass();
   private static final CouchbaseSessionSettings sessionSettings = support.sessionSettings();
@@ -94,7 +94,7 @@ public class CouchbaseExamplesTest {
   private static TestObject sampleData;
   private static List<TestObject> sampleSequence;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     support.beforeAll();
     actorSystem = support.actorSystem();
@@ -102,12 +102,12 @@ public class CouchbaseExamplesTest {
     sampleSequence = support.sampleJavaList();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     support.afterAll();
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(actorSystem));
   }
@@ -305,7 +305,7 @@ public class CouchbaseExamplesTest {
     // #upsertDocWithResult
 
     assertThat(writeResults.size(), is(sampleSequence.size()));
-    assertTrue("unexpected failed writes", failedDocs.isEmpty());
+    assertTrue(failedDocs.isEmpty(), "unexpected failed writes");
   }
 
   @Test
@@ -330,8 +330,8 @@ public class CouchbaseExamplesTest {
     assert (document.content().get("value") == "FirstReplace");
   }
 
-  @Test(expected = DocumentDoesNotExistException.class)
-  public void replaceFailsWhenDocumentDoesntExists() throws Throwable {
+  @Test
+  public void replaceFailsWhenDocumentDoesntExists() {
 
     support.cleanAllInBucket(bucketName);
 
@@ -347,11 +347,15 @@ public class CouchbaseExamplesTest {
             .runWith(Sink.head(), actorSystem);
     // #replace
 
-    try {
-      jsonDocumentReplace.toCompletableFuture().get(3, TimeUnit.SECONDS);
-    } catch (ExecutionException ex) {
-      throw ex.getCause();
-    }
+    Assertions.assertThrows(
+        DocumentDoesNotExistException.class,
+        () -> {
+          try {
+            jsonDocumentReplace.toCompletableFuture().get(3, TimeUnit.SECONDS);
+          } catch (ExecutionException ex) {
+            throw ex.getCause();
+          }
+        });
   }
 
   @Test

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -20,14 +20,15 @@ import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.DiscoverySupport;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSession;
 // #registry
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
@@ -36,20 +37,19 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(LogCapturingExtension.class)
 public class DiscoveryTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem actorSystem;
   private static final String bucketName = "pekko";
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() {
     Config config = ConfigFactory.parseResources("discovery.conf");
     actorSystem = ActorSystem.create("DiscoveryTest", config);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     TestKit.shutdownActorSystem(actorSystem);
   }

--- a/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvFormattingTest.java
@@ -20,14 +20,15 @@ import org.apache.pekko.stream.connectors.csv.javadsl.CsvFormatting;
 import org.apache.pekko.stream.connectors.csv.javadsl.CsvQuotingStyle;
 
 // #import
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -42,8 +43,8 @@ import java.util.concurrent.TimeoutException;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(LogCapturingExtension.class)
 public class CsvFormattingTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -82,17 +83,17 @@ public class CsvFormattingTest {
     assertThat(result.utf8String(), equalTo("one,two,three\r\n"));
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }

--- a/csv/src/test/java/docs/javadsl/CsvParsingTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvParsingTest.java
@@ -17,14 +17,15 @@ import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.SystemMaterializer;
 import org.apache.pekko.stream.connectors.csv.MalformedCsvException;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 // #import
 import org.apache.pekko.stream.connectors.csv.javadsl.CsvParsing;
@@ -40,10 +41,10 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(LogCapturingExtension.class)
 public class CsvParsingTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -118,17 +119,17 @@ public class CsvParsingTest {
     assertThat(res.get(2), equalTo("\\c"));
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }

--- a/csv/src/test/java/docs/javadsl/CsvToMapTest.java
+++ b/csv/src/test/java/docs/javadsl/CsvToMapTest.java
@@ -20,14 +20,15 @@ import org.apache.pekko.stream.connectors.csv.javadsl.CsvParsing;
 import org.apache.pekko.stream.connectors.csv.javadsl.CsvToMap;
 
 // #import
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -39,8 +40,8 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(LogCapturingExtension.class)
 public class CsvToMapTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -339,17 +340,17 @@ public class CsvToMapTest {
     // #header-line
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }

--- a/doc-examples/src/test/java/org/apache/pekko/stream/connectors/eip/javadsl/PassThroughExamples.java
+++ b/doc-examples/src/test/java/org/apache/pekko/stream/connectors/eip/javadsl/PassThroughExamples.java
@@ -29,9 +29,9 @@ import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -80,12 +80,12 @@ public class PassThroughExamples {
     // #PassThroughTuple
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
@@ -136,7 +136,7 @@ class PassThroughFlowKafkaCommitExample {
     // #passThroughKafkaFlow
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create();
   }

--- a/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/ExampleTest.java
@@ -21,13 +21,14 @@ import org.apache.pekko.japi.Pair;
 // #init-client
 import org.apache.pekko.stream.connectors.dynamodb.DynamoDbOp;
 import org.apache.pekko.stream.connectors.dynamodb.javadsl.DynamoDb;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.SourceWithContext;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 // #init-client
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import scala.util.Try;
@@ -45,15 +46,15 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+@ExtendWith(LogCapturingExtension.class)
 public class ExampleTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static ActorSystem system;
   static DynamoDbAsyncClient client;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
 
     // #init-client
@@ -85,7 +86,7 @@ public class ExampleTest {
     ExampleTest.client = client;
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     client.close();
     TestKit.shutdownActorSystem(system);
@@ -104,8 +105,8 @@ public class ExampleTest {
     assertNotNull(result.tableNames());
   }
 
-  @Test(expected = ExecutionException.class)
-  public void allowMultipleRequests() throws Exception {
+  @Test
+  public void allowMultipleRequests() {
     // #flow
     Source<DescribeTableResponse, NotUsed> tableArnSource =
         Source.single(CreateTableRequest.builder().tableName("testTable").build())
@@ -121,11 +122,13 @@ public class ExampleTest {
     CompletionStage<List<DescribeTableResponse>> streamCompletion =
         tableArnSource.runWith(Sink.seq(), system);
     // exception expected
-    streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    Assertions.assertThrows(
+        ExecutionException.class,
+        () -> streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS));
   }
 
-  @Test(expected = ExecutionException.class)
-  public void flowWithContext() throws Throwable {
+  @Test
+  public void flowWithContext() {
     class SomeContext {}
 
     // #withContext
@@ -152,11 +155,13 @@ public class ExampleTest {
     CompletionStage<Pair<PutItemResponse, SomeContext>> streamCompletion =
         writtenSource.runWith(Sink.head(), system);
     // exception expected
-    streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS);
+    Assertions.assertThrows(
+        ExecutionException.class,
+        () -> streamCompletion.toCompletableFuture().get(5, TimeUnit.SECONDS));
   }
 
-  @Test(expected = ExecutionException.class)
-  public void paginated() throws Exception {
+  @Test
+  public void paginated() {
     // #paginated
     ScanRequest scanRequest = ScanRequest.builder().tableName("testTable").build();
 
@@ -166,11 +171,13 @@ public class ExampleTest {
     // #paginated
     CompletionStage<List<ScanResponse>> streamCompletion = scanPages.runWith(Sink.seq(), system);
     // exception expected
-    streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
+    Assertions.assertThrows(
+        ExecutionException.class,
+        () -> streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS));
   }
 
-  @Test(expected = ExecutionException.class)
-  public void flowPaginated() throws Exception {
+  @Test
+  public void flowPaginated() {
     ScanRequest scanRequest = ScanRequest.builder().tableName("testTable").build();
     // #paginated
     Source<ScanResponse, NotUsed> scanPageInFlow =
@@ -179,6 +186,8 @@ public class ExampleTest {
     CompletionStage<List<ScanResponse>> streamCompletion2 =
         scanPageInFlow.runWith(Sink.seq(), system);
     // exception expected
-    streamCompletion2.toCompletableFuture().get(1, TimeUnit.SECONDS);
+    Assertions.assertThrows(
+        ExecutionException.class,
+        () -> streamCompletion2.toCompletableFuture().get(1, TimeUnit.SECONDS));
   }
 }

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -15,10 +15,11 @@ package docs.javadsl;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 // #clientRetryConfig
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
@@ -32,8 +33,8 @@ import software.amazon.awssdk.retries.DefaultRetryStrategy;
 
 // #awsRetryConfiguration
 
+@ExtendWith(LogCapturingExtension.class)
 public class RetryTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void setup() throws Exception {

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
@@ -20,9 +20,7 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSou
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -30,14 +28,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(value = Parameterized.class)
 public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {
   private final ApiVersion apiVersion;
 
-  @Parameterized.Parameters(name = "{index}: port={0} api={1}")
   public static Iterable<Object[]> data() {
     return List.of(
         new Object[][] {
@@ -50,14 +46,12 @@ public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {
     this.apiVersion = apiVersion;
   }
 
-  @Parameterized.BeforeParam
   public static void beforeParam(
       int port, org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase esApiVersion)
       throws IOException {
     prepareIndex(port, esApiVersion);
   }
 
-  @Parameterized.AfterParam
   public static void afterParam() throws IOException {
     cleanIndex();
   }

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
@@ -20,39 +20,30 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSou
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {
-  private final ApiVersion apiVersion;
+  private ApiVersion apiVersion;
 
-  public static Iterable<Object[]> data() {
-    return List.of(
-        new Object[][] {
-          {9201, ApiVersion.V5},
-          {9202, ApiVersion.V7}
-        });
+  public static Stream<Arguments> data() {
+    return Stream.of(Arguments.of(9201, ApiVersion.V5), Arguments.of(9202, ApiVersion.V7));
   }
 
-  public ElasticsearchParameterizedTest(int port, ApiVersion apiVersion) {
-    this.apiVersion = apiVersion;
-  }
-
-  public static void beforeParam(
-      int port, org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase esApiVersion)
-      throws IOException {
-    prepareIndex(port, esApiVersion);
-  }
-
-  public static void afterParam() throws IOException {
+  @AfterEach
+  public void afterParam() throws IOException {
     cleanIndex();
   }
 
@@ -82,8 +73,11 @@ public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {
     // #es-params
   }
 
-  @Test
-  public void testUsingVersions() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testUsingVersions(int port, ApiVersion apiVersion) throws Exception {
+    this.apiVersion = apiVersion;
+    prepareIndex(port, apiVersion);
     // Since the scala-test does a lot more logic testing,
     // all we need to test here is that we can receive and send version
 
@@ -160,8 +154,11 @@ public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {
     assertEquals(false, success);
   }
 
-  @Test
-  public void testUsingVersionType() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testUsingVersionType(int port, ApiVersion apiVersion) throws Exception {
+    this.apiVersion = apiVersion;
+    prepareIndex(port, apiVersion);
     String indexName = "book-test-version-type";
     String typeName = "_doc";
 
@@ -202,8 +199,11 @@ public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {
     assertEquals(externalVersion, message.version().get());
   }
 
-  @Test
-  public void testMultipleIndicesWithNoMatching() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testMultipleIndicesWithNoMatching(int port, ApiVersion apiVersion) throws Exception {
+    this.apiVersion = apiVersion;
+    prepareIndex(port, apiVersion);
     String indexName = "missing-*";
     String typeName = "_doc";
 

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -23,18 +23,18 @@ import org.apache.pekko.stream.connectors.elasticsearch.ElasticsearchConnectionS
 import org.apache.pekko.stream.connectors.elasticsearch.ElasticsearchParams;
 import org.apache.pekko.stream.connectors.elasticsearch.OpensearchApiVersion;
 import org.apache.pekko.stream.connectors.elasticsearch.OpensearchParams;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+@ExtendWith(LogCapturingExtension.class)
 public class ElasticsearchTestBase {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   protected static ElasticsearchConnectionSettings connectionSettings;
   protected static ActorSystem system;
@@ -53,13 +53,13 @@ public class ElasticsearchTestBase {
 
   // #define-class
 
-  @BeforeClass
+  @BeforeAll
   public static void setupBase() {
     system = ActorSystem.create();
     http = Http.get(system);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
@@ -22,27 +22,27 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSou
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ElasticsearchV5Test extends ElasticsearchTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     setupBase();
 
     prepareIndex(9201, ApiVersion.V5);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws IOException {
     cleanIndex();
   }

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
@@ -22,26 +22,26 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSou
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ElasticsearchV7Test extends ElasticsearchTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     setupBase();
 
     prepareIndex(9202, ApiVersion.V7);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws IOException {
     cleanIndex();
   }

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
@@ -20,9 +20,7 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSou
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.time.Duration;
@@ -30,14 +28,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(value = Parameterized.class)
 public class OpensearchParameterizedTest extends ElasticsearchTestBase {
   private final OpensearchApiVersion apiVersion;
 
-  @Parameterized.Parameters(name = "{index}: port={0} api={1}")
   public static Iterable<Object[]> data() {
     return List.of(new Object[][] {{9203, OpensearchApiVersion.V1}});
   }
@@ -46,14 +42,12 @@ public class OpensearchParameterizedTest extends ElasticsearchTestBase {
     this.apiVersion = apiVersion;
   }
 
-  @Parameterized.BeforeParam
   public static void beforeParam(
       int port, org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase osApiVersion)
       throws IOException {
     prepareIndex(port, osApiVersion);
   }
 
-  @Parameterized.AfterParam
   public static void afterParam() throws IOException {
     cleanIndex();
   }

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
@@ -20,35 +20,30 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSou
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpensearchParameterizedTest extends ElasticsearchTestBase {
-  private final OpensearchApiVersion apiVersion;
+  private OpensearchApiVersion apiVersion;
 
-  public static Iterable<Object[]> data() {
-    return List.of(new Object[][] {{9203, OpensearchApiVersion.V1}});
+  public static Stream<Arguments> data() {
+    return Stream.of(Arguments.of(9203, OpensearchApiVersion.V1));
   }
 
-  public OpensearchParameterizedTest(int port, OpensearchApiVersion apiVersion) {
-    this.apiVersion = apiVersion;
-  }
-
-  public static void beforeParam(
-      int port, org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase osApiVersion)
-      throws IOException {
-    prepareIndex(port, osApiVersion);
-  }
-
-  public static void afterParam() throws IOException {
+  @AfterEach
+  public void afterParam() throws IOException {
     cleanIndex();
   }
 
@@ -77,8 +72,11 @@ public class OpensearchParameterizedTest extends ElasticsearchTestBase {
     // #opensearch-params
   }
 
-  @Test
-  public void testUsingVersions() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testUsingVersions(int port, OpensearchApiVersion apiVersion) throws Exception {
+    this.apiVersion = apiVersion;
+    prepareIndex(port, apiVersion);
     // Since the scala-test does a lot more logic testing,
     // all we need to test here is that we can receive and send version
 
@@ -155,8 +153,11 @@ public class OpensearchParameterizedTest extends ElasticsearchTestBase {
     assertEquals(false, success);
   }
 
-  @Test
-  public void testUsingVersionType() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testUsingVersionType(int port, OpensearchApiVersion apiVersion) throws Exception {
+    this.apiVersion = apiVersion;
+    prepareIndex(port, apiVersion);
     String indexName = "book-test-version-type";
     String typeName = "_doc";
 
@@ -197,8 +198,12 @@ public class OpensearchParameterizedTest extends ElasticsearchTestBase {
     assertEquals(externalVersion, message.version().get());
   }
 
-  @Test
-  public void testMultipleIndicesWithNoMatching() throws Exception {
+  @ParameterizedTest
+  @MethodSource("data")
+  public void testMultipleIndicesWithNoMatching(int port, OpensearchApiVersion apiVersion)
+      throws Exception {
+    this.apiVersion = apiVersion;
+    prepareIndex(port, apiVersion);
     String indexName = "missing-*";
     String typeName = "_doc";
 

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
@@ -22,26 +22,26 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSou
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OpensearchV1Test extends ElasticsearchTestBase {
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws IOException {
     setupBase();
 
     prepareIndex(9203, OpensearchApiVersion.V1);
   }
 
-  @AfterClass
+  @AfterAll
   public static void shutdown() throws IOException {
     cleanIndex();
   }

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -24,14 +24,15 @@ import org.apache.pekko.stream.connectors.file.TarArchiveMetadata;
 import org.apache.pekko.stream.connectors.file.ZipArchiveMetadata;
 import org.apache.pekko.stream.connectors.file.javadsl.Archive;
 import org.apache.pekko.stream.connectors.file.javadsl.Directory;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.FileIO;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import static org.apache.pekko.util.ByteString.emptyByteString;
 
@@ -50,24 +51,24 @@ import java.util.concurrent.TimeUnit;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
 
+@ExtendWith(LogCapturingExtension.class)
 public class ArchiveTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
   private ArchiveHelper archiveHelper;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     archiveHelper = new ArchiveHelper();
   }
@@ -280,7 +281,7 @@ public class ArchiveTest {
     assertThat(file.exists(), is(true));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
   }

--- a/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
@@ -21,7 +21,8 @@ import org.apache.pekko.stream.connectors.file.DirectoryChange;
 // #minimal-sample
 import org.apache.pekko.stream.connectors.file.javadsl.DirectoryChangesSource;
 // #minimal-sample
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
@@ -30,7 +31,7 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
 import com.google.common.jimfs.WatchServiceConfiguration;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -41,28 +42,27 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class DirectoryChangesSourceTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private FileSystem fs;
   private Path testDir;
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     fs =
         Jimfs.newFileSystem(
@@ -141,7 +141,7 @@ public class DirectoryChangesSourceTest {
     probe.cancel();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
     fs.close();

--- a/file/src/test/java/docs/javadsl/DirectoryTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryTest.java
@@ -23,7 +23,8 @@ import org.apache.pekko.stream.connectors.file.javadsl.Directory;
 // #ls
 import java.nio.file.FileVisitOption;
 // #walk
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -32,7 +33,7 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -41,27 +42,27 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class DirectoryTest {
 
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
   private FileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setup() {
     fs = Jimfs.newFileSystem(Configuration.unix());
   }
@@ -173,7 +174,7 @@ public class DirectoryTest {
     assertTrue(Files.isDirectory(result.get(1)));
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fs.close();
     fs = null;

--- a/file/src/test/java/docs/javadsl/FileTailSourceTest.java
+++ b/file/src/test/java/docs/javadsl/FileTailSourceTest.java
@@ -20,7 +20,8 @@ import org.apache.pekko.stream.KillSwitches;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.UniqueKillSwitch;
 import org.apache.pekko.stream.connectors.file.DirectoryChange;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
@@ -30,7 +31,7 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
@@ -45,27 +46,26 @@ import java.util.concurrent.TimeoutException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.APPEND;
 import static java.nio.file.StandardOpenOption.WRITE;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class FileTailSourceTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
   private FileSystem fs;
 
-  @Before
+  @BeforeEach
   public void setup() {
     fs = Jimfs.newFileSystem(Configuration.unix());
   }
@@ -213,7 +213,7 @@ public class FileTailSourceTest {
     subscriber.expectComplete();
   }
 
-  @After
+  @AfterEach
   public void tearDown() throws Exception {
     fs.close();
     fs = null;

--- a/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
+++ b/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
@@ -20,12 +20,13 @@ import org.apache.pekko.japi.function.Creator;
 import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.file.javadsl.LogRotatorSink;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -37,25 +38,24 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class LogRotatorSinkTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws Exception {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void checkForStageLeaks() {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
   }

--- a/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
+++ b/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
@@ -19,16 +19,17 @@ import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.connectors.file.TarArchiveMetadata;
 import org.apache.pekko.stream.connectors.file.javadsl.Archive;
 import org.apache.pekko.stream.connectors.file.javadsl.Directory;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,22 +40,21 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
+@ExtendWith(LogCapturingExtension.class)
 public class NestedTarReaderTest {
   private static final Logger logger = LoggerFactory.getLogger(NestedTarReaderTest.class);
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final String TARGZ_EXT = "tar.gz";
   private static final int MAX_GUNZIP_CHUNK_SIZE = 64000;
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void beforeAll() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws Exception {
     TestKit.shutdownActorSystem(system);
   }

--- a/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
+++ b/ftp/src/test/java/docs/javadsl/FtpWritingTest.java
@@ -18,7 +18,8 @@ package docs.javadsl;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 // #create-settings
 import org.apache.pekko.stream.IOResult;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Compression;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.util.ByteString;
@@ -37,20 +38,19 @@ import java.net.InetAddress;
 import org.apache.pekko.stream.connectors.ftp.BaseFtpSupport;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(LogCapturingExtension.class)
 public class FtpWritingTest extends BaseFtpSupport {
 
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
-
-  @After
+  @AfterEach
   public void afterEach() {
     StreamTestKit.assertAllStagesStopped(getMaterializer());
     TestKit.shutdownActorSystem(getSystem());

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/BaseSupportImpl.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/BaseSupportImpl.java
@@ -15,7 +15,7 @@ package org.apache.pekko.stream.connectors.ftp;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
-import org.junit.After;
+import org.junit.jupiter.api.AfterEach;
 
 import java.io.File;
 import java.io.IOException;
@@ -44,7 +44,7 @@ public abstract class BaseSupportImpl implements BaseSupport, PekkoSupport {
   abstract Path getRootDir();
 
   @Override
-  @After
+  @AfterEach
   public void cleanFiles() {
     try {
       Files.walkFileTree(

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
@@ -23,16 +23,16 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.util.ByteString;
-import org.junit.Assert;
 
 import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 interface CommonFtpStageTest extends BaseSupport, PekkoSupport {
 
@@ -109,7 +109,7 @@ interface CommonFtpStageTest extends BaseSupport, PekkoSupport {
     byte[] actualStoredContent = getFtpFileContents(fileName);
 
     assertEquals(IOResult.createSuccessful(expectedNumOfBytes), result);
-    Assert.assertArrayEquals(actualStoredContent, getDefaultContent().getBytes());
+    assertArrayEquals(actualStoredContent, getDefaultContent().getBytes());
   }
 
   default void remove() throws Exception {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpStageTest.java
@@ -16,20 +16,20 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+
+import org.junit.jupiter.api.Test;
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class FtpStageTest extends BaseFtpSupport implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {
@@ -47,13 +47,13 @@ public class FtpStageTest extends BaseFtpSupport implements CommonFtpStageTest {
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void remove() throws Exception {
     CommonFtpStageTest.super.remove();
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void move() throws Exception {
     CommonFtpStageTest.super.move();
   }

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpWithProxyStageTest.java
@@ -16,13 +16,14 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -30,8 +31,8 @@ import java.net.Proxy;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class FtpWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =
@@ -53,13 +54,13 @@ public class FtpWithProxyStageTest extends BaseFtpSupport implements CommonFtpSt
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void remove() throws Exception {
     CommonFtpStageTest.super.remove();
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void move() throws Exception {
     CommonFtpStageTest.super.move();
   }

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsStageTest.java
@@ -16,20 +16,20 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftps;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class FtpsStageTest extends BaseFtpSupport implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsWithProxyStageTest.java
@@ -16,13 +16,14 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftps;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -30,9 +31,8 @@ import java.net.Proxy;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class FtpsWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final int PROXYPORT = 3128;
   private final Proxy PROXY =
@@ -54,13 +54,13 @@ public class FtpsWithProxyStageTest extends BaseFtpSupport implements CommonFtpS
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void remove() throws Exception {
     CommonFtpStageTest.super.remove();
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void move() throws Exception {
     CommonFtpStageTest.super.move();
   }

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/KeyFileSftpSourceTest.java
@@ -16,19 +16,19 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class KeyFileSftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/RawKeySftpSourceTest.java
@@ -16,21 +16,21 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class RawKeySftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpStageTest.java
@@ -16,21 +16,21 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class SftpStageTest extends BaseSftpSupport implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {
@@ -48,13 +48,13 @@ public class SftpStageTest extends BaseSftpSupport implements CommonFtpStageTest
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void remove() throws Exception {
     CommonFtpStageTest.super.remove();
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void move() throws Exception {
     CommonFtpStageTest.super.move();
   }

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpWithProxyStageTest.java
@@ -16,13 +16,14 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -30,9 +31,8 @@ import java.net.Proxy;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class SftpWithProxyStageTest extends BaseSftpSupport implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final Integer PROXYPORT = 3128;
   private final Proxy PROXY =
@@ -54,13 +54,13 @@ public class SftpWithProxyStageTest extends BaseSftpSupport implements CommonFtp
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void remove() throws Exception {
     CommonFtpStageTest.super.remove();
   }
 
   @Test
-  @Ignore("flakey, see https://github.com/akka/alpakka/issues/2126")
+  @Disabled("flakey, see https://github.com/akka/alpakka/issues/2126")
   public void move() throws Exception {
     CommonFtpStageTest.super.move();
   }

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/StrictHostCheckingSftpSourceTest.java
@@ -16,20 +16,20 @@ package org.apache.pekko.stream.connectors.ftp;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 import java.net.InetAddress;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class StrictHostCheckingSftpSourceTest extends BaseSftpSupport
     implements CommonFtpStageTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void listFiles() throws Exception {

--- a/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
@@ -19,21 +19,21 @@ import org.apache.pekko.stream.connectors.geode.GeodeSettings;
 import org.apache.pekko.stream.connectors.geode.RegionSettings;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
 import org.apache.pekko.stream.connectors.geode.javadsl.GeodeWithPoolSubscription;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
-import org.junit.Rule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Date;
 import java.util.List;
 
+@ExtendWith(LogCapturingExtension.class)
 public class GeodeBaseTestCase {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   protected static final Logger LOGGER = LoggerFactory.getLogger(GeodeFlowTestCase.class);
 
@@ -53,7 +53,7 @@ public class GeodeBaseTestCase {
 
   // #region
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
@@ -87,7 +87,7 @@ public class GeodeBaseTestCase {
     return geode;
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
@@ -17,21 +17,22 @@ import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.geode.javadsl.GeodeWithPoolSubscription;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
+@ExtendWith(LogCapturingExtension.class)
 public class GeodeContinuousSourceTestCase extends GeodeBaseTestCase {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void continuousSourceTest() throws ExecutionException, InterruptedException {

--- a/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
@@ -15,15 +15,16 @@ package docs.javadsl;
 
 import org.apache.pekko.Done;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
+@ExtendWith(LogCapturingExtension.class)
 public class GeodeFiniteSourceTestCase extends GeodeBaseTestCase {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void finiteSourceTest() throws ExecutionException, InterruptedException {

--- a/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
@@ -15,20 +15,21 @@ package docs.javadsl;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
+@ExtendWith(LogCapturingExtension.class)
 public class GeodeFlowTestCase extends GeodeBaseTestCase {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void flow() throws ExecutionException, InterruptedException {

--- a/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
@@ -16,19 +16,20 @@ package docs.javadsl;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.RunnableGraph;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
+@ExtendWith(LogCapturingExtension.class)
 public class GeodeSinkTestCase extends GeodeBaseTestCase {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void sinkTest() throws ExecutionException, InterruptedException {

--- a/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
+++ b/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
@@ -19,13 +19,14 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryS
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryStorageSpecBase;
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.scaladsl.BigQueryStorageAttributes;
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.scaladsl.GrpcBigQueryStorageReader;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 
 import com.google.cloud.bigquery.storage.v1.DataFormat;
 import com.google.cloud.bigquery.storage.v1.ReadSession;
 
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -33,11 +34,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(LogCapturingExtension.class)
 public class BigQueryStorageSpec extends BigQueryStorageSpecBase {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void filterResultsBasedOnRowRestrictionConfigured()
@@ -56,8 +56,8 @@ public class BigQueryStorageSpec extends BigQueryStorageSpecBase {
             .runWith(Sink.seq(), system());
 
     assertTrue(
-        "number of generic records should be more than 0",
-        bigQueryRecords.toCompletableFuture().get(5, TimeUnit.SECONDS).isEmpty());
+        bigQueryRecords.toCompletableFuture().get(5, TimeUnit.SECONDS).isEmpty(),
+        "number of generic records should be more than 0");
   }
 
   public Attributes mockBQReader() {
@@ -70,12 +70,12 @@ public class BigQueryStorageSpec extends BigQueryStorageSpecBase {
     return BigQueryStorageAttributes.reader(reader);
   }
 
-  @Before
+  @BeforeEach
   public void initialize() {
     startMock();
   }
 
-  @After
+  @AfterEach
   public void tearDown() {
     stopMock();
     system().terminate();

--- a/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -44,9 +44,9 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.specto.hoverfly.junit.core.Hoverfly;
 import io.specto.hoverfly.junit.core.HoverflyMode;
 import io.specto.hoverfly.junit.core.SimulationSource;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -58,7 +58,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class BigQueryEndToEndTest extends EndToEndHelper {
 
@@ -131,7 +131,7 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
                       TableFieldSchemaType.timestamp(),
                       Optional.of(TableFieldSchemaMode.required())))));
 
-  @BeforeClass
+  @BeforeAll
   public static void before() {
     hoverfly.start();
     switch (system
@@ -149,7 +149,7 @@ public class BigQueryEndToEndTest extends EndToEndHelper {
     }
   }
 
-  @AfterClass
+  @AfterAll
   public static void after() {
     hoverfly.close();
     system.terminate();

--- a/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
+++ b/google-cloud-pub-sub-grpc/src/test/java/docs/javadsl/IntegrationTest.java
@@ -24,16 +24,17 @@ import org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc.PubSubSettings
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc.javadsl.GooglePubSub;
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc.javadsl.GrpcPublisher;
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc.javadsl.PubSubAttributes;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.*;
 
 // #publish-single
 
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.List;
@@ -43,11 +44,11 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class IntegrationTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static final ActorSystem system = ActorSystem.create("IntegrationTest");
 
@@ -76,8 +77,8 @@ public class IntegrationTest {
     // #publish-single
 
     assertTrue(
-        "number of published messages should be more than 0",
-        publishedMessageIds.toCompletableFuture().get(2, TimeUnit.SECONDS).size() > 0);
+        publishedMessageIds.toCompletableFuture().get(2, TimeUnit.SECONDS).size() > 0,
+        "number of published messages should be more than 0");
   }
 
   @Test
@@ -105,8 +106,8 @@ public class IntegrationTest {
     // #publish-fast
 
     assertTrue(
-        "number of published messages should be more than 0",
-        published.toCompletableFuture().get(2, TimeUnit.SECONDS).size() > 0);
+        published.toCompletableFuture().get(2, TimeUnit.SECONDS).size() > 0,
+        "number of published messages should be more than 0");
   }
 
   @Test
@@ -143,9 +144,9 @@ public class IntegrationTest {
     Source.single(publishRequest).via(GooglePubSub.publish(1)).runWith(Sink.ignore(), system);
 
     assertEquals(
-        "received and expected messages not the same",
         msg,
-        first.toCompletableFuture().get(2, TimeUnit.SECONDS).getMessage().getData());
+        first.toCompletableFuture().get(2, TimeUnit.SECONDS).getMessage().getData(),
+        "received and expected messages not the same");
   }
 
   @Test
@@ -182,9 +183,9 @@ public class IntegrationTest {
     Source.single(publishRequest).via(GooglePubSub.publish(1)).runWith(Sink.ignore(), system);
 
     assertEquals(
-        "received and expected messages not the same",
         msg,
-        first.toCompletableFuture().get(2, TimeUnit.SECONDS).getMessage().getData());
+        first.toCompletableFuture().get(2, TimeUnit.SECONDS).getMessage().getData(),
+        "received and expected messages not the same");
   }
 
   @Test
@@ -341,7 +342,7 @@ public class IntegrationTest {
             .toCompletableFuture()
             .get(15, TimeUnit.SECONDS);
 
-    assertEquals("nacked message should be redelivered", msg, redelivered.getMessage().getData());
+    assertEquals(msg, redelivered.getMessage().getData(), "nacked message should be redelivered");
   }
 
   @Test
@@ -437,7 +438,7 @@ public class IntegrationTest {
             .toCompletableFuture()
             .get(15, TimeUnit.SECONDS);
 
-    assertEquals("should process all 3 messages", 3, result.size());
+    assertEquals(3, result.size(), "should process all 3 messages");
   }
 
   @Test
@@ -452,7 +453,7 @@ public class IntegrationTest {
         org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc.AckDeadlineDistribution.create();
 
     // initially should use default
-    assertEquals("initial deadline", 60, dist.currentDeadlineSeconds());
+    assertEquals(60, dist.currentDeadlineSeconds(), "initial deadline");
 
     // publish messages
     final String prefix = "adaptive-java-" + System.nanoTime();
@@ -489,9 +490,9 @@ public class IntegrationTest {
             .toCompletableFuture()
             .get(15, TimeUnit.SECONDS);
 
-    assertEquals("should process all messages", 2, result.size());
+    assertEquals(2, result.size(), "should process all messages");
     // adaptive deadline should be at least the minimum
-    assertTrue("deadline should be >= 10", dist.currentDeadlineSeconds() >= 10);
+    assertTrue(dist.currentDeadlineSeconds() >= 10, "deadline should be >= 10");
   }
 
   @Test
@@ -505,7 +506,7 @@ public class IntegrationTest {
     // #attributes
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     system.terminate();
   }

--- a/google-cloud-pub-sub-grpc/src/test/java/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesTest.java
+++ b/google-cloud-pub-sub-grpc/src/test/java/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/AutoExtendAckDeadlinesTest.java
@@ -17,7 +17,7 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.*;
@@ -32,8 +32,8 @@ import org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc.javadsl.GrpcSu
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc.javadsl.PubSubAttributes;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.AfterClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
 
 public class AutoExtendAckDeadlinesTest {
 
@@ -174,8 +174,8 @@ public class AutoExtendAckDeadlinesTest {
       fail("Expected AckDeadlineExtensionException");
     } catch (ExecutionException e) {
       assertTrue(
-          "Expected AckDeadlineExtensionException but got: " + e.getCause().getClass(),
-          e.getCause() instanceof AckDeadlineExtensionException);
+          e.getCause() instanceof AckDeadlineExtensionException,
+          "Expected AckDeadlineExtensionException but got: " + e.getCause().getClass());
       assertTrue(e.getCause().getMessage().contains("ticker failed"));
     }
   }
@@ -198,8 +198,8 @@ public class AutoExtendAckDeadlinesTest {
       fail("Expected AckDeadlineExtensionException");
     } catch (ExecutionException e) {
       assertTrue(
-          "Expected AckDeadlineExtensionException but got: " + e.getCause().getClass(),
-          e.getCause() instanceof AckDeadlineExtensionException);
+          e.getCause() instanceof AckDeadlineExtensionException,
+          "Expected AckDeadlineExtensionException but got: " + e.getCause().getClass());
       assertTrue(e.getCause().getMessage().contains("ticker failed"));
     }
   }
@@ -286,7 +286,7 @@ public class AutoExtendAckDeadlinesTest {
     assertEquals(3, result.size());
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() {
     system.terminate();
   }

--- a/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
+++ b/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
@@ -25,29 +25,29 @@ import org.apache.pekko.stream.connectors.googlecloud.storage.Bucket;
 import org.apache.pekko.stream.connectors.googlecloud.storage.StorageObject;
 import org.apache.pekko.stream.connectors.googlecloud.storage.javadsl.GCStorage;
 import org.apache.pekko.stream.connectors.googlecloud.storage.scaladsl.GCStorageWiremockBase;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
+@ExtendWith(LogCapturingExtension.class)
 public class GCStorageTest extends GCStorageWiremockBase {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private final ActorSystem actorSystem = system();
   private final GoogleSettings sampleSettings = GoogleSettings.create(system());
 
-  @After
+  @AfterEach
   public void afterAll() {
     this.stopWireMockServer();
   }

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -19,7 +19,8 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.hbase.HTableSettings;
 import org.apache.pekko.stream.connectors.hbase.javadsl.HTableStage;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -28,10 +29,10 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
@@ -42,19 +43,19 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class HBaseStageTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
@@ -21,7 +21,8 @@ import org.apache.pekko.stream.connectors.hdfs.*;
 import org.apache.pekko.stream.connectors.hdfs.javadsl.HdfsFlow;
 import org.apache.pekko.stream.connectors.hdfs.javadsl.HdfsSource;
 import org.apache.pekko.stream.connectors.hdfs.util.JavaTestUtils;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
@@ -33,17 +34,17 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.DefaultCodec;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class HdfsReaderTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static MiniDFSCluster hdfsCluster = null;
   private static ActorSystem system;
@@ -151,7 +152,7 @@ public class HdfsReaderTest {
     assertArrayEquals(readData.toArray(), content.toArray());
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     hdfsCluster = JavaTestUtils.setupCluster();
 
@@ -163,14 +164,14 @@ public class HdfsReaderTest {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     fs.close();
     hdfsCluster.shutdown();
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void afterEach() throws IOException {
     fs.delete(new Path(destination), true);
     fs.delete(settings.pathGenerator().apply(0L, 0L).getParent(), true);

--- a/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
@@ -20,7 +20,8 @@ import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.hdfs.*;
 import org.apache.pekko.stream.connectors.hdfs.javadsl.HdfsFlow;
 import org.apache.pekko.stream.connectors.hdfs.util.JavaTestUtils;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -35,7 +36,7 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.DefaultCodec;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import scala.concurrent.duration.Duration;
 
@@ -46,11 +47,11 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class HdfsWriterTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static MiniDFSCluster hdfsCluster = null;
   private static ActorSystem system;
@@ -473,7 +474,7 @@ public class HdfsWriterTest {
     JavaTestUtils.verifySequenceFile(fs, content, logs);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     hdfsCluster = JavaTestUtils.setupCluster();
 
@@ -487,14 +488,14 @@ public class HdfsWriterTest {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     fs.close();
     hdfsCluster.shutdown();
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void afterEach() throws IOException {
     fs.delete(new Path(destination), true);
     fs.delete(settings.pathGenerator().apply(0L, 0L).getParent(), true);

--- a/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
@@ -185,7 +185,7 @@ object JavaTestUtils extends TestUtils {
   type Pair[A, B] = pekko.japi.Pair[A, B]
   type Assertion = Unit
 
-  import org.junit.Assert._
+  import org.junit.jupiter.api.Assertions._
 
   import scala.jdk.CollectionConverters._
 

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
@@ -16,11 +16,12 @@ package docs.javadsl;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
@@ -34,33 +35,33 @@ import static docs.javadsl.TestUtils.dropDatabase;
 import static docs.javadsl.TestUtils.populateDatabase;
 import static docs.javadsl.TestUtils.setupConnection;
 
+@ExtendWith(LogCapturingExtension.class)
 public class InfluxDbSourceTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static InfluxDB influxDB;
 
   private static final String DATABASE_NAME = "InfluxDbSourceTest";
 
-  @BeforeClass
+  @BeforeAll
   public static void setupDatabase() {
     system = ActorSystem.create();
 
     influxDB = setupConnection(DATABASE_NAME);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     dropDatabase(influxDB, DATABASE_NAME);
     TestKit.shutdownActorSystem(system);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     populateDatabase(influxDB, InfluxDbSourceCpu.class);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     cleanDatabase(influxDB, DATABASE_NAME);
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
@@ -77,7 +78,7 @@ public class InfluxDbSourceTest {
 
     List<InfluxDbSourceCpu> cpus = rows.toCompletableFuture().get();
 
-    Assert.assertEquals(2, cpus.size());
+    Assertions.assertEquals(2, cpus.size());
   }
 
   @Test
@@ -90,10 +91,10 @@ public class InfluxDbSourceTest {
     List<QueryResult> queryResults = completionStage.toCompletableFuture().get();
     QueryResult queryResult = queryResults.get(0);
 
-    Assert.assertFalse(queryResult.hasError());
+    Assertions.assertFalse(queryResult.hasError());
 
     final int resultSize = queryResult.getResults().get(0).getSeries().get(0).getValues().size();
 
-    Assert.assertEquals(2, resultSize);
+    Assertions.assertEquals(2, resultSize);
   }
 }

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
@@ -23,12 +23,13 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.influxdb.InfluxDB;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
@@ -49,10 +50,10 @@ import static docs.javadsl.TestUtils.dropDatabase;
 import static docs.javadsl.TestUtils.populateDatabase;
 import static docs.javadsl.TestUtils.resultToPoint;
 import static docs.javadsl.TestUtils.setupConnection;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class InfluxDbTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static InfluxDB influxDB;
@@ -88,25 +89,25 @@ public class InfluxDbTest {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setupDatabase() {
     system = ActorSystem.create();
 
     influxDB = setupConnection(DATABASE_NAME);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     dropDatabase(influxDB, DATABASE_NAME);
     TestKit.shutdownActorSystem(system);
   }
 
-  @Before
+  @BeforeEach
   public void setUp() throws Exception {
     populateDatabase(influxDB, InfluxDbCpu.class);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     cleanDatabase(influxDB, DATABASE_NAME);
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
@@ -127,7 +128,7 @@ public class InfluxDbTest {
             .runWith(InfluxDbSink.typed(InfluxDbCpu.class, influxDB), system);
     // #run-typed
 
-    Assert.assertNotNull(completionStage.toCompletableFuture().get());
+    Assertions.assertNotNull(completionStage.toCompletableFuture().get());
 
     CompletionStage<List<Cpu>> sources =
         InfluxDbSource.typed(Cpu.class, InfluxDbReadSettings.Default(), influxDB, query)
@@ -149,7 +150,7 @@ public class InfluxDbTest {
             .runWith(InfluxDbSink.create(influxDB), system);
     // #run-query-result
 
-    Assert.assertNotNull(completionStage.toCompletableFuture().get());
+    Assertions.assertNotNull(completionStage.toCompletableFuture().get());
 
     List<QueryResult> queryResult =
         InfluxDbSource.create(influxDB, query)
@@ -182,7 +183,7 @@ public class InfluxDbTest {
     // #run-flow
 
     InfluxDbWriteResult<Point, NotUsed> influxDbWriteResult = completableFuture.get().get(0).get(0);
-    Assert.assertTrue(influxDbWriteResult.error().isEmpty());
+    Assertions.assertTrue(influxDbWriteResult.error().isEmpty());
   }
 
   @Test

--- a/ironmq/src/test/java/docs/javadsl/IronMqDocsTest.java
+++ b/ironmq/src/test/java/docs/javadsl/IronMqDocsTest.java
@@ -23,14 +23,15 @@ import org.apache.pekko.stream.connectors.ironmq.javadsl.*;
 
 // #imports
 import org.apache.pekko.stream.connectors.ironmq.impl.IronMqClientForJava;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
+import org.junit.jupiter.api.Test;
 import scala.concurrent.Await;
 
 import java.time.Duration;
@@ -38,10 +39,10 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class IronMqDocsTest extends IronMqClientForJava {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create();
   private static final Materializer materializer = Materializer.matFromSystem(system);
@@ -58,7 +59,7 @@ public class IronMqDocsTest extends IronMqClientForJava {
     super(system, materializer);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     TestKit.shutdownActorSystem(system);
   }

--- a/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
+++ b/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
@@ -16,13 +16,11 @@ package org.apache.pekko.stream.connectors.ironmq;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.ironmq.impl.IronMqClient;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.List;
 import java.util.UUID;
@@ -32,13 +30,12 @@ import static scala.jdk.javaapi.FutureConverters.*;
 import static scala.collection.JavaConverters.*;
 
 public abstract class UnitTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private ActorSystem system;
   private Materializer materializer;
   private IronMqClient ironMqClient;
 
-  @Before
+  @BeforeEach
   public void setup() throws Exception {
     Config config = initConfig();
     system = ActorSystem.create("TestActorSystem", config);
@@ -50,7 +47,7 @@ public abstract class UnitTest {
             materializer);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws Exception {
     materializer.shutdown();
     TestKit.shutdownActorSystem(system);

--- a/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/javadsl/IronMqConsumerTest.java
+++ b/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/javadsl/IronMqConsumerTest.java
@@ -16,19 +16,20 @@ package org.apache.pekko.stream.connectors.ironmq.javadsl;
 import org.apache.pekko.stream.connectors.ironmq.IronMqSettings;
 import org.apache.pekko.stream.connectors.ironmq.PushMessage;
 import org.apache.pekko.stream.connectors.ironmq.UnitTest;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(LogCapturingExtension.class)
 public class IronMqConsumerTest extends UnitTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void ironMqConsumerShouldBeNiceToMe() throws Exception {

--- a/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -28,14 +28,15 @@ import org.apache.pekko.stream.connectors.jakartams.*;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -45,24 +46,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsBufferedAckConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config consumerConfig;
   private static Config producerConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -759,15 +759,15 @@ public class JmsConnectorsTest {
           Try<List<Message>> tryResult = tryFuture.toCompletableFuture().get();
           long endTime = System.currentTimeMillis();
 
-          assertTrue("Total retry is too short", endTime - startTime > 100L + 400L + 900L + 1600L);
-          assertTrue("Result must be a failure", tryResult.isFailure());
+          assertTrue(endTime - startTime > 100L + 400L + 900L + 1600L, "Total retry is too short");
+          assertTrue(tryResult.isFailure(), "Result must be a failure");
           Throwable exception = tryResult.failed().get();
           assertTrue(
-              "Did not fail with a ConnectionRetryException",
-              exception instanceof ConnectionRetryException);
+              exception instanceof ConnectionRetryException,
+              "Did not fail with a ConnectionRetryException");
           assertTrue(
-              "Cause of failure is not a JMSException",
-              exception.getCause() instanceof JMSException);
+              exception.getCause() instanceof JMSException,
+              "Cause of failure is not a JMSException");
         });
   }
 

--- a/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -55,8 +55,8 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 final class DummyJavaTests implements java.io.Serializable {

--- a/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -30,16 +30,17 @@ import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducerStatus;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import scala.util.Failure;
 import scala.util.Success;
 import scala.util.Try;
@@ -55,8 +56,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 final class DummyJavaTests implements java.io.Serializable {
 
@@ -86,22 +87,21 @@ final class DummyJavaTests implements java.io.Serializable {
   }
 }
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config producerConfig;
   private static Config browseConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
     browseConfig = system.settings().config().getConfig(JmsBrowseSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
@@ -319,7 +319,7 @@ public class JmsConnectorsTest {
 
           CompletionStage<List<String>> result = controlAndResult.second();
           List<String> outMessages = result.toCompletableFuture().get(3, TimeUnit.SECONDS);
-          assertEquals("unexpected number of elements", expectedMessages, outMessages.size());
+          assertEquals(expectedMessages, outMessages.size(), "unexpected number of elements");
           // #jms-source
           JmsConsumerControl control = controlAndResult.first();
           control.shutdown();

--- a/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -31,14 +31,15 @@ import org.apache.pekko.stream.connectors.jakartams.TxEnvelope;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -49,17 +50,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsIbmmqConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static MQQueueConnectionFactory queueConnectionFactory;
   private static MQTopicConnectionFactory topicConnectionFactory;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws JMSException {
     system = ActorSystem.create();
     // #ibmmq-connection-factory
@@ -86,7 +86,7 @@ public class JmsIbmmqConnectorsTest {
     return connectionFactory;
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/jakartams/src/test/java/docs/javadsl/JmsSettingsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsSettingsTest.java
@@ -18,22 +18,22 @@ import com.typesafe.config.ConfigFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.apache.pekko.stream.connectors.jakartams.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
-import org.junit.Rule;
-import org.junit.Test;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.junit.jupiter.api.Test;
 import scala.Option;
 
 import java.time.Duration;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // #retry-settings #send-retry-settings
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsSettingsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void producerSettings() throws Exception {

--- a/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -28,14 +28,15 @@ import org.apache.pekko.stream.connectors.jakartams.*;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -46,24 +47,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsTxConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config consumerConfig;
   private static Config producerConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
+++ b/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
@@ -25,14 +25,15 @@ import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.jakartams.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.*;
 import java.util.concurrent.CompletionStage;
@@ -40,24 +41,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsAckConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config consumerConfig;
   private static Config producerConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -20,17 +20,18 @@ import org.apache.pekko.stream.connectors.jms.*;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import jmstestkit.JmsBroker;
 import com.typesafe.config.Config;
 import org.apache.activemq.command.ActiveMQQueue;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
@@ -42,24 +43,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsBufferedAckConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config consumerConfig;
   private static Config producerConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -55,8 +55,8 @@ import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 final class DummyJavaTests implements java.io.Serializable {

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -23,7 +23,8 @@ import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducerStatus;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -35,10 +36,10 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.ActiveMQSession;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTextMessage;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import scala.util.Failure;
 import scala.util.Success;
 import scala.util.Try;
@@ -55,8 +56,8 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 final class DummyJavaTests implements java.io.Serializable {
 
@@ -86,22 +87,21 @@ final class DummyJavaTests implements java.io.Serializable {
   }
 }
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config producerConfig;
   private static Config browseConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
     browseConfig = system.settings().config().getConfig(JmsBrowseSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
@@ -333,7 +333,7 @@ public class JmsConnectorsTest {
 
           CompletionStage<List<String>> result = controlAndResult.second();
           List<String> outMessages = result.toCompletableFuture().get(3, TimeUnit.SECONDS);
-          assertEquals("unexpected number of elements", expectedMessages, outMessages.size());
+          assertEquals(expectedMessages, outMessages.size(), "unexpected number of elements");
           // #jms-source
           JmsConsumerControl control = controlAndResult.first();
           control.shutdown();

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -798,15 +798,15 @@ public class JmsConnectorsTest {
           Try<List<Message>> tryResult = tryFuture.toCompletableFuture().get();
           long endTime = System.currentTimeMillis();
 
-          assertTrue("Total retry is too short", endTime - startTime > 100L + 400L + 900L + 1600L);
-          assertTrue("Result must be a failure", tryResult.isFailure());
+          assertTrue(endTime - startTime > 100L + 400L + 900L + 1600L, "Total retry is too short");
+          assertTrue(tryResult.isFailure(), "Result must be a failure");
           Throwable exception = tryResult.failed().get();
           assertTrue(
-              "Did not fail with a ConnectionRetryException",
-              exception instanceof ConnectionRetryException);
+              exception instanceof ConnectionRetryException,
+              "Did not fail with a ConnectionRetryException");
           assertTrue(
-              "Cause of failure is not a JMSException",
-              exception.getCause() instanceof JMSException);
+              exception.getCause() instanceof JMSException,
+              "Cause of failure is not a JMSException");
         });
   }
 

--- a/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -22,7 +22,8 @@ import org.apache.pekko.stream.connectors.jms.TxEnvelope;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
@@ -31,10 +32,10 @@ import com.ibm.mq.jms.MQQueueConnectionFactory;
 import com.ibm.mq.jms.MQQueueSession;
 import com.ibm.mq.jms.MQTopicConnectionFactory;
 import com.ibm.msg.client.wmq.common.CommonConstants;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import javax.jms.Destination;
 import javax.jms.JMSException;
@@ -49,17 +50,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsIbmmqConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static MQQueueConnectionFactory queueConnectionFactory;
   private static MQTopicConnectionFactory topicConnectionFactory;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws JMSException {
     system = ActorSystem.create();
     // #ibmmq-connection-factory
@@ -86,7 +86,7 @@ public class JmsIbmmqConnectorsTest {
     return connectionFactory;
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsSettingsTest.java
@@ -14,17 +14,18 @@
 package docs.javadsl;
 
 import org.apache.pekko.stream.connectors.jms.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import com.typesafe.config.ConfigFactory;
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.junit.Rule;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // #retry-settings #send-retry-settings
 import com.typesafe.config.Config;
@@ -32,9 +33,8 @@ import scala.Option;
 
 // #retry-settings #send-retry-settings
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsSettingsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   @Test
   public void producerSettings() throws Exception {

--- a/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -20,17 +20,18 @@ import org.apache.pekko.stream.connectors.jms.*;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import jmstestkit.JmsBroker;
 import com.typesafe.config.Config;
 import org.apache.activemq.command.ActiveMQQueue;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
@@ -43,24 +44,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsTxConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config consumerConfig;
   private static Config producerConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
@@ -17,16 +17,17 @@ import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.jms.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import com.typesafe.config.Config;
 import org.apache.activemq.command.ActiveMQQueue;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import jmstestkit.JmsBroker;
 
 import javax.jms.ConnectionFactory;
@@ -39,24 +40,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JmsAckConnectorsTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Config consumerConfig;
   private static Config producerConfig;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
     consumerConfig = system.settings().config().getConfig(JmsConsumerSettings.configPath());
     producerConfig = system.settings().config().getConfig(JmsProducerSettings.configPath());
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
+++ b/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
@@ -15,14 +15,15 @@ package docs.javadsl;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.json.javadsl.JsonReader;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -33,8 +34,8 @@ import java.util.concurrent.TimeoutException;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+@ExtendWith(LogCapturingExtension.class)
 public class JsonReaderUsageTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -79,12 +80,12 @@ public class JsonReaderUsageTest {
         .get(5, TimeUnit.SECONDS);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     TestKit.shutdownActorSystem(system);
   }

--- a/kinesis/src/test/java/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisTest.java
@@ -16,14 +16,15 @@ package org.apache.pekko.stream.connectors.kinesis.javadsl;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.kinesis.ShardSettings;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.*;
@@ -32,17 +33,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(LogCapturingExtension.class)
 public class KinesisTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static ShardSettings settings;
   private static KinesisAsyncClient amazonKinesisAsync;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     System.setProperty("aws.accessKeyId", "someKeyId");
     System.setProperty("aws.secretKey", "someSecretKey");
@@ -53,12 +54,12 @@ public class KinesisTest {
     amazonKinesisAsync = mock(KinesisAsyncClient.class);
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     TestKit.shutdownActorSystem(system);
   }
 
-  //  @Ignore("This test appears to trigger a deadlock, see
+  //  @Disabled("This test appears to trigger a deadlock, see
   // https://github.com/akka/alpakka/issues/390")
   @Test
   public void PullRecord() throws Exception {

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -19,7 +19,8 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.kudu.KuduAttributes;
 import org.apache.pekko.stream.connectors.kudu.KuduTableSettings;
 import org.apache.pekko.stream.connectors.kudu.javadsl.KuduTable;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -32,11 +33,11 @@ import org.apache.kudu.client.CreateTableOptions;
 import org.apache.kudu.client.KuduClient;
 import org.apache.kudu.client.KuduException;
 import org.apache.kudu.client.PartialRow;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,15 +45,15 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
+@ExtendWith(LogCapturingExtension.class)
 public class KuduTableTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static Schema schema;
 
   private static KuduTableSettings<Person> tableSettings;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
 
@@ -84,7 +85,7 @@ public class KuduTableTest {
     KuduTableTest.tableSettings = tableSettings;
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws KuduException {
     TestKit.shutdownActorSystem(system);
   }

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -21,7 +21,8 @@ import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.mongodb.DocumentReplace;
 import org.apache.pekko.stream.connectors.mongodb.DocumentUpdate;
 import org.apache.pekko.stream.connectors.mongodb.javadsl.MongoSink;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
@@ -37,7 +38,7 @@ import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.bson.conversions.Bson;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,11 +48,11 @@ import java.util.stream.IntStream;
 
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class MongoSinkTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -120,20 +121,20 @@ public class MongoSinkTest {
         .get(5, TimeUnit.SECONDS);
   }
 
-  @Before
+  @BeforeEach
   public void cleanDb() throws Exception {
     deleteCollection(numbersDocumentColl);
     deleteCollection(domainObjectsDocumentColl);
   }
 
-  @After
+  @AfterEach
   public void checkForLeaks() throws Exception {
     checkCollectionForLeaks(numbersDocumentColl);
     checkCollectionForLeaks(domainObjectsDocumentColl);
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
   }
 
-  @AfterClass
+  @AfterAll
   public static void terminateActorSystem() {
     system.terminate();
   }

--- a/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
@@ -17,7 +17,8 @@ import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.mongodb.javadsl.MongoSource;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
@@ -28,17 +29,17 @@ import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class MongoSourceTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -67,7 +68,7 @@ public class MongoSourceTest {
     numbersDocumentColl = db.getCollection("numbers");
   }
 
-  @Before
+  @BeforeEach
   public void cleanDb() throws Exception {
     Source.fromPublisher(numbersDocumentColl.deleteMany(new Document()))
         .runWith(Sink.head(), system)
@@ -75,7 +76,7 @@ public class MongoSourceTest {
         .get(5, TimeUnit.SECONDS);
   }
 
-  @After
+  @AfterEach
   public void checkForLeaks() throws Exception {
     Source.fromPublisher(numbersDocumentColl.deleteMany(new Document()))
         .runWith(Sink.head(), system)
@@ -84,7 +85,7 @@ public class MongoSourceTest {
     StreamTestKit.assertAllStagesStopped(Materializer.matFromSystem(system));
   }
 
-  @AfterClass
+  @AfterAll
   public static void terminateActorSystem() {
     system.terminate();
   }

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -43,7 +43,8 @@ import org.apache.pekko.stream.connectors.mqtt.streaming.javadsl.ActorMqttServer
 import org.apache.pekko.stream.connectors.mqtt.streaming.javadsl.Mqtt;
 import org.apache.pekko.stream.connectors.mqtt.streaming.javadsl.MqttClientSession;
 import org.apache.pekko.stream.connectors.mqtt.streaming.javadsl.MqttServerSession;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -54,7 +55,7 @@ import org.apache.pekko.stream.javadsl.BroadcastHub;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 import scala.Tuple2;
 import scala.collection.JavaConverters;
 
@@ -67,11 +68,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class MqttFlowTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static int TIMEOUT_SECONDS = 5;
 
@@ -82,17 +82,17 @@ public class MqttFlowTest {
     return system;
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = setupSystem();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
 
-  @After
+  @AfterEach
   public void assertStageStopping() {
     StreamTestKit.assertAllStagesStopped(SystemMaterializer.get(system).materializer());
   }

--- a/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -24,7 +24,8 @@ import org.apache.pekko.stream.connectors.mqtt.MqttSubscriptions;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttFlow;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttMessageWithAckImpl;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -32,10 +33,10 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +45,10 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@ExtendWith(LogCapturingExtension.class)
 public class MqttFlowTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final Logger log = LoggerFactory.getLogger(MqttFlowTest.class);
 
@@ -56,12 +56,12 @@ public class MqttFlowTest {
 
   private static final int bufferSize = 8;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create("MqttFlowTest");
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -23,17 +23,18 @@ import org.apache.pekko.stream.connectors.mqtt.*;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttSink;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttSource;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,13 +50,12 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@ExtendWith(LogCapturingExtension.class)
 public class MqttSourceTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final Logger log = LoggerFactory.getLogger(MqttSourceTest.class);
 
@@ -63,12 +63,12 @@ public class MqttSourceTest {
 
   private static final int bufferSize = 8;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create("MqttSourceTest");
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
@@ -200,7 +200,7 @@ public class MqttSourceTest {
               try {
                 m.ack().toCompletableFuture().get(3, TimeUnit.SECONDS);
               } catch (Exception e) {
-                assertFalse("Error acking message manually", false);
+                assertFalse(false, "Error acking message manually");
               }
             });
   }

--- a/mqttv5/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -24,7 +24,8 @@ import org.apache.pekko.stream.connectors.mqttv5.MqttSubscriptions;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttFlow;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttMessageWithAckImpl;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -32,10 +33,10 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,11 +45,10 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@ExtendWith(LogCapturingExtension.class)
 public class MqttFlowTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final Logger log = LoggerFactory.getLogger(MqttFlowTest.class);
 
@@ -56,12 +56,12 @@ public class MqttFlowTest {
 
   private static final int bufferSize = 8;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create("MqttFlowTest");
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -27,17 +27,18 @@ import org.apache.pekko.stream.connectors.mqttv5.MqttUserProperty;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttSink;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttSource;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,12 +54,11 @@ import java.util.stream.Stream;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
+@ExtendWith(LogCapturingExtension.class)
 public class MqttSourceTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final Logger log = LoggerFactory.getLogger(MqttSourceTest.class);
 
@@ -66,12 +66,12 @@ public class MqttSourceTest {
 
   private static final int bufferSize = 8;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create("MqttSourceTest");
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }
@@ -203,7 +203,7 @@ public class MqttSourceTest {
               try {
                 m.ack().toCompletableFuture().get(3, TimeUnit.SECONDS);
               } catch (Exception e) {
-                assertFalse("Error acking message manually", false);
+                assertFalse(false, "Error acking message manually");
               }
             });
   }

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -22,7 +22,8 @@ import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteSettings;
 import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbFlow;
 import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSink;
 import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSource;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
@@ -38,10 +39,10 @@ import com.orientechnologies.orient.core.db.ODatabasePool;
 import com.orientechnologies.orient.core.db.ODatabaseSession;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -51,10 +52,10 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class OrientDbTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static OrientDB orientDB;
   private static ODatabasePool oDatabase;
@@ -151,7 +152,7 @@ public class OrientDbTest {
     }
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     system = ActorSystem.create();
 
@@ -177,7 +178,7 @@ public class OrientDbTest {
     flush(sourceClass, "book_title", "Akka Concurrency");
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDown() throws Exception {
     unregister(sourceClass);
     unregister(sinkClass1);

--- a/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
@@ -17,8 +17,8 @@ import java.net.URI;
 import java.util.UUID;
 
 import org.apache.pekko.stream.connectors.pravega.PravegaPekkoTestCaseSupport;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import org.apache.pekko.testkit.javadsl.TestKit;
 
@@ -44,7 +44,7 @@ public abstract class PravegaBaseTestCase extends PravegaPekkoTestCaseSupport {
     return "java-test-table-" + UUID.randomUUID().toString();
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     init();
   }
@@ -74,7 +74,7 @@ public abstract class PravegaBaseTestCase extends PravegaPekkoTestCaseSupport {
     streamManager.close();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
@@ -18,10 +18,10 @@ import org.apache.pekko.stream.connectors.pravega.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 
 import io.pravega.client.stream.impl.UTF8StringSerializer;
-import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -33,7 +33,7 @@ public class PravegaSettingsTestCase {
 
   protected static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
@@ -52,11 +52,11 @@ public class PravegaSettingsTestCase {
             .withSerializer(new UTF8StringSerializer());
     // #reader-settings
 
-    Assert.assertEquals("Timeout value doesn't match", readerSettings.timeout(), 3000);
-    Assert.assertTrue(
-        "TLS does not match", readerSettings.clientConfig().isEnableTlsToController());
-    Assert.assertTrue(
-        "Window should not be enabled", readerSettings.readerConfig().isDisableTimeWindows());
+    Assertions.assertEquals(readerSettings.timeout(), 3000, "Timeout value doesn't match");
+    Assertions.assertTrue(
+        readerSettings.clientConfig().isEnableTlsToController(), "TLS does not match");
+    Assertions.assertTrue(
+        readerSettings.readerConfig().isDisableTimeWindows(), "Window should not be enabled");
   }
 
   @Test
@@ -69,8 +69,8 @@ public class PravegaSettingsTestCase {
             .withSerializer(new UTF8StringSerializer());
     // #writer-settings
 
-    Assert.assertEquals(
-        "Default value doesn't match", writerSettings.maximumInflightMessages(), 10);
+    Assertions.assertEquals(
+        writerSettings.maximumInflightMessages(), 10, "Default value doesn't match");
   }
 
   @Test
@@ -108,11 +108,11 @@ public class PravegaSettingsTestCase {
 
     // #table-reader-settings
 
-    Assert.assertEquals(
-        "Default value doesn't match", tableWriterSettings.maximumInflightMessages(), 10);
+    Assertions.assertEquals(
+        tableWriterSettings.maximumInflightMessages(), 10, "Default value doesn't match");
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaGraphTestCase.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaGraphTestCase.java
@@ -21,8 +21,8 @@ import docs.javadsl.PravegaBaseTestCase;
 
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.impl.JavaSerializer;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import org.apache.pekko.japi.Pair;
 
@@ -110,6 +110,6 @@ public class PravegaGraphTestCase extends PravegaBaseTestCase {
     pair.first().shutdown();
 
     Integer result = pair.second().toCompletableFuture().get(timeoutSeconds, TimeUnit.SECONDS);
-    Assert.assertTrue("Read 6 events", result == 0);
+    Assertions.assertTrue(result == 0, "Read 6 events");
   }
 }

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
@@ -30,9 +30,9 @@ import io.pravega.client.stream.impl.UTF8StringSerializer;
 
 import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.client.tables.TableKey;
-import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -104,8 +104,8 @@ public class PravegaKVTableTestCase extends PravegaBaseTestCase {
                 system);
 
     String result = readingDone.toCompletableFuture().get(timeoutSeconds, TimeUnit.SECONDS);
-    Assert.assertTrue(
-        String.format("Read 2 elements [%s]", result), result.equals("One, Two, Three, Four"));
+    Assertions.assertTrue(
+        result.equals("One, Two, Three, Four"), String.format("Read 2 elements [%s]", result));
 
     Flow<Integer, Optional<String>, NotUsed> readFlow =
         PravegaTable.readFlow(scope, tableName, tableReaderSettings);
@@ -126,10 +126,10 @@ public class PravegaKVTableTestCase extends PravegaBaseTestCase {
 
     List<String> values = readFlowFut.toCompletableFuture().get(timeoutSeconds, TimeUnit.SECONDS);
 
-    Assert.assertEquals(values, List.of("One", "Two", "Three", "Four"));
+    Assertions.assertEquals(values, List.of("One", "Two", "Three", "Four"));
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setUp() {
     createScope(scope);
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -97,7 +97,8 @@ object Dependencies {
       "org.scalatest" %% "scalatest" % ScalaTestVersion,
       "com.dimafeng" %% "testcontainers-scala-scalatest" % TestContainersScalaTestVersion,
       "com.github.sbt" % "junit-interface" % "0.13.3",
-      "junit" % "junit" % "4.13.2"))
+      "junit" % "junit" % "4.13.2",
+      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value))
 
   val Mockito = Seq(
     "org.mockito" % "mockito-core" % mockitoVersion % Test,
@@ -107,6 +108,7 @@ object Dependencies {
   val Amqp = Seq(
     libraryDependencies ++= Seq(
       "com.rabbitmq" % "amqp-client" % "5.32.0",
+      "org.junit.jupiter" % "junit-jupiter-params" % JupiterKeys.junitJupiterVersion.value % Test,
       "org.scalatestplus" %% scalaTestScalaCheckArtifact % scalaTestScalaCheckVersion % Test) ++ Mockito)
 
   val AwsSpiPekkoHttp = Seq(
@@ -176,6 +178,7 @@ object Dependencies {
       "org.apache.pekko" %% "pekko-stream-testkit" % PekkoVersion % Test,
       "org.apache.pekko" %% "pekko-connectors-kafka" % "2.0.0-M1" % Test,
       "junit" % "junit" % "4.13.2" % Test,
+      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value % Test,
       "org.scalatest" %% "scalatest" % ScalaTestVersion % Test))
 
   val DynamoDB = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -98,7 +98,8 @@ object Dependencies {
       "com.dimafeng" %% "testcontainers-scala-scalatest" % TestContainersScalaTestVersion,
       "com.github.sbt" % "junit-interface" % "0.13.3",
       "junit" % "junit" % "4.13.2",
-      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value))
+      "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value,
+      "com.github.sbt.junit" % "jupiter-interface" % JupiterKeys.jupiterVersion.value))
 
   val Mockito = Seq(
     "org.mockito" % "mockito-core" % mockitoVersion % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -99,6 +99,7 @@ object Dependencies {
       "com.github.sbt" % "junit-interface" % "0.13.3",
       "junit" % "junit" % "4.13.2",
       "org.junit.jupiter" % "junit-jupiter-api" % JupiterKeys.junitJupiterVersion.value,
+      "org.junit.jupiter" % "junit-jupiter-params" % JupiterKeys.junitJupiterVersion.value,
       "com.github.sbt.junit" % "jupiter-interface" % JupiterKeys.jupiterVersion.value))
 
   val Mockito = Seq(

--- a/reference/src/test/java/docs/javadsl/ReferenceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceTest.java
@@ -22,13 +22,14 @@ import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.reference.*;
 import org.apache.pekko.stream.connectors.reference.javadsl.Reference;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.*;
+import org.junit.jupiter.api.*;
 
 import java.util.*;
 import java.util.concurrent.CompletionStage;
@@ -37,21 +38,21 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /** Append "Test" to every Java test suite. */
+@ExtendWith(LogCapturingExtension.class)
 public class ReferenceTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static ActorSystem system;
 
   static final String clientId = "test-client-id";
 
   /** Called before test suite. */
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() {
     system = ActorSystem.create("ReferenceTest");
   }
 
   /** Called before every test. */
-  @Before
+  @BeforeEach
   public void setUp() {}
 
   @Test
@@ -95,12 +96,12 @@ public class ReferenceTest {
     final CompletionStage<ReferenceReadResult> stage = source.runWith(Sink.head(), system);
     final ReferenceReadResult msg = stage.toCompletableFuture().get(5, TimeUnit.SECONDS);
 
-    Assert.assertEquals(List.of(ByteString.fromString("one")), msg.getData());
+    Assertions.assertEquals(List.of(ByteString.fromString("one")), msg.getData());
 
     final OptionalInt expected = OptionalInt.of(100);
-    Assert.assertEquals(expected, msg.getBytesRead());
+    Assertions.assertEquals(expected, msg.getBytesRead());
 
-    Assert.assertEquals(Optional.empty(), msg.getBytesReadFailure());
+    Assertions.assertEquals(Optional.empty(), msg.getBytesReadFailure());
   }
 
   @Test
@@ -135,7 +136,7 @@ public class ReferenceTest {
     final List<ByteString> bytes =
         result.stream().flatMap(m -> m.getMessage().getData().stream()).toList();
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of(
             ByteString.fromString("one"),
             ByteString.fromString("two"),
@@ -144,7 +145,7 @@ public class ReferenceTest {
         bytes);
 
     final long actual = result.stream().findFirst().get().getMetrics().get("total");
-    Assert.assertEquals(50L, actual);
+    Assertions.assertEquals(50L, actual);
   }
 
   @Test
@@ -157,7 +158,7 @@ public class ReferenceTest {
             .toCompletableFuture()
             .get(5, TimeUnit.SECONDS);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of("one default msg"),
         result.stream()
             .flatMap(m -> m.getMessage().getData().stream())
@@ -179,7 +180,7 @@ public class ReferenceTest {
             .toCompletableFuture()
             .get(5, TimeUnit.SECONDS);
 
-    Assert.assertEquals(
+    Assertions.assertEquals(
         List.of("one attributes msg"),
         result.stream()
             .flatMap(m -> m.getMessage().getData().stream())
@@ -188,11 +189,11 @@ public class ReferenceTest {
   }
 
   /** Called after every test. */
-  @After
+  @AfterEach
   public void tearDown() {}
 
   /** Called after test suite. */
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() {
     TestKit.shutdownActorSystem(system);
   }

--- a/s3/src/test/java/docs/javadsl/S3Test.java
+++ b/s3/src/test/java/docs/javadsl/S3Test.java
@@ -29,17 +29,18 @@ import org.apache.pekko.stream.connectors.s3.headers.CustomerKeys;
 import org.apache.pekko.stream.connectors.s3.headers.ServerSideEncryption;
 import org.apache.pekko.stream.connectors.s3.javadsl.S3;
 import org.apache.pekko.stream.connectors.s3.scaladsl.S3WireMockBase;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import com.github.tomakehurst.wiremock.WireMockServer;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
@@ -47,11 +48,11 @@ import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class S3Test extends S3WireMockBase {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
   private static WireMockServer wireMockServerForShutdown;
@@ -60,13 +61,13 @@ public class S3Test extends S3WireMockBase {
   private final String prefix = listPrefix();
   private final String delimiter = listDelimiter();
 
-  @Before
+  @BeforeEach
   public void before() {
     wireMockServerForShutdown = _wireMockServer();
     system = system();
   }
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() throws Exception {
     wireMockServerForShutdown.stop();
     Http.get(system)

--- a/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
+++ b/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
@@ -16,14 +16,15 @@ package docs.javadsl;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.recordio.javadsl.RecordIOFraming;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
+import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -33,12 +34,12 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+@ExtendWith(LogCapturingExtension.class)
 public class RecordIOFramingTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create();
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     TestKit.shutdownActorSystem(system);
   }

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -20,16 +20,17 @@ import org.apache.pekko.japi.function.Function2;
 import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
 import org.apache.pekko.stream.connectors.slick.javadsl.SlickRow;
 import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -46,15 +47,15 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * This unit test is run using a local H2 database using `/tmp/pekko-connectors-slick-h2-test` for
  * temporary storage.
  */
+@ExtendWith(LogCapturingExtension.class)
 public class SlickTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -90,7 +91,7 @@ public class SlickTest {
   private static final String selectAllUsers =
       "SELECT ID, NAME FROM PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS";
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     // #init-mat
     system = ActorSystem.create();
@@ -102,12 +103,12 @@ public class SlickTest {
         system);
   }
 
-  @After
+  @AfterEach
   public void cleanUp() {
     executeStatement("DELETE FROM PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS", session, system);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     executeStatement("DROP TABLE PEKKO_CONNECTORS_SLICK_JAVADSL_TEST_USERS", session, system);
 

--- a/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
+++ b/sns/src/test/java/docs/javadsl/SnsPublisherTest.java
@@ -18,7 +18,8 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.connectors.sns.javadsl.SnsPublisher;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
@@ -31,10 +32,10 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sns.SnsAsyncClient;
 // #init-client
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sns.model.CreateTopicRequest;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
 
@@ -45,8 +46,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+@ExtendWith(LogCapturingExtension.class)
 public class SnsPublisherTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   static ActorSystem system;
   static SnsAsyncClient snsClient;
@@ -54,7 +55,7 @@ public class SnsPublisherTest {
 
   static final String endpoint = "http://localhost:4100";
 
-  @BeforeClass
+  @BeforeAll
   public static void setUpBeforeClass() throws ExecutionException, InterruptedException {
     system = ActorSystem.create("SnsPublisherTest");
     snsClient = createSnsClient();
@@ -65,7 +66,7 @@ public class SnsPublisherTest {
             .topicArn();
   }
 
-  @AfterClass
+  @AfterAll
   public static void tearDownAfterClass() throws Exception {
     Http.get(system)
         .shutdownAllConnectionPools()

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -23,7 +23,8 @@ import org.apache.pekko.stream.connectors.solr.WriteMessage;
 import org.apache.pekko.stream.connectors.solr.javadsl.SolrFlow;
 import org.apache.pekko.stream.connectors.solr.javadsl.SolrSink;
 import org.apache.pekko.stream.connectors.solr.javadsl.SolrSource;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
@@ -47,10 +48,10 @@ import org.apache.solr.client.solrj.response.UpdateResponse;
 import org.apache.solr.cloud.MiniSolrCloudCluster;
 import org.apache.solr.cloud.ZkTestServer;
 import org.apache.solr.common.SolrInputDocument;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -64,11 +65,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class SolrTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static MiniSolrCloudCluster cluster;
   private static SolrClient solrClient;
@@ -760,7 +761,7 @@ public class SolrTest {
         CommittableOffsetBatch.committedOffsets.stream().map(o -> o.offset).toList());
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() throws Exception {
     setupCluster();
 
@@ -780,7 +781,7 @@ public class SolrTest {
         .commit(solrClient, predefinedCollection);
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     solrClient.close();
     cluster.shutdown();

--- a/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
+++ b/solr/src/test/scala/docs/scaladsl/SolrSpec.scala
@@ -33,7 +33,6 @@ import org.apache.solr.client.solrj.io.{ SolrClientCache, Tuple }
 import org.apache.solr.client.solrj.request.{ CollectionAdminRequest, UpdateRequest }
 import org.apache.solr.cloud.{ MiniSolrCloudCluster, ZkTestServer }
 import org.apache.solr.common.SolrInputDocument
-import org.junit.Assert.assertTrue
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.BeforeAndAfterAll
 
@@ -744,7 +743,7 @@ class SolrSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll with Sca
       .uploadConfig(confDir.toPath, "conf")
     solrClient.setIdField("router")
 
-    assertTrue(!solrClient.getZkStateReader.getClusterState.getLiveNodes.isEmpty)
+    assert(!solrClient.getZkStateReader.getClusterState.getLiveNodes.isEmpty)
   }
 
   private val number = new AtomicInteger(2)

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -26,7 +26,7 @@ import org.apache.pekko.stream.connectors.sqs.javadsl.SqsAckFlow;
 import org.apache.pekko.stream.connectors.sqs.javadsl.SqsAckSink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.Sink;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.*;
 
@@ -40,7 +40,7 @@ import java.util.stream.IntStream;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SqsAckTest extends BaseSqsTest {
 

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -24,7 +24,7 @@ import org.apache.pekko.stream.connectors.sqs.javadsl.SqsPublishFlow;
 import org.apache.pekko.stream.connectors.sqs.javadsl.SqsPublishSink;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.model.*;
 
 import java.math.BigInteger;
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SqsPublishTest extends BaseSqsTest {
 

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -24,7 +24,7 @@ import org.apache.pekko.stream.connectors.sqs.javadsl.SqsPublishSink;
 import org.apache.pekko.stream.connectors.sqs.javadsl.SqsSource;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
@@ -40,7 +40,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SqsSourceTest extends BaseSqsTest {
 

--- a/sqs/src/test/java/org/apache/pekko/stream/connectors/sqs/javadsl/BaseSqsTest.java
+++ b/sqs/src/test/java/org/apache/pekko/stream/connectors/sqs/javadsl/BaseSqsTest.java
@@ -16,7 +16,6 @@ package org.apache.pekko.stream.connectors.sqs.javadsl;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
 import org.apache.pekko.testkit.javadsl.TestKit;
 // #init-client
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -25,10 +24,10 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 // #init-client
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
+
 import software.amazon.awssdk.services.sqs.model.CreateQueueRequest;
 
 import java.net.URI;
@@ -37,8 +36,6 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class BaseSqsTest {
 
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
-
   protected static ActorSystem system;
   private static SqsAsyncClient sqsClientForClose;
 
@@ -46,14 +43,14 @@ public abstract class BaseSqsTest {
   protected String sqsEndpoint = "http://localhost:9324";
   protected SqsAsyncClient sqsClient;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     // #init-mat
     system = ActorSystem.create();
     // #init-mat
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() throws Exception {
     if (sqsClientForClose != null) {
       sqsClientForClose.close();
@@ -65,7 +62,7 @@ public abstract class BaseSqsTest {
         .get(2, TimeUnit.SECONDS);
   }
 
-  @Before
+  @BeforeEach
   public void setupBefore() {
     if (!initialized) {
       sqsClient = createAsyncClient(sqsEndpoint);

--- a/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/javadsl/LogCapturingExtension.scala
+++ b/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/javadsl/LogCapturingExtension.scala
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) since 2016 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.stream.connectors.testkit.javadsl
+
+import org.apache.pekko.stream.connectors.testkit.CapturingAppender
+import org.junit.jupiter.api.extension.{ AfterTestExecutionCallback, BeforeTestExecutionCallback, ExtensionContext }
+
+/**
+ * See https://pekko.apache.org/docs/pekko/current/typed/testing-async.html#silence-logging-output-from-tests
+ *
+ * JUnit Jupiter extension to make log lines appear only when the test failed.
+ *
+ * Use this in test by adding `@ExtendWith` annotation:
+ * {{{
+ *   @ExtendWith(LogCapturingExtension.class)
+ * }}}
+ *
+ * Requires Logback and configuration like the following the logback-test.xml:
+ *
+ * {{{
+ *     <appender name="CapturingAppender" class="org.apache.pekko.actor.testkit.typed.internal.CapturingAppender" />
+ *
+ *     <logger name="org.apache.pekko.actor.testkit.typed.internal.CapturingAppenderDelegate" >
+ *       <appender-ref ref="STDOUT"/>
+ *     </logger>
+ *
+ *     <root level="DEBUG">
+ *         <appender-ref ref="CapturingAppender"/>
+ *     </root>
+ * }}}
+ */
+class LogCapturingExtension extends BeforeTestExecutionCallback with AfterTestExecutionCallback {
+
+  // eager access of CapturingAppender to fail fast if misconfigured
+  private val capturingAppender = CapturingAppender.get("")
+
+  override def beforeTestExecution(context: ExtensionContext): Unit = {
+    capturingAppender.clear()
+  }
+
+  override def afterTestExecution(context: ExtensionContext): Unit = {
+    if (context.getExecutionException.isPresent) {
+      val error = context.getExecutionException.get().toString
+      val method =
+        s"[${Console.BLUE}${context.getRequiredTestClass.getName}: ${context.getRequiredTestMethod.getName}${Console.RESET}]"
+      System.out.println(
+        s"--> $method Start of log messages of test that failed with $error")
+      capturingAppender.flush()
+      System.out.println(
+        s"<-- $method End of log messages of test that failed with $error")
+    }
+  }
+}

--- a/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/javadsl/LogCapturingJunit4.scala
+++ b/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/javadsl/LogCapturingJunit4.scala
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory
  *     </root>
  * }}}
  */
+@deprecated("Use LogCapturingExtension (JUnit Jupiter) instead", "2.0.0")
 final class LogCapturingJunit4 extends TestRule {
   // eager access of CapturingAppender to fail fast if misconfigured
   private val capturingAppender = CapturingAppender.get("")

--- a/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
+++ b/text/src/test/java/docs/javadsl/CharsetCodingFlowsDoc.java
@@ -15,7 +15,8 @@ package docs.javadsl;
 
 // #encoding
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.text.javadsl.TextFlow;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.javadsl.FileIO;
@@ -26,9 +27,9 @@ import org.apache.pekko.util.ByteString;
 import java.nio.charset.StandardCharsets;
 
 // #encoding
-import org.junit.AfterClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -37,16 +38,15 @@ import java.util.Properties;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(LogCapturingExtension.class)
 public class CharsetCodingFlowsDoc {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final ActorSystem system = ActorSystem.create();
 
-  @AfterClass
+  @AfterAll
   public static void afterAll() {
     system.terminate();
   }
@@ -72,7 +72,7 @@ public class CharsetCodingFlowsDoc {
             .runWith(FileIO.toPath(targetFile), system);
     // #encoding
     IOResult result = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
-    assertTrue("result is greater than 50 bytes", result.count() > 50L);
+    assertTrue(result.count() > 50L, "result is greater than 50 bytes");
   }
 
   @Test
@@ -108,6 +108,6 @@ public class CharsetCodingFlowsDoc {
             .runWith(FileIO.toPath(targetFile), system);
     // #transcoding
     IOResult result = streamCompletion.toCompletableFuture().get(1, TimeUnit.SECONDS);
-    assertTrue("result is greater than 5 bytes", result.count() > 5L);
+    assertTrue(result.count() > 5L, "result is greater than 5 bytes");
   }
 }

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -17,7 +17,8 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.io.Inet;
 import org.apache.pekko.io.UdpSO;
 import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.udp.Datagram;
 import org.apache.pekko.stream.connectors.udp.javadsl.Udp;
 import org.apache.pekko.stream.javadsl.Flow;
@@ -29,10 +30,10 @@ import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.stream.testkit.javadsl.TestSource;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.net.*;
 import java.util.ArrayList;
@@ -41,17 +42,17 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 
+@ExtendWith(LogCapturingExtension.class)
 public class UdpTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create("UdpTest");
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -19,7 +19,8 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.OverflowStrategy;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.unixdomainsocket.javadsl.UnixDomainSocket;
 import org.apache.pekko.stream.connectors.unixdomainsocket.javadsl.UnixDomainSocket.IncomingConnection;
 import org.apache.pekko.stream.connectors.unixdomainsocket.javadsl.UnixDomainSocket.ServerBinding;
@@ -29,10 +30,10 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +42,10 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class UnixDomainSocketTest {
-
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static final Logger log = LoggerFactory.getLogger(UnixDomainSocketTest.class);
   private static ActorSystem system;
@@ -58,14 +58,14 @@ public class UnixDomainSocketTest {
     return Pair.create(system, materializer);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     final Pair<ActorSystem, Materializer> sysmat = setupMaterializer();
     system = sysmat.first();
     materializer = sysmat.second();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -15,7 +15,8 @@ package docs.javadsl;
 
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.xml.Characters;
 import org.apache.pekko.stream.connectors.xml.EndDocument;
 import org.apache.pekko.stream.connectors.xml.EndElement;
@@ -28,10 +29,10 @@ import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import com.fasterxml.aalto.AsyncXMLInputFactory;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 import org.w3c.dom.Element;
 
 import java.util.Collections;
@@ -48,8 +49,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 @SuppressWarnings("deprecation")
+@ExtendWith(LogCapturingExtension.class)
 public class XmlParsingTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -244,12 +245,12 @@ public class XmlParsingTest {
         .get(5, TimeUnit.SECONDS);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }

--- a/xml/src/test/java/docs/javadsl/XmlWritingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlWritingTest.java
@@ -14,7 +14,8 @@
 package docs.javadsl;
 
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingJunit4;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.xml.Characters;
 import org.apache.pekko.stream.connectors.xml.EndDocument;
 import org.apache.pekko.stream.connectors.xml.EndElement;
@@ -29,10 +30,10 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
 import java.util.ArrayList;
@@ -45,10 +46,10 @@ import java.util.concurrent.TimeoutException;
 
 import javax.xml.stream.XMLOutputFactory;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@ExtendWith(LogCapturingExtension.class)
 public class XmlWritingTest {
-  @Rule public final LogCapturingJunit4 logCapturing = new LogCapturingJunit4();
 
   private static ActorSystem system;
 
@@ -174,12 +175,12 @@ public class XmlWritingTest {
         .get(5, TimeUnit.SECONDS);
   }
 
-  @BeforeClass
+  @BeforeAll
   public static void setup() {
     system = ActorSystem.create();
   }
 
-  @AfterClass
+  @AfterAll
   public static void teardown() {
     TestKit.shutdownActorSystem(system);
   }


### PR DESCRIPTION
## Motivation
JUnit 4 is end-of-life. JUnit 6 unifies version numbering across Platform, Jupiter, and Vintage components.

## Modification
- Add JupiterKeys overrides for JUnit Jupiter and Platform 6.1.0
- Migrate ~98 test files from JUnit 4 annotations to Jupiter equivalents
- Create `LogCapturingExtension` for JUnit Jupiter
- Deprecate `LogCapturingJunit4` (use `LogCapturingExtension` for JUnit Jupiter instead)
- Keep JUnit 4 dependency for deprecated testkit class (binary compatibility)

## Result
All tests run on JUnit 6.1.0. Deprecated JUnit 4 testkit class remains for backward compatibility.