### PR TITLE
one off reorder of java imports

### DIFF
--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -13,6 +13,13 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -27,7 +34,6 @@ import org.apache.pekko.stream.connectors.amqp.javadsl.AmqpSink;
 import org.apache.pekko.stream.connectors.amqp.javadsl.AmqpSource;
 import org.apache.pekko.stream.connectors.amqp.javadsl.CommittableReadResult;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -37,16 +43,8 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-
 import org.junit.jupiter.api.*;
-
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Needs a local running AMQP server on the default port with no password. */
 @ExtendWith(LogCapturingExtension.class)

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectionProvidersTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectionProvidersTest.java
@@ -15,20 +15,18 @@ package org.apache.pekko.stream.connectors.amqp.javadsl;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.apache.pekko.stream.connectors.amqp.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
-
-import org.junit.jupiter.api.Test;
-
 import java.net.ConnectException;
+import org.apache.pekko.stream.connectors.amqp.*;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class AmqpConnectionProvidersTest {

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
@@ -13,6 +13,15 @@
 
 package org.apache.pekko.stream.connectors.amqp.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import com.rabbitmq.client.AuthenticationFailureException;
+import java.net.ConnectException;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -22,7 +31,6 @@ import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.UniqueKillSwitch;
 import org.apache.pekko.stream.connectors.amqp.*;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -32,19 +40,10 @@ import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import com.rabbitmq.client.AuthenticationFailureException;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.collection.JavaConverters;
 import scala.concurrent.duration.Duration;
-
-import java.net.ConnectException;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /** Needs a local running AMQP server on the default port with no password. */
 @ExtendWith(LogCapturingExtension.class)

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
@@ -16,14 +16,6 @@ package org.apache.pekko.stream.connectors.amqp.javadsl;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
-
-import scala.collection.JavaConverters;
-
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
-
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -33,7 +25,6 @@ import org.apache.pekko.stream.connectors.amqp.QueueDeclaration;
 import org.apache.pekko.stream.connectors.amqp.WriteMessage;
 import org.apache.pekko.stream.connectors.amqp.WriteResult;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Keep;
@@ -41,6 +32,11 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import scala.collection.JavaConverters;
 
 /** Needs a local running AMQP server on the default port with no password. */
 @ExtendWith(LogCapturingExtension.class)

--- a/avroparquet/src/test/java/docs/javadsl/Examples.java
+++ b/avroparquet/src/test/java/docs/javadsl/Examples.java
@@ -13,24 +13,24 @@
 
 package docs.javadsl;
 
-import java.io.IOException;
-// #init-reader
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
-import org.apache.parquet.avro.AvroParquetReader;
-import org.apache.parquet.avro.AvroParquetWriter;
-import org.apache.parquet.hadoop.ParquetReader;
-import org.apache.parquet.hadoop.ParquetWriter;
-import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.avroparquet.javadsl.AvroParquetFlow;
 import org.apache.pekko.stream.connectors.avroparquet.javadsl.AvroParquetSource;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import java.io.IOException;
+// #init-reader
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.fs.Path;
+import org.apache.avro.Schema;
 import org.apache.pekko.stream.javadsl.Source;
+import org.apache.parquet.avro.AvroParquetReader;
 
 // #init-reader
 

--- a/avroparquet/src/test/java/docs/javadsl/Examples.java
+++ b/avroparquet/src/test/java/docs/javadsl/Examples.java
@@ -13,24 +13,24 @@
 
 package docs.javadsl;
 
+import java.io.IOException;
+// #init-reader
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.avro.AvroParquetReader;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.hadoop.ParquetReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.avroparquet.javadsl.AvroParquetFlow;
 import org.apache.pekko.stream.connectors.avroparquet.javadsl.AvroParquetSource;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.parquet.avro.AvroParquetWriter;
-import org.apache.parquet.hadoop.ParquetWriter;
-import org.apache.parquet.hadoop.util.HadoopInputFile;
-import java.io.IOException;
-// #init-reader
-import org.apache.parquet.hadoop.ParquetReader;
-import org.apache.avro.generic.GenericRecord;
-import org.apache.hadoop.fs.Path;
-import org.apache.avro.Schema;
 import org.apache.pekko.stream.javadsl.Source;
-import org.apache.parquet.avro.AvroParquetReader;
 
 // #init-reader
 

--- a/aws-spi-pekko-http/src/test/java/org/apache/pekko/stream/connectors/awsspi/s3/S3Test.java
+++ b/aws-spi-pekko-http/src/test/java/org/apache/pekko/stream/connectors/awsspi/s3/S3Test.java
@@ -17,6 +17,15 @@
 
 package org.apache.pekko.stream.connectors.awsspi.s3;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.SecureRandom;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpAsyncHttpService;
 import org.junit.jupiter.api.Test;
@@ -33,16 +42,6 @@ import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.security.SecureRandom;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @Testcontainers
 public class S3Test {

--- a/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
+++ b/awslambda/src/test/java/docs/javadsl/AwsLambdaFlowTest.java
@@ -13,30 +13,29 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awslambda.javadsl.AwsLambdaFlow;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
-
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(LogCapturingExtension.class)
 public class AwsLambdaFlowTest {

--- a/awslambda/src/test/java/docs/javadsl/Examples.java
+++ b/awslambda/src/test/java/docs/javadsl/Examples.java
@@ -13,28 +13,27 @@
 
 package docs.javadsl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.NotUsed;
 // #init-sys
 import org.apache.pekko.actor.ActorSystem;
 // #init-sys
 import org.apache.pekko.stream.connectors.awslambda.javadsl.AwsLambdaFlow;
+import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 // #init-client
-import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+// #run
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
 // #init-client
 // #run
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
-import software.amazon.awssdk.core.SdkBytes;
-// #run
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 public class Examples {
 

--- a/awslambda/src/test/java/docs/javadsl/Examples.java
+++ b/awslambda/src/test/java/docs/javadsl/Examples.java
@@ -13,27 +13,28 @@
 
 package docs.javadsl;
 
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 import org.apache.pekko.NotUsed;
 // #init-sys
 import org.apache.pekko.actor.ActorSystem;
 // #init-sys
 import org.apache.pekko.stream.connectors.awslambda.javadsl.AwsLambdaFlow;
-import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 // #init-client
+import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.SdkBytes;
-// #run
 import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
 // #init-client
 // #run
 import software.amazon.awssdk.services.lambda.model.InvokeRequest;
 import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+import software.amazon.awssdk.core.SdkBytes;
+// #run
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 public class Examples {
 

--- a/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
+++ b/azure-storage-queue/src/test/java/docs/javadsl/JavaDslTest.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import com.microsoft.azure.storage.*;
+import com.microsoft.azure.storage.queue.*;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -26,23 +35,12 @@ import org.apache.pekko.stream.connectors.azure.storagequeue.javadsl.AzureQueueW
 import org.apache.pekko.stream.connectors.azure.storagequeue.javadsl.MessageAndDeleteOrUpdate;
 import org.apache.pekko.stream.connectors.azure.storagequeue.javadsl.MessageWithTimeouts;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.microsoft.azure.storage.*;
-import com.microsoft.azure.storage.queue.*;
-
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Supplier;
-
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JavaDslTest {

--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -13,38 +13,35 @@
 
 package docs.javadsl;
 
+import static docs.javadsl.CassandraTestHelper.await;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+// #prepared
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
 import org.apache.pekko.Done;
 // #prepared
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.function.Function2;
 import org.apache.pekko.japi.Pair;
+import org.apache.pekko.japi.function.Function2;
 import org.apache.pekko.stream.connectors.cassandra.CassandraWriteSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraFlow;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.SourceWithContext;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
-import com.datastax.oss.driver.api.core.cql.PreparedStatement;
-// #prepared
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSource;
 import org.apache.pekko.stream.connectors.cassandra.scaladsl.CassandraAccess;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.javadsl.SourceWithContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.*;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import static docs.javadsl.CassandraTestHelper.await;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class CassandraFlowTest {

--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -13,35 +13,38 @@
 
 package docs.javadsl;
 
-import static docs.javadsl.CassandraTestHelper.await;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
-import com.datastax.oss.driver.api.core.cql.PreparedStatement;
-// #prepared
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.*;
 import org.apache.pekko.Done;
 // #prepared
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
 import org.apache.pekko.japi.function.Function2;
+import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.cassandra.CassandraWriteSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraFlow;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.pekko.stream.javadsl.SourceWithContext;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+// #prepared
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSource;
 import org.apache.pekko.stream.connectors.cassandra.scaladsl.CassandraAccess;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.stream.javadsl.SourceWithContext;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import static docs.javadsl.CassandraTestHelper.await;
 
 @ExtendWith(LogCapturingExtension.class)
 public class CassandraFlowTest {

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -15,6 +15,18 @@ package docs.javadsl;
 
 // #init-session
 
+import static docs.javadsl.CassandraTestHelper.await;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+// #statement
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.cassandra.CassandraSessionSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
@@ -25,26 +37,12 @@ import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSource;
 // #cql
 import org.apache.pekko.stream.connectors.cassandra.scaladsl.CassandraAccess;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
-// #statement
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.oss.driver.api.core.cql.Statement;
 // #statement
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
-
-import static docs.javadsl.CassandraTestHelper.await;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class CassandraSourceTest {

--- a/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraSourceTest.java
@@ -15,18 +15,6 @@ package docs.javadsl;
 
 // #init-session
 
-import static docs.javadsl.CassandraTestHelper.await;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
-import com.datastax.oss.driver.api.core.cql.Statement;
-// #statement
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.cassandra.CassandraSessionSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
@@ -37,12 +25,26 @@ import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSource;
 // #cql
 import org.apache.pekko.stream.connectors.cassandra.scaladsl.CassandraAccess;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
+// #statement
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
 // #statement
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static docs.javadsl.CassandraTestHelper.await;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(LogCapturingExtension.class)
 public class CassandraSourceTest {

--- a/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraTestHelper.java
@@ -13,6 +13,11 @@
 
 package docs.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.cassandra.CassandraSessionSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
@@ -22,12 +27,6 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
-
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class CassandraTestHelper {
   final ActorSystem system;

--- a/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
@@ -13,12 +13,11 @@
 
 package org.apache.pekko.stream.connectors.couchbase.javadsl;
 
+import com.typesafe.config.Config;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
-import com.typesafe.config.Config;
-
-import java.util.concurrent.CompletionStage;
 
 /**
  * Utility to delegate Couchbase node address lookup to

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -13,23 +13,27 @@
 
 package docs.javadsl;
 
-import static com.couchbase.client.java.query.Select.select;
-import static com.couchbase.client.java.query.dsl.Expression.*;
-// #statement
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import com.couchbase.client.java.Bucket;
-import com.couchbase.client.java.CouchbaseCluster;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.Materializer;
+// #deleteWithResult
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseDeleteResult;
+// #deleteWithResult
+// #upsertDocWithResult
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteFailure;
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteResult;
+// #upsertDocWithResult
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteSettings;
+import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseFlow;
+import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSource;
+import org.apache.pekko.stream.connectors.couchbase.testing.CouchbaseSupportClass;
+import org.apache.pekko.stream.connectors.couchbase.testing.TestObject;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
-import com.couchbase.client.java.auth.PasswordAuthenticator;
-// #sessionFromBucket
-// #statement
 import com.couchbase.client.java.document.JsonDocument;
 import com.couchbase.client.java.document.StringDocument;
 import com.couchbase.client.java.document.json.JsonObject;
@@ -45,40 +49,39 @@ import com.couchbase.client.java.query.N1qlParams;
 import com.couchbase.client.java.query.N1qlQuery;
 // #n1ql
 import com.couchbase.client.java.query.SimpleN1qlQuery;
+
+import org.junit.jupiter.api.*;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
 // #registry
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.Materializer;
-// #deleteWithResult
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseDeleteResult;
-// #deleteWithResult
-// #upsertDocWithResult
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionRegistry;
 // #session
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteFailure;
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteResult;
-// #upsertDocWithResult
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteSettings;
-import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseFlow;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSession;
 // #session
 // #registry
 // #sessionFromBucket
-import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSource;
-import org.apache.pekko.stream.connectors.couchbase.testing.CouchbaseSupportClass;
-import org.apache.pekko.stream.connectors.couchbase.testing.TestObject;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.api.extension.ExtendWith;
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.CouchbaseCluster;
+import com.couchbase.client.java.auth.PasswordAuthenticator;
+// #sessionFromBucket
+// #statement
+import static com.couchbase.client.java.query.Select.select;
+import static com.couchbase.client.java.query.dsl.Expression.*;
+// #statement
+
 import scala.concurrent.duration.FiniteDuration;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(LogCapturingExtension.class)
 public class CouchbaseExamplesTest {

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -13,27 +13,23 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.Materializer;
-// #deleteWithResult
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseDeleteResult;
-// #deleteWithResult
-// #upsertDocWithResult
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteFailure;
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteResult;
-// #upsertDocWithResult
-import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteSettings;
-import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseFlow;
-import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSource;
-import org.apache.pekko.stream.connectors.couchbase.testing.CouchbaseSupportClass;
-import org.apache.pekko.stream.connectors.couchbase.testing.TestObject;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
+import static com.couchbase.client.java.query.Select.select;
+import static com.couchbase.client.java.query.dsl.Expression.*;
+// #statement
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.CouchbaseCluster;
 import com.couchbase.client.java.PersistTo;
 import com.couchbase.client.java.ReplicateTo;
+import com.couchbase.client.java.auth.PasswordAuthenticator;
+// #sessionFromBucket
+// #statement
 import com.couchbase.client.java.document.JsonDocument;
 import com.couchbase.client.java.document.StringDocument;
 import com.couchbase.client.java.document.json.JsonObject;
@@ -49,39 +45,40 @@ import com.couchbase.client.java.query.N1qlParams;
 import com.couchbase.client.java.query.N1qlQuery;
 // #n1ql
 import com.couchbase.client.java.query.SimpleN1qlQuery;
-
-import org.junit.jupiter.api.*;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.*;
 // #registry
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.Materializer;
+// #deleteWithResult
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseDeleteResult;
+// #deleteWithResult
+// #upsertDocWithResult
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionRegistry;
 // #session
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteFailure;
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteResult;
+// #upsertDocWithResult
+import org.apache.pekko.stream.connectors.couchbase.CouchbaseWriteSettings;
+import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseFlow;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSession;
 // #session
 // #registry
 // #sessionFromBucket
-import com.couchbase.client.java.Bucket;
-import com.couchbase.client.java.CouchbaseCluster;
-import com.couchbase.client.java.auth.PasswordAuthenticator;
-// #sessionFromBucket
-// #statement
-import static com.couchbase.client.java.query.Select.select;
-import static com.couchbase.client.java.query.dsl.Expression.*;
-// #statement
-
+import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSource;
+import org.apache.pekko.stream.connectors.couchbase.testing.CouchbaseSupportClass;
+import org.apache.pekko.stream.connectors.couchbase.testing.TestObject;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.concurrent.duration.FiniteDuration;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(LogCapturingExtension.class)
 public class CouchbaseExamplesTest {

--- a/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
+++ b/couchbase/src/test/java/docs/javadsl/CouchbaseExamplesTest.java
@@ -28,7 +28,6 @@ import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSource;
 import org.apache.pekko.stream.connectors.couchbase.testing.CouchbaseSupportClass;
 import org.apache.pekko.stream.connectors.couchbase.testing.TestObject;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
@@ -51,6 +50,7 @@ import com.couchbase.client.java.query.N1qlQuery;
 import com.couchbase.client.java.query.SimpleN1qlQuery;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.time.Duration;
 import java.util.ArrayList;

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -13,27 +13,28 @@
 
 package docs.javadsl;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 import org.apache.pekko.actor.ActorSystem;
 // #registry
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionRegistry;
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
+import org.apache.pekko.stream.connectors.couchbase.javadsl.DiscoverySupport;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSession;
 // #registry
-import org.apache.pekko.stream.connectors.couchbase.javadsl.DiscoverySupport;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
 import org.apache.pekko.testkit.javadsl.TestKit;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 @ExtendWith(LogCapturingExtension.class)
 public class DiscoveryTest {

--- a/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
+++ b/couchbase/src/test/java/docs/javadsl/DiscoveryTest.java
@@ -13,29 +13,27 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.actor.ActorSystem;
 // #registry
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionRegistry;
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
-import org.apache.pekko.stream.connectors.couchbase.javadsl.DiscoverySupport;
 import org.apache.pekko.stream.connectors.couchbase.javadsl.CouchbaseSession;
 // #registry
+import org.apache.pekko.stream.connectors.couchbase.javadsl.DiscoverySupport;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class DiscoveryTest {

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvFormatting.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvFormatting.java
@@ -13,6 +13,10 @@
 
 package org.apache.pekko.stream.connectors.csv.javadsl;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.Optional;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.csv.scaladsl.CsvQuotingStyle$;
 import org.apache.pekko.stream.javadsl.Flow;
@@ -21,11 +25,6 @@ import scala.Option;
 import scala.Some;
 import scala.collection.JavaConverters;
 import scala.collection.immutable.List;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.util.Collection;
-import java.util.Optional;
 
 /**
  * Provides CSV formatting flows that convert a sequence of String into their CSV representation in

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvParsing.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvParsing.java
@@ -13,12 +13,11 @@
 
 package org.apache.pekko.stream.connectors.csv.javadsl;
 
+import java.util.Collection;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.util.ByteString;
 import scala.collection.JavaConverters;
-
-import java.util.Collection;
 
 public class CsvParsing {
 

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvToMap.java
@@ -13,17 +13,16 @@
 
 package org.apache.pekko.stream.connectors.csv.javadsl;
 
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.connectors.csv.impl.CsvToMapAsStringsJavaStage;
-import org.apache.pekko.stream.connectors.csv.impl.CsvToMapJavaStage;
-import org.apache.pekko.util.ByteString;
-
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.pekko.stream.connectors.csv.impl.CsvToMapAsStringsJavaStage;
+import org.apache.pekko.stream.connectors.csv.impl.CsvToMapJavaStage;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.util.ByteString;
 
 public class CsvToMap {
 

--- a/doc-examples/src/test/java/org/apache/pekko/stream/connectors/eip/javadsl/PassThroughExamples.java
+++ b/doc-examples/src/test/java/org/apache/pekko/stream/connectors/eip/javadsl/PassThroughExamples.java
@@ -13,6 +13,11 @@
 
 package org.apache.pekko.stream.connectors.eip.javadsl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -27,15 +32,9 @@ import org.apache.pekko.kafka.javadsl.Consumer;
 import org.apache.pekko.stream.*;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.kafka.common.serialization.ByteArrayDeserializer;
-import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
 
 public class PassThroughExamples {
   private static ActorSystem system;

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -16,18 +16,17 @@ package docs.javadsl;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.testkit.javadsl.TestKit;
-
 import org.junit.jupiter.api.Test;
 // #clientRetryConfig
+import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.retries.DefaultRetryStrategy;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 // #awsRetryConfiguration
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
-import software.amazon.awssdk.retries.DefaultRetryStrategy;
 
 // #clientRetryConfig
 

--- a/dynamodb/src/test/java/docs/javadsl/RetryTest.java
+++ b/dynamodb/src/test/java/docs/javadsl/RetryTest.java
@@ -16,17 +16,18 @@ package docs.javadsl;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.testkit.javadsl.TestKit;
+
 import org.junit.jupiter.api.Test;
 // #clientRetryConfig
-import org.junit.jupiter.api.extension.ExtendWith;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.regions.Region;
-import software.amazon.awssdk.retries.DefaultRetryStrategy;
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient;
 // #awsRetryConfiguration
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
+import software.amazon.awssdk.retries.DefaultRetryStrategy;
 
 // #clientRetryConfig
 

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchParameterizedTest.java
@@ -13,27 +13,26 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.connectors.elasticsearch.*;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.connectors.elasticsearch.*;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class ElasticsearchParameterizedTest extends ElasticsearchTestBase {
   private ApiVersion apiVersion;

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -13,6 +13,9 @@
 
 package docs.javadsl;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.model.ContentTypes;
@@ -24,14 +27,10 @@ import org.apache.pekko.stream.connectors.elasticsearch.ElasticsearchParams;
 import org.apache.pekko.stream.connectors.elasticsearch.OpensearchApiVersion;
 import org.apache.pekko.stream.connectors.elasticsearch.OpensearchParams;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class ElasticsearchTestBase {

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV5Test.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.elasticsearch.*;
@@ -21,18 +29,9 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSin
 import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ElasticsearchV5Test extends ElasticsearchTestBase {
   @BeforeAll

--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchV7Test.java
@@ -13,6 +13,13 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.elasticsearch.*;
@@ -21,17 +28,9 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSin
 import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ElasticsearchV7Test extends ElasticsearchTestBase {
   @BeforeAll

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchParameterizedTest.java
@@ -13,27 +13,26 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.connectors.elasticsearch.*;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
-import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.connectors.elasticsearch.*;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchFlow;
+import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class OpensearchParameterizedTest extends ElasticsearchTestBase {
   private OpensearchApiVersion apiVersion;

--- a/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
+++ b/elasticsearch/src/test/java/docs/javadsl/OpensearchV1Test.java
@@ -13,6 +13,13 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.elasticsearch.*;
@@ -21,17 +28,9 @@ import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSin
 import org.apache.pekko.stream.connectors.elasticsearch.javadsl.ElasticsearchSource;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class OpensearchV1Test extends ElasticsearchTestBase {
   @BeforeAll

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
@@ -13,6 +13,14 @@
 
 package org.apache.pekko.stream.connectors.file.impl;
 
+import static java.nio.file.StandardWatchEventKinds.*;
+
+import com.sun.nio.file.SensitivityWatchEventModifier;
+import java.io.IOException;
+import java.nio.file.*;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.function.BiFunction;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.annotation.InternalApi;
 import org.apache.pekko.japi.Pair;
@@ -25,16 +33,7 @@ import org.apache.pekko.stream.stage.AbstractOutHandler;
 import org.apache.pekko.stream.stage.GraphStage;
 import org.apache.pekko.stream.stage.GraphStageLogic;
 import org.apache.pekko.stream.stage.TimerGraphStageLogic;
-import com.sun.nio.file.SensitivityWatchEventModifier;
 import scala.concurrent.duration.FiniteDuration;
-
-import java.io.IOException;
-import java.nio.file.*;
-import java.util.ArrayDeque;
-import java.util.Queue;
-import java.util.function.BiFunction;
-
-import static java.nio.file.StandardWatchEventKinds.*;
 
 /**
  * INTERNAL API

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/FileTailSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/FileTailSource.java
@@ -13,6 +13,13 @@
 
 package org.apache.pekko.stream.connectors.file.impl;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.AsynchronousFileChannel;
+import java.nio.channels.CompletionHandler;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import org.apache.pekko.annotation.InternalApi;
 import org.apache.pekko.stream.Attributes;
 import org.apache.pekko.stream.Outlet;
@@ -23,14 +30,6 @@ import scala.concurrent.duration.FiniteDuration;
 import scala.util.Failure;
 import scala.util.Success;
 import scala.util.Try;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.AsynchronousFileChannel;
-import java.nio.channels.CompletionHandler;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 /**
  * INTERNAL API

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/Directory.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/Directory.java
@@ -13,15 +13,14 @@
 
 package org.apache.pekko.stream.connectors.file.javadsl;
 
+import java.nio.file.FileVisitOption;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.StreamConverters;
-
-import java.nio.file.FileVisitOption;
-import java.nio.file.Files;
-import java.nio.file.Path;
 
 public final class Directory {
 

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/DirectoryChangesSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/DirectoryChangesSource.java
@@ -13,13 +13,11 @@
 
 package org.apache.pekko.stream.connectors.file.javadsl;
 
+import java.nio.file.Path;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.file.DirectoryChange;
 import org.apache.pekko.stream.javadsl.Source;
-
-import java.nio.file.Path;
-
 import scala.jdk.javaapi.DurationConverters;
 
 /**

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
@@ -13,15 +13,13 @@
 
 package org.apache.pekko.stream.connectors.file.javadsl;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.javadsl.Framing;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Path;
-
 import scala.jdk.javaapi.DurationConverters;
 
 /**

--- a/file/src/test/java/docs/javadsl/ArchiveHelper.java
+++ b/file/src/test/java/docs/javadsl/ArchiveHelper.java
@@ -13,13 +13,12 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.util.ByteString;
-
 import java.io.ByteArrayOutputStream;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+import org.apache.pekko.util.ByteString;
 
 public class ArchiveHelper {
 

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -13,28 +13,9 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.IOResult;
-import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.stream.connectors.file.ArchiveMetadata;
-import org.apache.pekko.stream.connectors.file.TarArchiveMetadata;
-import org.apache.pekko.stream.connectors.file.ZipArchiveMetadata;
-import org.apache.pekko.stream.connectors.file.javadsl.Archive;
-import org.apache.pekko.stream.connectors.file.javadsl.Directory;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.FileIO;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.pekko.util.ByteString;
-import org.junit.jupiter.api.*;
-
 import static org.apache.pekko.util.ByteString.emptyByteString;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.*;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -47,9 +28,26 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.MatcherAssert.*;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.IOResult;
+import org.apache.pekko.stream.Materializer;
+import org.apache.pekko.stream.connectors.file.ArchiveMetadata;
+import org.apache.pekko.stream.connectors.file.TarArchiveMetadata;
+import org.apache.pekko.stream.connectors.file.ZipArchiveMetadata;
+import org.apache.pekko.stream.connectors.file.javadsl.Archive;
+import org.apache.pekko.stream.connectors.file.javadsl.Directory;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.FileIO;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class ArchiveTest {

--- a/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
@@ -13,19 +13,6 @@
 
 package docs.javadsl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
-import com.google.common.jimfs.WatchServiceConfiguration;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -40,8 +27,22 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.google.common.jimfs.WatchServiceConfiguration;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(LogCapturingExtension.class)
 public class DirectoryChangesSourceTest {

--- a/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryChangesSourceTest.java
@@ -13,6 +13,19 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import com.google.common.jimfs.WatchServiceConfiguration;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -22,27 +35,13 @@ import org.apache.pekko.stream.connectors.file.DirectoryChange;
 import org.apache.pekko.stream.connectors.file.javadsl.DirectoryChangesSource;
 // #minimal-sample
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
-import com.google.common.jimfs.WatchServiceConfiguration;
 import org.junit.jupiter.api.*;
-
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class DirectoryChangesSourceTest {

--- a/file/src/test/java/docs/javadsl/DirectoryTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryTest.java
@@ -13,6 +13,19 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
+import java.nio.file.FileSystem;
+import java.nio.file.FileVisitOption;
+// #walk
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -21,29 +34,15 @@ import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.file.javadsl.Directory;
 // #ls
-import java.nio.file.FileVisitOption;
-// #walk
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.*;
-
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class DirectoryTest {

--- a/file/src/test/java/docs/javadsl/DirectoryTest.java
+++ b/file/src/test/java/docs/javadsl/DirectoryTest.java
@@ -13,19 +13,6 @@
 
 package docs.javadsl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Jimfs;
-import java.nio.file.FileSystem;
-import java.nio.file.FileVisitOption;
-// #walk
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -34,6 +21,8 @@ import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.file.javadsl.Directory;
 // #ls
+import java.nio.file.FileVisitOption;
+// #walk
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
@@ -41,8 +30,20 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
+import com.google.common.jimfs.Configuration;
+import com.google.common.jimfs.Jimfs;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(LogCapturingExtension.class)
 public class DirectoryTest {

--- a/file/src/test/java/docs/javadsl/FileTailSourceTest.java
+++ b/file/src/test/java/docs/javadsl/FileTailSourceTest.java
@@ -13,26 +13,13 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.pf.PFBuilder;
-import org.apache.pekko.stream.KillSwitches;
-import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.stream.UniqueKillSwitch;
-import org.apache.pekko.stream.connectors.file.DirectoryChange;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.stream.testkit.TestSubscriber;
-import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.pekko.util.ByteString;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.nio.file.StandardOpenOption.WRITE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import org.junit.jupiter.api.*;
-
 import java.io.FileNotFoundException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
@@ -42,11 +29,23 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.TimeoutException;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.StandardOpenOption.APPEND;
-import static java.nio.file.StandardOpenOption.WRITE;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.pf.PFBuilder;
+import org.apache.pekko.stream.KillSwitches;
+import org.apache.pekko.stream.Materializer;
+import org.apache.pekko.stream.UniqueKillSwitch;
+import org.apache.pekko.stream.connectors.file.DirectoryChange;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.testkit.TestSubscriber;
+import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class FileTailSourceTest {

--- a/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
+++ b/file/src/test/java/docs/javadsl/LogRotatorSinkTest.java
@@ -13,20 +13,7 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.function.Creator;
-import org.apache.pekko.japi.function.Function;
-import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.stream.connectors.file.javadsl.LogRotatorSink;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.*;
-import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.pekko.util.ByteString;
-import org.junit.jupiter.api.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -37,8 +24,20 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.function.Creator;
+import org.apache.pekko.japi.function.Function;
+import org.apache.pekko.stream.Materializer;
+import org.apache.pekko.stream.connectors.file.javadsl.LogRotatorSink;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.*;
+import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class LogRotatorSinkTest {

--- a/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
+++ b/file/src/test/java/docs/javadsl/NestedTarReaderTest.java
@@ -13,25 +13,8 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.ClassicActorSystemProvider;
-import org.apache.pekko.stream.connectors.file.TarArchiveMetadata;
-import org.apache.pekko.stream.connectors.file.javadsl.Archive;
-import org.apache.pekko.stream.connectors.file.javadsl.Directory;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.*;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.pekko.util.ByteString;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.CoreMatchers.*;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,6 +22,22 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.ClassicActorSystemProvider;
+import org.apache.pekko.stream.connectors.file.TarArchiveMetadata;
+import org.apache.pekko.stream.connectors.file.javadsl.Archive;
+import org.apache.pekko.stream.connectors.file.javadsl.Directory;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.*;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @ExtendWith(LogCapturingExtension.class)
 public class NestedTarReaderTest {

--- a/ftp/src/main/java/org/apache/commons/net/ftp/LegacyFtpsClient.java
+++ b/ftp/src/main/java/org/apache/commons/net/ftp/LegacyFtpsClient.java
@@ -23,7 +23,6 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
-
 import javax.net.ssl.SSLSocket;
 
 /**

--- a/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
+++ b/ftp/src/test/java/docs/javadsl/ConfigureCustomSSHClient.java
@@ -15,10 +15,10 @@ package docs.javadsl;
 
 // #configure-custom-ssh-client
 
-import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.ftp.javadsl.SftpApi;
 import net.schmizz.sshj.DefaultConfig;
 import net.schmizz.sshj.SSHClient;
+import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
+import org.apache.pekko.stream.connectors.ftp.javadsl.SftpApi;
 
 public class ConfigureCustomSSHClient {
 

--- a/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpMovingExample.java
@@ -14,13 +14,13 @@
 package docs.javadsl;
 
 // #moving
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.FtpFile;
 import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.Sink;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 public class FtpMovingExample {
 

--- a/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpProcessAndMoveExample.java
@@ -14,6 +14,8 @@
 package docs.javadsl;
 
 // #processAndMove
+import java.nio.file.Files;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.ftp.FtpFile;
@@ -21,9 +23,6 @@ import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.FileIO;
 import org.apache.pekko.stream.javadsl.RunnableGraph;
-
-import java.nio.file.Files;
-import java.util.function.Function;
 
 public class FtpProcessAndMoveExample {
 

--- a/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRemovingExample.java
@@ -14,12 +14,12 @@
 package docs.javadsl;
 
 // #removing
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.FtpFile;
 import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.Sink;
-import java.util.concurrent.CompletionStage;
 
 public class FtpRemovingExample {
 

--- a/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/FtpRetrievingExample.java
@@ -14,12 +14,12 @@
 package docs.javadsl;
 
 // #retrieving
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.FtpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-import java.util.concurrent.CompletionStage;
 
 public class FtpRetrievingExample {
 

--- a/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
+++ b/ftp/src/test/java/docs/javadsl/SftpRetrievingExample.java
@@ -15,13 +15,12 @@ package docs.javadsl;
 
 // #retrieving-with-unconfirmed-reads
 
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.SftpSettings;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-
-import java.util.concurrent.CompletionStage;
 
 public class SftpRetrievingExample {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/BaseSupportImpl.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/BaseSupportImpl.java
@@ -13,14 +13,13 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.Materializer;
-import org.junit.jupiter.api.AfterEach;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.Materializer;
+import org.junit.jupiter.api.AfterEach;
 
 public abstract class BaseSupportImpl implements BaseSupport, PekkoSupport {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
@@ -13,6 +13,16 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -23,16 +33,6 @@ import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
 import org.apache.pekko.util.ByteString;
-
-import java.time.Instant;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 interface CommonFtpStageTest extends BaseSupport, PekkoSupport {
 

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpStageTest.java
@@ -13,20 +13,19 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.Disabled;
-
 import org.junit.jupiter.api.Test;
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class FtpStageTest extends BaseFtpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpWithProxyStageTest.java
@@ -13,23 +13,21 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.IOResult;
-import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.util.ByteString;
-import org.junit.jupiter.api.Disabled;
-
-import org.junit.jupiter.api.Test;
-
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.IOResult;
+import org.apache.pekko.stream.connectors.ftp.javadsl.Ftp;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class FtpWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsStageTest.java
@@ -13,20 +13,18 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Ftps;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-
 import org.junit.jupiter.api.Test;
-
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class FtpsStageTest extends BaseFtpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/FtpsWithProxyStageTest.java
@@ -13,23 +13,21 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.IOResult;
-import org.apache.pekko.stream.connectors.ftp.javadsl.Ftps;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.util.ByteString;
-import org.junit.jupiter.api.Disabled;
-
-import org.junit.jupiter.api.Test;
-
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.IOResult;
+import org.apache.pekko.stream.connectors.ftp.javadsl.Ftps;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class FtpsWithProxyStageTest extends BaseFtpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/KeyFileSftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/KeyFileSftpSourceTest.java
@@ -13,19 +13,18 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-
 import org.junit.jupiter.api.Test;
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class KeyFileSftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/RawKeySftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/RawKeySftpSourceTest.java
@@ -13,21 +13,20 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.IOResult;
-import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.util.ByteString;
-
-import org.junit.jupiter.api.Test;
 import java.net.InetAddress;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.IOResult;
+import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class RawKeySftpSourceTest extends BaseSftpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpStageTest.java
@@ -13,21 +13,19 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.Disabled;
-
 import org.junit.jupiter.api.Test;
-
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class SftpStageTest extends BaseSftpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpWithProxyStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/SftpWithProxyStageTest.java
@@ -13,23 +13,21 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.IOResult;
-import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.util.ByteString;
-import org.junit.jupiter.api.Disabled;
-
-import org.junit.jupiter.api.Test;
-
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.stream.IOResult;
+import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class SftpWithProxyStageTest extends BaseSftpSupport implements CommonFtpStageTest {

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/StrictHostCheckingSftpSourceTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/StrictHostCheckingSftpSourceTest.java
@@ -13,19 +13,18 @@
 
 package org.apache.pekko.stream.connectors.ftp;
 
+import java.net.InetAddress;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.IOResult;
 import org.apache.pekko.stream.connectors.ftp.javadsl.Sftp;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
-
 import org.junit.jupiter.api.Test;
-import java.net.InetAddress;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class StrictHostCheckingSftpSourceTest extends BaseSftpSupport

--- a/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/Geode.java
+++ b/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/Geode.java
@@ -13,23 +13,20 @@
 
 package org.apache.pekko.stream.connectors.geode.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
-import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
 import org.apache.pekko.stream.connectors.geode.GeodeSettings;
+import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
 import org.apache.pekko.stream.connectors.geode.RegionSettings;
 import org.apache.pekko.stream.connectors.geode.impl.GeodeCache;
-
 import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeFiniteSourceStage;
 import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeFlowStage;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.apache.geode.cache.client.ClientCacheFactory;
-
-import java.util.concurrent.CompletionStage;
-
 import scala.jdk.javaapi.FutureConverters;
 
 /** Java API: Geode client without server event subscription. */

--- a/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/GeodeWithPoolSubscription.java
+++ b/geode/src/main/java/org/apache/pekko/stream/connectors/geode/javadsl/GeodeWithPoolSubscription.java
@@ -13,18 +13,16 @@
 
 package org.apache.pekko.stream.connectors.geode.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
-import org.apache.pekko.stream.connectors.geode.GeodeSettings;
-import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeContinuousSourceStage;
-import org.apache.pekko.stream.javadsl.Source;
+import java.util.concurrent.CompletionStage;
 import org.apache.geode.cache.client.ClientCacheFactory;
 import org.apache.geode.cache.query.CqException;
 import org.apache.geode.cache.query.CqQuery;
 import org.apache.geode.cache.query.QueryService;
-
-import java.util.concurrent.CompletionStage;
-
+import org.apache.pekko.Done;
+import org.apache.pekko.stream.connectors.geode.GeodeSettings;
+import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
+import org.apache.pekko.stream.connectors.geode.impl.stage.GeodeContinuousSourceStage;
+import org.apache.pekko.stream.javadsl.Source;
 import scala.jdk.javaapi.FutureConverters;
 
 /** Java API: Geode client with server event subscription. Can build continuous sources. */

--- a/geode/src/test/java/docs/javadsl/AnimalPdxSerializer.java
+++ b/geode/src/test/java/docs/javadsl/AnimalPdxSerializer.java
@@ -13,9 +13,9 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
 import org.apache.geode.pdx.PdxReader;
 import org.apache.geode.pdx.PdxWriter;
+import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
 
 // #animal-pdx-serializer
 public class AnimalPdxSerializer implements PekkoPdxSerializer<Animal> {

--- a/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeBaseTestCase.java
@@ -13,6 +13,8 @@
 
 package docs.javadsl;
 
+import java.util.Date;
+import java.util.List;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.geode.GeodeSettings;
@@ -20,17 +22,13 @@ import org.apache.pekko.stream.connectors.geode.RegionSettings;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
 import org.apache.pekko.stream.connectors.geode.javadsl.GeodeWithPoolSubscription;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Date;
-import java.util.List;
 
 @ExtendWith(LogCapturingExtension.class)
 public class GeodeBaseTestCase {

--- a/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeContinuousSourceTestCase.java
@@ -13,23 +13,21 @@
 
 package docs.javadsl;
 
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.geode.javadsl.GeodeWithPoolSubscription;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.Date;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class GeodeContinuousSourceTestCase extends GeodeBaseTestCase {

--- a/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFiniteSourceTestCase.java
@@ -13,15 +13,13 @@
 
 package docs.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.Done;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class GeodeFiniteSourceTestCase extends GeodeBaseTestCase {

--- a/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeFlowTestCase.java
@@ -13,20 +13,18 @@
 
 package docs.javadsl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class GeodeFlowTestCase extends GeodeBaseTestCase {

--- a/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
+++ b/geode/src/test/java/docs/javadsl/GeodeSinkTestCase.java
@@ -13,20 +13,18 @@
 
 package docs.javadsl;
 
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.geode.javadsl.Geode;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.RunnableGraph;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class GeodeSinkTestCase extends GeodeBaseTestCase {

--- a/geode/src/test/java/docs/javadsl/PersonPdxSerializer.java
+++ b/geode/src/test/java/docs/javadsl/PersonPdxSerializer.java
@@ -13,11 +13,10 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
+import java.util.Date;
 import org.apache.geode.pdx.PdxReader;
 import org.apache.geode.pdx.PdxWriter;
-
-import java.util.Date;
+import org.apache.pekko.stream.connectors.geode.PekkoPdxSerializer;
 
 // #person-pdx-serializer
 public class PersonPdxSerializer implements PekkoPdxSerializer<Person> {

--- a/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
+++ b/google-cloud-bigquery-storage/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/storage/javadsl/BigQueryStorageSpec.java
@@ -13,6 +13,15 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.javadsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.google.cloud.bigquery.storage.v1.DataFormat;
+import com.google.cloud.bigquery.storage.v1.ReadSession;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pekko.stream.Attributes;
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryRecord;
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryStorageSettings;
@@ -20,21 +29,9 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.BigQueryS
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.scaladsl.BigQueryStorageAttributes;
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.storage.scaladsl.GrpcBigQueryStorageReader;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
-
-import com.google.cloud.bigquery.storage.v1.DataFormat;
-import com.google.cloud.bigquery.storage.v1.ReadSession;
-
 import org.junit.jupiter.api.*;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class BigQueryStorageSpec extends BigQueryStorageSpecBase {

--- a/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
+++ b/google-cloud-bigquery/src/test/java/docs/javadsl/BigQueryDoc.java
@@ -15,6 +15,21 @@ package docs.javadsl;
 
 // #imports
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.http.javadsl.marshallers.jackson.Jackson;
@@ -43,22 +58,6 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableSchema
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
-
-import java.io.IOException;
-import java.util.Collections;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
 
 // #imports
 

--- a/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
+++ b/google-cloud-bigquery/src/test/java/org/apache/pekko/stream/connectors/googlecloud/bigquery/e2e/javadsl/BigQueryEndToEndTest.java
@@ -13,6 +13,25 @@
 
 package org.apache.pekko.stream.connectors.googlecloud.bigquery.e2e.javadsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.specto.hoverfly.junit.core.Hoverfly;
+import io.specto.hoverfly.junit.core.HoverflyMode;
+import io.specto.hoverfly.junit.core.SimulationSource;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.marshallers.jackson.Jackson;
@@ -36,29 +55,9 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableFieldS
 import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableSchema;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import io.specto.hoverfly.junit.core.Hoverfly;
-import io.specto.hoverfly.junit.core.HoverflyMode;
-import io.specto.hoverfly.junit.core.SimulationSource;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.OptionalLong;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 public class BigQueryEndToEndTest extends EndToEndHelper {
 

--- a/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
+++ b/google-cloud-pub-sub/src/test/java/docs/javadsl/ExampleUsageJava.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import com.google.common.collect.Lists;
+import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -22,16 +31,6 @@ import org.apache.pekko.stream.RestartSettings;
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.*;
 import org.apache.pekko.stream.connectors.googlecloud.pubsub.javadsl.GooglePubSub;
 import org.apache.pekko.stream.javadsl.*;
-import com.google.common.collect.Lists;
-
-import java.security.NoSuchAlgorithmException;
-import java.security.spec.InvalidKeySpecException;
-import java.time.Duration;
-import java.util.Base64;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
 
 public class ExampleUsageJava {
 

--- a/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
+++ b/google-cloud-storage/src/test/java/docs/javadsl/GCStorageTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -26,20 +32,12 @@ import org.apache.pekko.stream.connectors.googlecloud.storage.StorageObject;
 import org.apache.pekko.stream.connectors.googlecloud.storage.javadsl.GCStorage;
 import org.apache.pekko.stream.connectors.googlecloud.storage.scaladsl.GCStorageWiremockBase;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.AfterEach;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class GCStorageTest extends GCStorageWiremockBase {

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -13,26 +13,7 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.hbase.HTableSettings;
-import org.apache.pekko.stream.connectors.hbase.javadsl.HTableStage;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.client.*;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
@@ -42,8 +23,25 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.hbase.HTableSettings;
+import org.apache.pekko.stream.connectors.hbase.javadsl.HTableStage;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class HBaseStageTest {

--- a/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsReaderTest.java
@@ -13,6 +13,18 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.compress.DefaultCodec;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -22,26 +34,13 @@ import org.apache.pekko.stream.connectors.hdfs.javadsl.HdfsFlow;
 import org.apache.pekko.stream.connectors.hdfs.javadsl.HdfsSource;
 import org.apache.pekko.stream.connectors.hdfs.util.JavaTestUtils;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hdfs.MiniDFSCluster;
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.compress.DefaultCodec;
 import org.junit.jupiter.api.*;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class HdfsReaderTest {

--- a/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
+++ b/hdfs/src/test/java/docs/javadsl/HdfsWriterTest.java
@@ -13,21 +13,15 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.actor.Cancellable;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.hdfs.*;
-import org.apache.pekko.stream.connectors.hdfs.javadsl.HdfsFlow;
-import org.apache.pekko.stream.connectors.hdfs.util.JavaTestUtils;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.pekko.util.ByteString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -36,19 +30,23 @@ import org.apache.hadoop.hdfs.MiniDFSCluster;
 import org.apache.hadoop.io.SequenceFile;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.DefaultCodec;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.actor.Cancellable;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.hdfs.*;
+import org.apache.pekko.stream.connectors.hdfs.javadsl.HdfsFlow;
+import org.apache.pekko.stream.connectors.hdfs.util.JavaTestUtils;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.*;
-
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.concurrent.duration.Duration;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(LogCapturingExtension.class)
 public class HdfsWriterTest {

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbCpu.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbCpu.java
@@ -14,7 +14,6 @@
 package docs.javadsl;
 
 import java.time.Instant;
-
 import org.influxdb.annotation.Measurement;
 
 // #define-class

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceCpu.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceCpu.java
@@ -14,7 +14,6 @@
 package docs.javadsl;
 
 import java.time.Instant;
-
 import org.influxdb.annotation.Measurement;
 
 @Measurement(name = "cpu", database = "InfluxDbSourceTest")

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbSourceTest.java
@@ -13,27 +13,26 @@
 
 package docs.javadsl;
 
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.influxdb.InfluxDB;
-import org.influxdb.dto.Query;
-import org.influxdb.dto.QueryResult;
-import org.junit.jupiter.api.*;
-
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.Materializer;
-import org.apache.pekko.stream.connectors.influxdb.InfluxDbReadSettings;
-import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSource;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import org.apache.pekko.testkit.javadsl.TestKit;
 import static docs.javadsl.TestUtils.cleanDatabase;
 import static docs.javadsl.TestUtils.dropDatabase;
 import static docs.javadsl.TestUtils.populateDatabase;
 import static docs.javadsl.TestUtils.setupConnection;
+
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.Materializer;
+import org.apache.pekko.stream.connectors.influxdb.InfluxDbReadSettings;
+import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSource;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class InfluxDbSourceTest {

--- a/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
+++ b/influxdb/src/test/java/docs/javadsl/InfluxDbTest.java
@@ -13,6 +13,13 @@
 
 package docs.javadsl;
 
+import static docs.javadsl.TestUtils.cleanDatabase;
+import static docs.javadsl.TestUtils.dropDatabase;
+import static docs.javadsl.TestUtils.populateDatabase;
+import static docs.javadsl.TestUtils.resultToPoint;
+import static docs.javadsl.TestUtils.setupConnection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -22,15 +29,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.influxdb.InfluxDB;
-import org.influxdb.dto.Point;
-import org.influxdb.dto.Query;
-import org.influxdb.dto.QueryResult;
-import org.junit.jupiter.api.*;
-
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -41,16 +39,17 @@ import org.apache.pekko.stream.connectors.influxdb.InfluxDbWriteResult;
 import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbFlow;
 import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSink;
 import org.apache.pekko.stream.connectors.influxdb.javadsl.InfluxDbSource;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import static docs.javadsl.TestUtils.cleanDatabase;
-import static docs.javadsl.TestUtils.dropDatabase;
-import static docs.javadsl.TestUtils.populateDatabase;
-import static docs.javadsl.TestUtils.resultToPoint;
-import static docs.javadsl.TestUtils.setupConnection;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.influxdb.InfluxDB;
+import org.influxdb.dto.Point;
+import org.influxdb.dto.Query;
+import org.influxdb.dto.QueryResult;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class InfluxDbTest {

--- a/influxdb/src/test/java/docs/javadsl/TestUtils.java
+++ b/influxdb/src/test/java/docs/javadsl/TestUtils.java
@@ -13,21 +13,20 @@
 
 package docs.javadsl;
 
+import static docs.javadsl.TestConstants.INFLUXDB_URL;
+import static docs.javadsl.TestConstants.PASSWORD;
+import static docs.javadsl.TestConstants.USERNAME;
+
 import java.lang.reflect.Constructor;
 import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-
 import org.influxdb.InfluxDB;
 import org.influxdb.InfluxDBFactory;
 import org.influxdb.dto.Point;
 import org.influxdb.dto.Query;
 import org.influxdb.dto.QueryResult;
 import org.influxdb.impl.InfluxDBMapper;
-
-import static docs.javadsl.TestConstants.INFLUXDB_URL;
-import static docs.javadsl.TestConstants.PASSWORD;
-import static docs.javadsl.TestConstants.USERNAME;
 
 public class TestUtils {
 

--- a/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
+++ b/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/UnitTest.java
@@ -13,21 +13,20 @@
 
 package org.apache.pekko.stream.connectors.ironmq;
 
+import static scala.collection.JavaConverters.*;
+import static scala.jdk.javaapi.FutureConverters.*;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.ironmq.impl.IronMqClient;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.IntStream;
-
-import static scala.jdk.javaapi.FutureConverters.*;
-import static scala.collection.JavaConverters.*;
 
 public abstract class UnitTest {
 

--- a/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/javadsl/IronMqConsumerTest.java
+++ b/ironmq/src/test/java/org/apache/pekko/stream/connectors/ironmq/javadsl/IronMqConsumerTest.java
@@ -13,20 +13,18 @@
 
 package org.apache.pekko.stream.connectors.ironmq.javadsl;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.stream.connectors.ironmq.IronMqSettings;
 import org.apache.pekko.stream.connectors.ironmq.PushMessage;
 import org.apache.pekko.stream.connectors.ironmq.UnitTest;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.TimeUnit;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class IronMqConsumerTest extends UnitTest {

--- a/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -13,11 +13,20 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.typesafe.config.Config;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
@@ -29,24 +38,13 @@ import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsBufferedAckConnectorsTest {

--- a/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -13,38 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import com.typesafe.config.Config;
 import jakarta.jms.*;
-import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
-import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
-import org.apache.activemq.artemis.jms.client.ActiveMQSession;
-import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
-import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.jakartams.Destination;
-import org.apache.pekko.stream.connectors.jakartams.*;
-import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
-import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
-import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducerStatus;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
-import scala.util.Failure;
-import scala.util.Success;
-import scala.util.Try;
-
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -54,10 +28,34 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
+import org.apache.activemq.artemis.jms.client.ActiveMQSession;
+import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
+import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.jakartams.*;
+import org.apache.pekko.stream.connectors.jakartams.Destination;
+import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
+import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
+import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
+import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducerStatus;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.util.Failure;
+import scala.util.Success;
+import scala.util.Try;
 
 final class DummyJavaTests implements java.io.Serializable {
 

--- a/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -13,6 +13,8 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.ibm.mq.jakarta.jms.MQConnectionFactory;
 import com.ibm.mq.jakarta.jms.MQQueueConnectionFactory;
 import com.ibm.mq.jakarta.jms.MQQueueSession;
@@ -22,6 +24,14 @@ import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
 import jakarta.jms.Session;
 import jakarta.jms.TextMessage;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.jakartams.CustomDestination;
@@ -32,25 +42,13 @@ import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsIbmmqConnectorsTest {

--- a/jakartams/src/test/java/docs/javadsl/JmsSettingsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsSettingsTest.java
@@ -13,22 +13,20 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import java.time.Duration;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
 import org.apache.pekko.stream.connectors.jakartams.*;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
-
-import java.time.Duration;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 // #retry-settings #send-retry-settings
 

--- a/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -13,11 +13,21 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.typesafe.config.Config;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
@@ -29,25 +39,13 @@ import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jakartams.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsTxConnectorsTest {

--- a/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
+++ b/jakartams/src/test/java/org/apache/pekko/stream/connectors/jakartams/javadsl/JmsAckConnectorsTest.java
@@ -13,11 +13,18 @@
 
 package org.apache.pekko.stream.connectors.jakartams.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.typesafe.config.Config;
 import jakarta.jms.ConnectionFactory;
 import jakarta.jms.JMSException;
 import jakarta.jms.Message;
 import jakarta.jms.TextMessage;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQQueue;
 import org.apache.activemq.artemis.junit.EmbeddedActiveMQResource;
@@ -26,22 +33,13 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.jakartams.*;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsAckConnectorsTest {

--- a/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsBufferedAckConnectorsTest.java
@@ -13,6 +13,20 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.typesafe.config.Config;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import jmstestkit.JmsBroker;
+import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -21,29 +35,13 @@ import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import jmstestkit.JmsBroker;
-import com.typesafe.config.Config;
-import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsBufferedAckConnectorsTest {

--- a/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsConnectorsTest.java
@@ -13,38 +13,11 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.jms.Destination;
-import org.apache.pekko.stream.connectors.jms.*;
-import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
-import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
-import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
-import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducerStatus;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
 import com.typesafe.config.Config;
-import jmstestkit.JmsBroker;
-import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.ActiveMQSession;
-import org.apache.activemq.command.ActiveMQQueue;
-import org.apache.activemq.command.ActiveMQTextMessage;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
-import scala.util.Failure;
-import scala.util.Success;
-import scala.util.Try;
-
-import javax.jms.*;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -54,10 +27,35 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import javax.jms.*;
+import jmstestkit.JmsBroker;
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.ActiveMQSession;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.jms.*;
+import org.apache.pekko.stream.connectors.jms.Destination;
+import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
+import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
+import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
+import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducerStatus;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import scala.util.Failure;
+import scala.util.Success;
+import scala.util.Try;
 
 final class DummyJavaTests implements java.io.Serializable {
 

--- a/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -13,6 +13,25 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.ibm.mq.jms.MQConnectionFactory;
+import com.ibm.mq.jms.MQQueueConnectionFactory;
+import com.ibm.mq.jms.MQQueueSession;
+import com.ibm.mq.jms.MQTopicConnectionFactory;
+import com.ibm.msg.client.wmq.common.CommonConstants;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import javax.jms.Destination;
+import javax.jms.JMSException;
+import javax.jms.Session;
+import javax.jms.TextMessage;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.jms.CustomDestination;
@@ -23,34 +42,13 @@ import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import com.ibm.mq.jms.MQConnectionFactory;
-import com.ibm.mq.jms.MQQueueConnectionFactory;
-import com.ibm.mq.jms.MQQueueSession;
-import com.ibm.mq.jms.MQTopicConnectionFactory;
-import com.ibm.msg.client.wmq.common.CommonConstants;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import javax.jms.Destination;
-import javax.jms.JMSException;
-import javax.jms.Session;
-import javax.jms.TextMessage;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Function;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsIbmmqConnectorsTest {

--- a/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsTxConnectorsTest.java
@@ -13,6 +13,21 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.typesafe.config.Config;
+import java.time.Duration;
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import jmstestkit.JmsBroker;
+import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -21,30 +36,13 @@ import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumer;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsConsumerControl;
 import org.apache.pekko.stream.connectors.jms.javadsl.JmsProducer;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
-import jmstestkit.JmsBroker;
-import com.typesafe.config.Config;
-import org.apache.activemq.command.ActiveMQQueue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
-import java.time.Duration;
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsTxConnectorsTest {

--- a/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
+++ b/jms/src/test/java/org/apache/pekko/stream/connectors/jms/javadsl/JmsAckConnectorsTest.java
@@ -13,34 +13,32 @@
 
 package org.apache.pekko.stream.connectors.jms.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Pair;
-import org.apache.pekko.stream.connectors.jms.*;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.typesafe.config.Config;
-import org.apache.activemq.command.ActiveMQQueue;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
-import jmstestkit.JmsBroker;
-
-import javax.jms.ConnectionFactory;
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.TextMessage;
 import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import jmstestkit.JmsBroker;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.pekko.Done;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.jms.*;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JmsAckConnectorsTest {

--- a/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
+++ b/json-streaming/src/test/java/docs/javadsl/JsonReaderUsageTest.java
@@ -13,26 +13,24 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.json.javadsl.JsonReader;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.*;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.pekko.util.ByteString;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.MatcherAssert.assertThat;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.connectors.json.javadsl.JsonReader;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.*;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class JsonReaderUsageTest {

--- a/kinesis/src/test/java/docs/javadsl/KclSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KclSnippets.java
@@ -16,7 +16,6 @@ package docs.javadsl;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.CompletionStage;
-
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.kinesis.CommittableRecord;
 import org.apache.pekko.stream.connectors.kinesis.KinesisSchedulerCheckpointSettings;

--- a/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
@@ -15,13 +15,13 @@ package docs.javadsl;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.connectors.kinesisfirehose.KinesisFirehoseFlowSettings;
 import org.apache.pekko.stream.connectors.kinesisfirehose.javadsl.KinesisFirehoseFlow;
 import org.apache.pekko.stream.connectors.kinesisfirehose.javadsl.KinesisFirehoseSink;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 // #init-client
+import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import software.amazon.awssdk.services.firehose.FirehoseAsyncClient;
 // #init-client
 import software.amazon.awssdk.services.firehose.model.PutRecordBatchResponseEntry;

--- a/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisFirehoseSnippets.java
@@ -15,13 +15,13 @@ package docs.javadsl;
 
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.connectors.kinesisfirehose.KinesisFirehoseFlowSettings;
 import org.apache.pekko.stream.connectors.kinesisfirehose.javadsl.KinesisFirehoseFlow;
 import org.apache.pekko.stream.connectors.kinesisfirehose.javadsl.KinesisFirehoseSink;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 // #init-client
-import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import software.amazon.awssdk.services.firehose.FirehoseAsyncClient;
 // #init-client
 import software.amazon.awssdk.services.firehose.model.PutRecordBatchResponseEntry;

--- a/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
@@ -13,8 +13,6 @@
 
 package docs.javadsl;
 
-import java.time.Duration;
-import java.util.List;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
@@ -36,6 +34,9 @@ import software.amazon.awssdk.services.kinesis.model.PutRecordsResultEntry;
 import software.amazon.awssdk.services.kinesis.model.Record;
 // #source-settings
 // #source-settings
+
+import java.time.Duration;
+import java.util.List;
 
 public class KinesisSnippets {
 

--- a/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
+++ b/kinesis/src/test/java/docs/javadsl/KinesisSnippets.java
@@ -13,6 +13,8 @@
 
 package docs.javadsl;
 
+import java.time.Duration;
+import java.util.List;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
@@ -34,9 +36,6 @@ import software.amazon.awssdk.services.kinesis.model.PutRecordsResultEntry;
 import software.amazon.awssdk.services.kinesis.model.Record;
 // #source-settings
 // #source-settings
-
-import java.time.Duration;
-import java.util.List;
 
 public class KinesisSnippets {
 

--- a/kinesis/src/test/java/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisTest.java
+++ b/kinesis/src/test/java/org/apache/pekko/stream/connectors/kinesis/javadsl/KinesisTest.java
@@ -13,28 +13,26 @@
 
 package org.apache.pekko.stream.connectors.kinesis.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.kinesis.ShardSettings;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.services.kinesis.KinesisAsyncClient;
 import software.amazon.awssdk.services.kinesis.model.*;
-
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(LogCapturingExtension.class)
 public class KinesisTest {

--- a/kudu/src/test/java/docs/javadsl/KuduTableTest.java
+++ b/kudu/src/test/java/docs/javadsl/KuduTableTest.java
@@ -13,30 +13,6 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.kudu.KuduAttributes;
-import org.apache.pekko.stream.connectors.kudu.KuduTableSettings;
-import org.apache.pekko.stream.connectors.kudu.javadsl.KuduTable;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.kudu.ColumnSchema;
-import org.apache.kudu.Schema;
-import org.apache.kudu.Type;
-import org.apache.kudu.client.CreateTableOptions;
-import org.apache.kudu.client.KuduClient;
-import org.apache.kudu.client.KuduException;
-import org.apache.kudu.client.PartialRow;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
@@ -44,6 +20,29 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import org.apache.kudu.ColumnSchema;
+import org.apache.kudu.Schema;
+import org.apache.kudu.Type;
+import org.apache.kudu.client.CreateTableOptions;
+import org.apache.kudu.client.KuduClient;
+import org.apache.kudu.client.KuduException;
+import org.apache.kudu.client.PartialRow;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.connectors.kudu.KuduAttributes;
+import org.apache.pekko.stream.connectors.kudu.KuduTableSettings;
+import org.apache.pekko.stream.connectors.kudu.javadsl.KuduTable;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class KuduTableTest {

--- a/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSinkTest.java
@@ -13,6 +13,23 @@
 
 package docs.javadsl;
 
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.InsertManyOptions;
+import com.mongodb.client.model.Updates;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import com.mongodb.reactivestreams.client.MongoCollection;
+import com.mongodb.reactivestreams.client.MongoDatabase;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -22,34 +39,16 @@ import org.apache.pekko.stream.connectors.mongodb.DocumentReplace;
 import org.apache.pekko.stream.connectors.mongodb.DocumentUpdate;
 import org.apache.pekko.stream.connectors.mongodb.javadsl.MongoSink;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import com.mongodb.client.model.Filters;
-import com.mongodb.client.model.InsertManyOptions;
-import com.mongodb.client.model.Updates;
-import com.mongodb.reactivestreams.client.MongoClient;
-import com.mongodb.reactivestreams.client.MongoClients;
-import com.mongodb.reactivestreams.client.MongoCollection;
-import com.mongodb.reactivestreams.client.MongoDatabase;
 import org.bson.Document;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.bson.conversions.Bson;
 import org.junit.jupiter.api.*;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-
-import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
-import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class MongoSinkTest {

--- a/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
+++ b/mongodb/src/test/java/docs/javadsl/MongoSourceTest.java
@@ -13,30 +13,29 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mongodb.client.result.InsertManyResult;
+import com.mongodb.reactivestreams.client.*;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.connectors.mongodb.javadsl.MongoSource;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
-import com.mongodb.client.result.InsertManyResult;
-import com.mongodb.reactivestreams.client.*;
 import org.bson.Document;
 import org.bson.codecs.ValueCodecProvider;
 import org.bson.codecs.configuration.CodecRegistries;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.junit.jupiter.api.*;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class MongoSourceTest {

--- a/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt-streaming/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -13,6 +13,16 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -44,31 +54,20 @@ import org.apache.pekko.stream.connectors.mqtt.streaming.javadsl.Mqtt;
 import org.apache.pekko.stream.connectors.mqtt.streaming.javadsl.MqttClientSession;
 import org.apache.pekko.stream.connectors.mqtt.streaming.javadsl.MqttServerSession;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.pekko.stream.javadsl.BroadcastHub;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.SourceQueueWithComplete;
 import org.apache.pekko.stream.javadsl.Tcp;
-import org.apache.pekko.stream.javadsl.BroadcastHub;
 import org.apache.pekko.stream.testkit.javadsl.StreamTestKit;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Tuple2;
 import scala.collection.JavaConverters;
-
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(LogCapturingExtension.class)
 public class MqttFlowTest {

--- a/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -25,7 +31,6 @@ import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttFlow;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttMessageWithAckImpl;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -35,17 +40,10 @@ import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(LogCapturingExtension.class)
 public class MqttFlowTest {

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -13,6 +13,19 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLContext;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -24,7 +37,6 @@ import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttSink;
 import org.apache.pekko.stream.connectors.mqtt.javadsl.MqttSource;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
@@ -33,26 +45,10 @@ import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.client.mqttv3.persist.MemoryPersistence;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLContext;
-
-import static org.hamcrest.CoreMatchers.*;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(LogCapturingExtension.class)
 public class MqttSourceTest {

--- a/mqttv5/src/test/java/docs/javadsl/MqttFlowTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttFlowTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -25,7 +31,6 @@ import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttFlow;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttMessageWithAckImpl;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
@@ -35,17 +40,10 @@ import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(LogCapturingExtension.class)
 public class MqttFlowTest {

--- a/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -13,6 +13,20 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import javax.net.ssl.SSLContext;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -28,7 +42,6 @@ import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttMessageWithAck;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttSink;
 import org.apache.pekko.stream.connectors.mqttv5.javadsl.MqttSource;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.apache.pekko.stream.testkit.javadsl.TestSink;
@@ -37,25 +50,10 @@ import org.apache.pekko.util.ByteString;
 import org.eclipse.paho.mqttv5.client.persist.MemoryPersistence;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLContext;
-import java.util.HashSet;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @ExtendWith(LogCapturingExtension.class)
 public class MqttSourceTest {

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -13,37 +13,20 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteMessage;
-import org.apache.pekko.stream.connectors.orientdb.OrientDbSourceSettings;
-import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteSettings;
-import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbFlow;
-import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSink;
-import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSource;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import com.orientechnologies.orient.core.annotation.OVersion;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
+import com.orientechnologies.orient.core.db.ODatabasePool;
+// #init-settings
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
+import com.orientechnologies.orient.core.db.ODatabaseSession;
 import com.orientechnologies.orient.core.db.ODatabaseType;
 import com.orientechnologies.orient.core.db.OrientDB;
 import com.orientechnologies.orient.core.db.OrientDBConfig;
 // #init-settings
-import com.orientechnologies.orient.core.db.ODatabasePool;
-// #init-settings
-import com.orientechnologies.orient.core.db.ODatabaseSession;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,8 +34,23 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.connectors.orientdb.OrientDbSourceSettings;
+import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteMessage;
+import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteSettings;
+import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbFlow;
+import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSink;
+import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSource;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class OrientDbTest {

--- a/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
+++ b/orientdb/src/test/java/docs/javadsl/OrientDbTest.java
@@ -13,20 +13,37 @@
 
 package docs.javadsl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteMessage;
+import org.apache.pekko.stream.connectors.orientdb.OrientDbSourceSettings;
+import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteSettings;
+import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbFlow;
+import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSink;
+import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSource;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
 import com.orientechnologies.orient.core.annotation.OVersion;
 import com.orientechnologies.orient.core.db.ODatabaseDocumentInternal;
-import com.orientechnologies.orient.core.db.ODatabasePool;
-// #init-settings
 import com.orientechnologies.orient.core.db.ODatabaseRecordThreadLocal;
-import com.orientechnologies.orient.core.db.ODatabaseSession;
 import com.orientechnologies.orient.core.db.ODatabaseType;
 import com.orientechnologies.orient.core.db.OrientDB;
 import com.orientechnologies.orient.core.db.OrientDBConfig;
 // #init-settings
+import com.orientechnologies.orient.core.db.ODatabasePool;
+// #init-settings
+import com.orientechnologies.orient.core.db.ODatabaseSession;
 import com.orientechnologies.orient.core.record.impl.ODocument;
 import com.orientechnologies.orient.object.db.OObjectDatabaseTx;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.junit.jupiter.api.Test;
+
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,23 +51,8 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.orientdb.OrientDbSourceSettings;
-import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteMessage;
-import org.apache.pekko.stream.connectors.orientdb.OrientDbWriteSettings;
-import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbFlow;
-import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSink;
-import org.apache.pekko.stream.connectors.orientdb.javadsl.OrientDbSource;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(LogCapturingExtension.class)
 public class OrientDbTest {

--- a/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/Pravega.java
+++ b/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/Pravega.java
@@ -13,10 +13,12 @@
 
 package org.apache.pekko.stream.connectors.pravega.javadsl;
 
+import io.pravega.client.ClientConfig;
+import io.pravega.client.stream.ReaderGroup;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.annotation.ApiMayChange;
-
 import org.apache.pekko.stream.connectors.pravega.*;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaFlow;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaSource;
@@ -24,12 +26,6 @@ import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
-import io.pravega.client.ClientConfig;
-import io.pravega.client.stream.ReaderGroup;
-
-import java.util.concurrent.CompletionStage;
-
 import scala.jdk.javaapi.FutureConverters;
 
 @ApiMayChange

--- a/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
+++ b/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
@@ -13,22 +13,20 @@
 
 package org.apache.pekko.stream.connectors.pravega.javadsl;
 
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.annotation.ApiMayChange;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.pravega.*;
+import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableReadFlow;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableSource;
 import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableWriteFlow;
-import org.apache.pekko.stream.connectors.pravega.impl.PravegaTableReadFlow;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-
 import scala.jdk.javaapi.FutureConverters;
 import scala.jdk.javaapi.OptionConverters;
 

--- a/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaBaseTestCase.java
@@ -13,18 +13,15 @@
 
 package docs.javadsl;
 
-import java.net.URI;
-import java.util.UUID;
-
-import org.apache.pekko.stream.connectors.pravega.PravegaPekkoTestCaseSupport;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.apache.pekko.testkit.javadsl.TestKit;
-
 import io.pravega.client.admin.StreamManager;
 import io.pravega.client.stream.ScalingPolicy;
 import io.pravega.client.stream.StreamConfiguration;
+import java.net.URI;
+import java.util.UUID;
+import org.apache.pekko.stream.connectors.pravega.PravegaPekkoTestCaseSupport;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public abstract class PravegaBaseTestCase extends PravegaPekkoTestCaseSupport {
 

--- a/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaReadWriteDocs.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import io.pravega.client.stream.ReaderGroup;
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.impl.JavaSerializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.client.tables.TableKey;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.Done;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.pravega.*;
@@ -22,15 +30,6 @@ import org.apache.pekko.stream.connectors.pravega.javadsl.PravegaTable;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import io.pravega.client.stream.ReaderGroup;
-import io.pravega.client.stream.Serializer;
-import io.pravega.client.stream.impl.JavaSerializer;
-import io.pravega.client.stream.impl.UTF8StringSerializer;
-import io.pravega.client.tables.TableKey;
-
-import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 public class PravegaReadWriteDocs extends PravegaPekkoTestCaseSupport {
 

--- a/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
+++ b/pravega/src/test/java/docs/javadsl/PravegaSettingsTestCase.java
@@ -13,21 +13,18 @@
 
 package docs.javadsl;
 
+import io.pravega.client.stream.Serializer;
+import io.pravega.client.stream.impl.UTF8StringSerializer;
+import io.pravega.client.tables.TableKey;
+import java.nio.ByteBuffer;
+import java.time.Duration;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.pravega.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
-
-import io.pravega.client.stream.impl.UTF8StringSerializer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-
-import java.nio.ByteBuffer;
-import java.time.Duration;
-
-import io.pravega.client.tables.TableKey;
-import io.pravega.client.stream.Serializer;
 
 public class PravegaSettingsTestCase {
 

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaGraphTestCase.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaGraphTestCase.java
@@ -13,27 +13,22 @@
 
 package org.apache.pekko.stream.connectors.pravega;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.stream.javadsl.Source;
-
 import com.typesafe.config.ConfigFactory;
 import docs.javadsl.PravegaBaseTestCase;
-
 import io.pravega.client.stream.ReaderGroup;
 import io.pravega.client.stream.impl.JavaSerializer;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
-import org.apache.pekko.japi.Pair;
-
-import org.apache.pekko.stream.UniqueKillSwitch;
-import org.apache.pekko.stream.KillSwitches;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.connectors.pravega.javadsl.Pravega;
-
 import java.util.List;
 import java.util.concurrent.*;
+import org.apache.pekko.Done;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.KillSwitches;
+import org.apache.pekko.stream.UniqueKillSwitch;
+import org.apache.pekko.stream.connectors.pravega.javadsl.Pravega;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 public class PravegaGraphTestCase extends PravegaBaseTestCase {
 

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaKVTableTestCase.java
@@ -13,33 +13,29 @@
 
 package org.apache.pekko.stream.connectors.pravega;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.japi.Pair;
-
-import org.apache.pekko.stream.connectors.pravega.javadsl.PravegaTable;
-import org.apache.pekko.stream.javadsl.Keep;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
 import docs.javadsl.PravegaBaseTestCase;
 import io.pravega.client.ClientConfig;
 import io.pravega.client.admin.KeyValueTableManager;
 import io.pravega.client.stream.Serializer;
 import io.pravega.client.stream.impl.UTF8StringSerializer;
-
 import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.client.tables.TableKey;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
-
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import java.util.concurrent.*;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.japi.Pair;
+import org.apache.pekko.stream.connectors.pravega.javadsl.PravegaTable;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Keep;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class PravegaKVTableTestCase extends PravegaBaseTestCase {
 

--- a/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaPekkoTestCaseSupport.java
+++ b/pravega/src/test/java/org/apache/pekko/stream/connectors/pravega/PravegaPekkoTestCaseSupport.java
@@ -13,8 +13,8 @@
 
 package org.apache.pekko.stream.connectors.pravega;
 
-import org.apache.pekko.actor.ActorSystem;
 import docs.javadsl.PravegaBaseTestCase;
+import org.apache.pekko.actor.ActorSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/reference/src/test/java/docs/javadsl/ReferenceTest.java
+++ b/reference/src/test/java/docs/javadsl/ReferenceTest.java
@@ -17,25 +17,24 @@
  */
 package docs.javadsl;
 
+import java.util.*;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.reference.*;
 import org.apache.pekko.stream.connectors.reference.javadsl.Reference;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Flow;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.*;
-
-import java.util.*;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Append "Test" to every Java test suite. */
 @ExtendWith(LogCapturingExtension.class)

--- a/s3/src/test/java/docs/javadsl/S3Test.java
+++ b/s3/src/test/java/docs/javadsl/S3Test.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -30,26 +39,15 @@ import org.apache.pekko.stream.connectors.s3.headers.ServerSideEncryption;
 import org.apache.pekko.stream.connectors.s3.javadsl.S3;
 import org.apache.pekko.stream.connectors.s3.scaladsl.S3WireMockBase;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Keep;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import com.github.tomakehurst.wiremock.WireMockServer;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class S3Test extends S3WireMockBase {

--- a/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
+++ b/simple-codecs/src/test/java/docs/javadsl/RecordIOFramingTest.java
@@ -13,18 +13,6 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.stream.connectors.recordio.javadsl.RecordIOFraming;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.apache.pekko.util.ByteString;
-import org.junit.jupiter.api.AfterAll;
-
-import org.junit.jupiter.api.Test;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -33,6 +21,17 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.stream.connectors.recordio.javadsl.RecordIOFraming;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.apache.pekko.util.ByteString;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class RecordIOFramingTest {

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlow.java
@@ -13,17 +13,16 @@
 
 package docs.javadsl;
 
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
 import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
-import java.sql.PreparedStatement;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.IntStream;
 
 public class DocSnippetFlow {
   public static void main(String[] args) throws Exception {

--- a/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetFlowWithPassThrough.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
@@ -20,13 +26,6 @@ import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
 import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-
-import java.sql.PreparedStatement;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Function;
-import java.util.stream.IntStream;
 
 // We're going to pretend we got messages from kafka.
 // After we've written them to a db with Slick, we want

--- a/slick/src/test/java/docs/javadsl/DocSnippetSink.java
+++ b/slick/src/test/java/docs/javadsl/DocSnippetSink.java
@@ -13,16 +13,15 @@
 
 package docs.javadsl;
 
+import java.sql.PreparedStatement;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
 import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
 import org.apache.pekko.stream.javadsl.Source;
-
-import java.sql.PreparedStatement;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.stream.IntStream;
 
 public class DocSnippetSink {
   public static void main(String[] args) throws Exception {

--- a/slick/src/test/java/docs/javadsl/SlickTest.java
+++ b/slick/src/test/java/docs/javadsl/SlickTest.java
@@ -13,24 +13,8 @@
 
 package docs.javadsl;
 
-import org.apache.pekko.Done;
-import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.function.Function2;
-import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
-import org.apache.pekko.stream.connectors.slick.javadsl.SlickRow;
-import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
-import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.apache.pekko.stream.javadsl.Flow;
-import org.apache.pekko.stream.javadsl.Sink;
-import org.apache.pekko.stream.javadsl.Source;
-import org.apache.pekko.testkit.javadsl.TestKit;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -46,9 +30,23 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import org.apache.pekko.Done;
+import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.ActorSystem;
+import org.apache.pekko.japi.function.Function2;
+import org.apache.pekko.stream.connectors.slick.javadsl.Slick;
+import org.apache.pekko.stream.connectors.slick.javadsl.SlickRow;
+import org.apache.pekko.stream.connectors.slick.javadsl.SlickSession;
+import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
+import org.apache.pekko.stream.javadsl.Flow;
+import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.testkit.javadsl.TestKit;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This unit test is run using a local H2 database using `/tmp/pekko-connectors-slick-h2-test` for

--- a/solr/src/test/java/docs/javadsl/SolrTest.java
+++ b/solr/src/test/java/docs/javadsl/SolrTest.java
@@ -13,6 +13,20 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.*;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -24,7 +38,6 @@ import org.apache.pekko.stream.connectors.solr.javadsl.SolrFlow;
 import org.apache.pekko.stream.connectors.solr.javadsl.SolrSink;
 import org.apache.pekko.stream.connectors.solr.javadsl.SolrSource;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.testkit.javadsl.TestKit;
@@ -50,23 +63,8 @@ import org.apache.solr.cloud.ZkTestServer;
 import org.apache.solr.common.SolrInputDocument;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.time.Duration;
-import java.util.Collections;
-import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class SolrTest {

--- a/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/PekkoStreamsRegistrar.java
+++ b/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/PekkoStreamsRegistrar.java
@@ -13,14 +13,14 @@
 
 package org.apache.pekko.stream.connectors.spring.web;
 
+import static org.springframework.core.ReactiveTypeDescriptor.multiValue;
+
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.javadsl.AsPublisher;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.util.Assert;
-
-import static org.springframework.core.ReactiveTypeDescriptor.multiValue;
 
 public class PekkoStreamsRegistrar {
 

--- a/spring-web/src/test/java/docs/javadsl/SampleController.java
+++ b/spring-web/src/test/java/docs/javadsl/SampleController.java
@@ -15,16 +15,15 @@ package docs.javadsl;
 
 // #use
 import jakarta.annotation.PostConstruct;
-
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.event.LoggingAdapter;
 import org.apache.pekko.stream.javadsl.Source;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.Assert;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.util.Assert;
 
 @RestController
 public class SampleController {

--- a/sqs/src/test/java/docs/javadsl/SqsAckTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsAckTest.java
@@ -13,6 +13,17 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.stream.connectors.sqs.MessageAction;
@@ -24,23 +35,11 @@ import org.apache.pekko.stream.connectors.sqs.SqsAckSettings;
 import org.apache.pekko.stream.connectors.sqs.javadsl.BaseSqsTest;
 import org.apache.pekko.stream.connectors.sqs.javadsl.SqsAckFlow;
 import org.apache.pekko.stream.connectors.sqs.javadsl.SqsAckSink;
-import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.javadsl.Sink;
+import org.apache.pekko.stream.javadsl.Source;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.*;
-
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SqsAckTest extends BaseSqsTest {
 

--- a/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsPublishTest.java
@@ -13,6 +13,15 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.math.BigInteger;
+import java.security.MessageDigest;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.stream.connectors.sqs.SqsPublishBatchSettings;
 import org.apache.pekko.stream.connectors.sqs.SqsPublishGroupedSettings;
@@ -26,16 +35,6 @@ import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.model.*;
-
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SqsPublishTest extends BaseSqsTest {
 

--- a/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
+++ b/sqs/src/test/java/docs/javadsl/SqsSourceTest.java
@@ -13,6 +13,14 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.stream.connectors.awsspi.PekkoHttpClient;
 import org.apache.pekko.stream.connectors.sqs.MessageAttributeName;
@@ -32,15 +40,6 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
-
-import java.net.URI;
-import java.time.Duration;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.IntStream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SqsSourceTest extends BaseSqsTest {
 

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -13,12 +13,17 @@
 
 package docs.javadsl;
 
+import java.net.*;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.io.Inet;
 import org.apache.pekko.io.UdpSO;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.udp.Datagram;
 import org.apache.pekko.stream.connectors.udp.javadsl.Udp;
 import org.apache.pekko.stream.javadsl.Flow;
@@ -32,15 +37,8 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.net.*;
-import java.util.ArrayList;
-import java.util.Enumeration;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CompletionStage;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class UdpTest {

--- a/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
+++ b/unix-domain-socket/src/test/java/docs/javadsl/UnixDomainSocketTest.java
@@ -13,6 +13,12 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Files;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -20,7 +26,6 @@ import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.Materializer;
 import org.apache.pekko.stream.OverflowStrategy;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.unixdomainsocket.javadsl.UnixDomainSocket;
 import org.apache.pekko.stream.connectors.unixdomainsocket.javadsl.UnixDomainSocket.IncomingConnection;
 import org.apache.pekko.stream.connectors.unixdomainsocket.javadsl.UnixDomainSocket.ServerBinding;
@@ -32,17 +37,10 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.nio.file.Files;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(LogCapturingExtension.class)
 public class UnixDomainSocketTest {

--- a/xml/src/test/java/docs/javadsl/XmlHelper.java
+++ b/xml/src/test/java/docs/javadsl/XmlHelper.java
@@ -13,13 +13,12 @@
 
 package docs.javadsl;
 
-import org.w3c.dom.Document;
-import org.w3c.dom.Node;
-
+import java.io.StringWriter;
 import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.StringWriter;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 
 public class XmlHelper {
 

--- a/xml/src/test/java/docs/javadsl/XmlParsingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlParsingTest.java
@@ -13,10 +13,22 @@
 
 package docs.javadsl;
 
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.fasterxml.aalto.AsyncXMLInputFactory;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.xml.Characters;
 import org.apache.pekko.stream.connectors.xml.EndDocument;
 import org.apache.pekko.stream.connectors.xml.EndElement;
@@ -28,25 +40,11 @@ import org.apache.pekko.stream.connectors.xml.javadsl.XmlParsing;
 import org.apache.pekko.stream.javadsl.*;
 import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
-import com.fasterxml.aalto.AsyncXMLInputFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.w3c.dom.Element;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.function.Consumer;
-
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 
 @SuppressWarnings("deprecation")
 @ExtendWith(LogCapturingExtension.class)

--- a/xml/src/test/java/docs/javadsl/XmlWritingTest.java
+++ b/xml/src/test/java/docs/javadsl/XmlWritingTest.java
@@ -13,9 +13,19 @@
 
 package docs.javadsl;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.xml.stream.XMLOutputFactory;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.stream.connectors.testkit.javadsl.LogCapturingExtension;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.apache.pekko.stream.connectors.xml.Characters;
 import org.apache.pekko.stream.connectors.xml.EndDocument;
 import org.apache.pekko.stream.connectors.xml.EndElement;
@@ -32,21 +42,8 @@ import org.apache.pekko.testkit.javadsl.TestKit;
 import org.apache.pekko.util.ByteString;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-
 import org.junit.jupiter.api.Test;
-
-import java.util.Collections;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import javax.xml.stream.XMLOutputFactory;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(LogCapturingExtension.class)
 public class XmlWritingTest {


### PR DESCRIPTION
* I set `javafmtSortImports := true` in my local env
* `sbt javafmtAll` seemed to skip some of the java files where we annotate the imports for doc purposes
* the order of the imports is not configurable in sbt-java-formatter
* the existing files have pretty erratic import order - I think this PR is a bit better