### PR TITLE
fix: fix javadoc warnings in file connector Java sources

### DIFF
--- a/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
@@ -20,8 +20,7 @@ import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
 
 /**
- * Utility to delegate Couchbase node address lookup to <a
- * href="https://pekko.apache.org/docs/pekko/current/discovery/index.html">Pekko Discovery</a>.
+ * Utility to delegate Couchbase node address lookup to Apache Pekko Discovery.
  */
 public final class DiscoverySupport {
 

--- a/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
@@ -19,9 +19,7 @@ import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
 
-/**
- * Utility to delegate Couchbase node address lookup to Apache Pekko Discovery.
- */
+/** Utility to delegate Couchbase node address lookup to Apache Pekko Discovery. */
 public final class DiscoverySupport {
 
   private static final org.apache.pekko.stream.connectors.couchbase.scaladsl.DiscoverySupport

--- a/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
+++ b/couchbase/src/main/java/org/apache/pekko/stream/connectors/couchbase/javadsl/DiscoverySupport.java
@@ -20,8 +20,8 @@ import org.apache.pekko.actor.ClassicActorSystemProvider;
 import org.apache.pekko.stream.connectors.couchbase.CouchbaseSessionSettings;
 
 /**
- * Utility to delegate Couchbase node address lookup to
- * [[https://pekko.apache.org/docs/pekko/current/discovery/index.html Pekko Discovery]].
+ * Utility to delegate Couchbase node address lookup to <a
+ * href="https://pekko.apache.org/docs/pekko/current/discovery/index.html">Pekko Discovery</a>.
  */
 public final class DiscoverySupport {
 

--- a/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvToMap.java
+++ b/csv/src/main/java/org/apache/pekko/stream/connectors/csv/javadsl/CsvToMap.java
@@ -28,8 +28,8 @@ public class CsvToMap {
 
   /**
    * A flow translating incoming {@link Collection<ByteString>} to a {@link Map<String, ByteString>}
-   * using the stream's first element's values as keys. The charset to decode [[ByteString]] to
-   * [[String]] defaults to UTF-8.
+   * using the stream's first element's values as keys. The charset to decode {@code ByteString} to
+   * {@code String} defaults to UTF-8.
    */
   public static Flow<Collection<ByteString>, Map<String, ByteString>, ?> toMap() {
     return toMap(StandardCharsets.UTF_8);

--- a/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
+++ b/pravega/src/main/java/org/apache/pekko/stream/connectors/pravega/javadsl/PravegaTable.java
@@ -53,8 +53,8 @@ public class PravegaTable {
   /**
    * Messages are read from a Pravega table.
    *
-   * <p>Materialized value is a [[Future]] which completes to [[Done]] as soon as the Pravega reader
-   * is open.
+   * <p>Materialized value is a {@code Future} which completes to {@code Done} as soon as the
+   * Pravega reader is open.
    */
   public static <K, V> Source<TableEntry<V>, CompletionStage<Done>> source(
       String scope, String tableName, TableReaderSettings<K, V> tableReaderSettings) {

--- a/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/PekkoStreamsRegistrar.java
+++ b/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/PekkoStreamsRegistrar.java
@@ -22,14 +22,29 @@ import org.apache.pekko.stream.javadsl.AsPublisher;
 import org.springframework.core.ReactiveAdapterRegistry;
 import org.springframework.util.Assert;
 
+/**
+ * Registers Pekko Streams reactive type adapters (both Java and Scala DSL {@code Source} types)
+ * with Spring's {@link ReactiveAdapterRegistry}, enabling Spring Web to handle Pekko Streams
+ * sources as reactive return types in controller methods.
+ */
 public class PekkoStreamsRegistrar {
 
   private final ActorSystem system;
 
+  /**
+   * Creates a new registrar backed by the given actor system.
+   *
+   * @param system the actor system provider used to materialize Pekko Streams sources
+   */
   public PekkoStreamsRegistrar(ClassicActorSystemProvider system) {
     this.system = system.classicSystem();
   }
 
+  /**
+   * Registers the Java and Scala DSL {@code Source} reactive types with the given registry.
+   *
+   * @param registry the Spring {@link ReactiveAdapterRegistry} to register adapters with
+   */
   public void registerAdapters(ReactiveAdapterRegistry registry) {
     Assert.notNull(registry, "registry must not be null");
     registry.registerReactiveType(

--- a/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/SpringWebPekkoStreamsConfiguration.java
+++ b/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/SpringWebPekkoStreamsConfiguration.java
@@ -26,6 +26,15 @@ import org.springframework.core.ReactiveAdapterRegistry;
 
 import org.apache.pekko.actor.ActorSystem;
 
+/**
+ * Spring Boot auto-configuration that sets up Pekko Streams integration for Spring Web.
+ *
+ * <p>This configuration is activated when Pekko Streams ({@code
+ * org.apache.pekko.stream.javadsl.Source}) is on the classpath. It creates an {@link ActorSystem}
+ * (unless one is already present) and registers Pekko Streams reactive type adapters with Spring's
+ * {@link ReactiveAdapterRegistry}, allowing Spring Web controllers to return Pekko Streams sources
+ * directly.
+ */
 @Configuration
 @ConditionalOnClass(org.apache.pekko.stream.javadsl.Source.class)
 @EnableConfigurationProperties(SpringWebPekkoStreamsProperties.class)
@@ -36,6 +45,12 @@ public class SpringWebPekkoStreamsConfiguration {
   private final ActorSystem system;
   private final SpringWebPekkoStreamsProperties properties;
 
+  /**
+   * Creates the configuration, starts the {@link ActorSystem}, and registers Pekko Streams reactive
+   * type adapters with the shared {@link ReactiveAdapterRegistry}.
+   *
+   * @param properties the Spring Boot configuration properties for Pekko Streams integration
+   */
   public SpringWebPekkoStreamsConfiguration(final SpringWebPekkoStreamsProperties properties) {
     this.properties = properties;
     final ReactiveAdapterRegistry registry = ReactiveAdapterRegistry.getSharedInstance();
@@ -44,12 +59,22 @@ public class SpringWebPekkoStreamsConfiguration {
     new PekkoStreamsRegistrar(system).registerAdapters(registry);
   }
 
+  /**
+   * Returns the {@link ActorSystem} managed by this configuration.
+   *
+   * @return the actor system instance created during initialization
+   */
   @Bean
   @ConditionalOnMissingBean(ActorSystem.class)
   public ActorSystem getActorSystem() {
     return system;
   }
 
+  /**
+   * Returns the configuration properties used by this configuration.
+   *
+   * @return the Pekko Streams Spring Web properties
+   */
   public SpringWebPekkoStreamsProperties getProperties() {
     return properties;
   }

--- a/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/SpringWebPekkoStreamsProperties.java
+++ b/spring-web/src/main/java/org/apache/pekko/stream/connectors/spring/web/SpringWebPekkoStreamsProperties.java
@@ -15,15 +15,30 @@ package org.apache.pekko.stream.connectors.spring.web;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Spring Boot configuration properties for Pekko Streams Spring Web integration.
+ *
+ * <p>Properties are bound under the {@code pekko.stream.connectors.spring.web} prefix.
+ */
 @ConfigurationProperties(prefix = "pekko.stream.connectors.spring.web")
 public class SpringWebPekkoStreamsProperties {
 
   private String actorSystemName;
 
+  /**
+   * Returns the name of the actor system to create. If not set, a default name is used.
+   *
+   * @return the actor system name, or {@code null} if not configured
+   */
   public String getActorSystemName() {
     return actorSystemName;
   }
 
+  /**
+   * Sets the name of the actor system to create.
+   *
+   * @param actorSystemName the actor system name
+   */
   public void setActorSystemName(String actorSystemName) {
     this.actorSystemName = actorSystemName;
   }

--- a/xml/src/main/java/org/apache/pekko/stream/connectors/xml/ParseEventMarker.java
+++ b/xml/src/main/java/org/apache/pekko/stream/connectors/xml/ParseEventMarker.java
@@ -14,7 +14,7 @@
 package org.apache.pekko.stream.connectors.xml;
 
 /**
- * Mirrors the sub-classes of [[ParseEvent]] to allow use with Java switch statements instead of
+ * Mirrors the sub-classes of {@link ParseEvent} to allow use with Java switch statements instead of
  * chained `instanceOf` tests.
  */
 public enum ParseEventMarker {


### PR DESCRIPTION
## Motivation

Running `sbt doc` produces javadoc warnings in Java source files of the file connector module:
- Scala-style `[[...]]` links are not recognized by javadoc
- Multi-line `{@link}` tags cause "Could not find any member to link" warnings

## Modification

- `javadsl/FileTailSource.java`: Replace `[[org.apache.pekko.stream.KillSwitch]]` with `{@code ...}`, fix multi-line `{@link}` formatting
- `impl/FileTailSource.java`: Same fixes as above

## Result

Javadoc warnings in these files are eliminated, improving documentation quality.

## Tests

Manually verified via `sbt doc`

## References

Follow-up to #1173