### PR TITLE
fix: fix scaladoc warnings

### DIFF
--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpRpcFlow.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpRpcFlow.scala
@@ -72,7 +72,7 @@ object AmqpRpcFlow {
    * delivered one time but in failure cases could be duplicated.
    *
    * If you commit the offset before processing the message you get "at-most once delivery" semantics,
-   * and for that there is a [[#atMostOnceFlow]].
+   * and for that there is a `atMostOnceFlow`.
    *
    * Compared to auto-commit, this gives exact control over when a message is considered consumed.
    */

--- a/awslambda/src/main/scala/org/apache/pekko/stream/connectors/awslambda/javadsl/AwsLambdaFlow.scala
+++ b/awslambda/src/main/scala/org/apache/pekko/stream/connectors/awslambda/javadsl/AwsLambdaFlow.scala
@@ -22,7 +22,7 @@ import software.amazon.awssdk.services.lambda.LambdaAsyncClient
 object AwsLambdaFlow {
 
   /**
-   * Java API: creates a [[AwsLambdaFlowStage]] for a AWS Lambda function invocation using an [[LambdaAsyncClient]]
+   * Java API: creates a `AwsLambdaFlowStage` for a AWS Lambda function invocation using an `LambdaAsyncClient`
    */
   def create(awsLambdaClient: LambdaAsyncClient, parallelism: Int): Flow[InvokeRequest, InvokeResponse, NotUsed] =
     pekko.stream.connectors.awslambda.scaladsl.AwsLambdaFlow.apply(parallelism)(awsLambdaClient).asJava

--- a/awslambda/src/main/scala/org/apache/pekko/stream/connectors/awslambda/scaladsl/AwsLambdaFlow.scala
+++ b/awslambda/src/main/scala/org/apache/pekko/stream/connectors/awslambda/scaladsl/AwsLambdaFlow.scala
@@ -24,7 +24,7 @@ import scala.jdk.FutureConverters._
 object AwsLambdaFlow {
 
   /**
-   * Scala API: creates a [[AwsLambdaFlowStage]] for a AWS Lambda function invocation using [[LambdaAsyncClient]]
+   * Scala API: creates a `AwsLambdaFlowStage` for a AWS Lambda function invocation using `LambdaAsyncClient`
    */
   def apply(
       parallelism: Int)(implicit awsLambdaClient: LambdaAsyncClient): Flow[InvokeRequest, InvokeResponse, NotUsed] =

--- a/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/javadsl/CouchbaseFlow.scala
+++ b/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/javadsl/CouchbaseFlow.scala
@@ -47,20 +47,20 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.get(GetOptions.getOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.get]] deserialize to Couchbase JsonObject
+   * reference to `CouchbaseFlow.get` deserialize to Couchbase JsonObject
    */
   def getJson(options: GetOptions,
       asyncCollection: AsyncCollection): Flow[String, JsonObject, NotUsed] =
     ScalaCouchbaseFlow.getJson(options)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.get]] deserialize to Couchbase JsonObject
+   * reference to `CouchbaseFlow.get` deserialize to Couchbase JsonObject
    */
   def getJson(asyncCollection: AsyncCollection): Flow[String, JsonObject, NotUsed] =
     ScalaCouchbaseFlow.getJson(GetOptions.getOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.get]],deserialize to class
+   * reference to `CouchbaseFlow.get`,deserialize to class
    * If you add DefaultScalaModule to jackson of couchbase, it could deserialize to scala class
    */
   def getObject[T](target: Class[T], options: GetOptions,
@@ -68,55 +68,55 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.getObject[T](target, options)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.get]],deserialize to class
+   * reference to `CouchbaseFlow.get`,deserialize to class
    * If you add DefaultScalaModule to jackson of couchbase, it could deserialize to scala class
    */
   def getObject[T](target: Class[T], asyncCollection: AsyncCollection): Flow[String, T, NotUsed] =
     ScalaCouchbaseFlow.getObject[T](target, GetOptions.getOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseSource.getObject]],deserialize to class with Generics
+   * reference to `CouchbaseSource.getObject`,deserialize to class with Generics
    */
   def getType[T](target: TypeRef[T], options: GetOptions,
       asyncCollection: AsyncCollection): Flow[String, T, NotUsed] =
     ScalaCouchbaseFlow.getType[T](target, options)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseSource.getObject]],deserialize to class with Generics
+   * reference to `CouchbaseSource.getObject`,deserialize to class with Generics
    */
   def getType[T](target: TypeRef[T], asyncCollection: AsyncCollection): Flow[String, T, NotUsed] =
     ScalaCouchbaseFlow.getType[T](target, GetOptions.getOptions)(asyncCollection).asJava
 
   /**
-   * similar to [[CouchbaseFlow.get]], but reads from all replicas on the active node
-   * @see [[CouchbaseFlow#get]]
+   * similar to `CouchbaseFlow.get`, but reads from all replicas on the active node
+   * @see `CouchbaseFlow#get`
    */
   def getAllReplicas(options: GetAllReplicasOptions,
       asyncCollection: AsyncCollection): Flow[String, GetReplicaResult, NotUsed] =
     ScalaCouchbaseFlow.getAllReplicas(options)(asyncCollection).asJava
 
   /**
-   * similar to [[CouchbaseFlow.get]], but reads from all replicas on the active node
-   * @see [[CouchbaseFlow#get]]
+   * similar to `CouchbaseFlow.get`, but reads from all replicas on the active node
+   * @see `CouchbaseFlow#get`
    */
   def getAllReplicas(asyncCollection: AsyncCollection): Flow[String, GetReplicaResult, NotUsed] =
     ScalaCouchbaseFlow.getAllReplicas(GetAllReplicasOptions.getAllReplicasOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.getAllReplicas]], deserialize to Couchbase JsonObject
+   * reference to `CouchbaseFlow.getAllReplicas`, deserialize to Couchbase JsonObject
    */
   def getAllReplicasJson(options: GetAllReplicasOptions,
       asyncCollection: AsyncCollection): Flow[String, JsonObject, NotUsed] =
     ScalaCouchbaseFlow.getAllReplicasJson(options)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.getAllReplicas]], deserialize to Couchbase JsonObject
+   * reference to `CouchbaseFlow.getAllReplicas`, deserialize to Couchbase JsonObject
    */
   def getAllReplicasJson(asyncCollection: AsyncCollection): Flow[String, JsonObject, NotUsed] =
     ScalaCouchbaseFlow.getAllReplicasJson(GetAllReplicasOptions.getAllReplicasOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.getAllReplicas]], deserialize to class
+   * reference to `CouchbaseFlow.getAllReplicas`, deserialize to class
    * If you add DefaultScalaModule to jackson of couchbase, it could deserialize to scala class
    */
   def getAllReplicasObject[T](target: Class[T],
@@ -125,7 +125,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.getAllReplicasObject[T](target, getOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.getAllReplicas]], deserialize to class
+   * reference to `CouchbaseFlow.getAllReplicas`, deserialize to class
    * If you add DefaultScalaModule to jackson of couchbase, it could deserialize to scala class
    */
   def getAllReplicasObject[T](target: Class[T],
@@ -134,7 +134,7 @@ object CouchbaseFlow {
       asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.getAllReplicasObject]], deserialize to class with Generics
+   * reference to `CouchbaseFlow.getAllReplicasObject`, deserialize to class with Generics
    */
   def getAllReplicasType[T](target: TypeRef[T],
       getOptions: GetAllReplicasOptions,
@@ -142,7 +142,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.getAllReplicasType(target, getOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.getAllReplicasObject]], deserialize to class with Generics
+   * reference to `CouchbaseFlow.getAllReplicasObject`, deserialize to class with Generics
    */
   def getAllReplicasType[T](target: TypeRef[T],
       asyncCollection: AsyncCollection): Flow[String, T, NotUsed] =
@@ -151,7 +151,7 @@ object CouchbaseFlow {
   /**
    * Inserts a full document which does not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#insert]]
+   * @see `AsyncCollection#insert`
    */
   def insert[T](applyId: JFunction[T, String],
       insertOptions: InsertOptions,
@@ -161,7 +161,7 @@ object CouchbaseFlow {
   /**
    * Inserts a full document which does not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#insert]]
+   * @see `AsyncCollection#insert`
    */
   def insert[T](applyId: JFunction[T, String],
       asyncCollection: AsyncCollection): Flow[T, T, NotUsed] =
@@ -170,7 +170,7 @@ object CouchbaseFlow {
   /**
    * Inserts a full document which does not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#insert]]
+   * @see `AsyncCollection#insert`
    * @deprecated Use the overloaded method that takes a java.util.function.Function instead (since 2.0.0)
    */
   @deprecated("Use the overloaded method that takes a java.util.function.Function instead", since = "2.0.0")
@@ -180,7 +180,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.insert[T](applyId, insertOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.insert]] <br>
+   * reference to `CouchbaseFlow.insert` <br>
    * use MutationDocument to wrapper id, document and result(MutationResult)
    */
   def insertDoc[T](insertOptions: InsertOptions,
@@ -188,7 +188,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.insertDoc[T](insertOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.insert]] <br>
+   * reference to `CouchbaseFlow.insert` <br>
    * use MutationDocument to wrapper id, document and result(MutationResult)
    */
   def insertDoc[T](asyncCollection: AsyncCollection): Flow[MutationDocument[T], MutationDocument[T], NotUsed] =
@@ -197,7 +197,7 @@ object CouchbaseFlow {
   /**
    * Replaces a full document which already exists with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#replace]]
+   * @see `AsyncCollection#replace`
    */
   def replace[T](applyId: JFunction[T, String],
       replaceOptions: ReplaceOptions,
@@ -207,7 +207,7 @@ object CouchbaseFlow {
   /**
    * Replaces a full document which already exists with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#replace]]
+   * @see `AsyncCollection#replace`
    */
   def replace[T](applyId: JFunction[T, String],
       asyncCollection: AsyncCollection): Flow[T, T, NotUsed] =
@@ -216,7 +216,7 @@ object CouchbaseFlow {
   /**
    * Replaces a full document which already exists with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#replace]]
+   * @see `AsyncCollection#replace`
    * @deprecated Use the overloaded method that takes a java.util.function.Function instead (since 2.0.0)
    */
   @deprecated("Use the overloaded method that takes a java.util.function.Function instead", since = "2.0.0")
@@ -226,7 +226,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.replace[T](applyId, replaceOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replace]]
+   * reference to `CouchbaseFlow.replace`
    * use MutationDocument to wrapper id, document and result(MutationResult)
    */
   def replaceDoc[T](replaceOptions: ReplaceOptions,
@@ -234,7 +234,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.replaceDoc[T](replaceOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replace]]
+   * reference to `CouchbaseFlow.replace`
    * use MutationDocument to wrapper id, document and result(MutationResult)
    */
   def replaceDoc[T](asyncCollection: AsyncCollection): Flow[MutationDocument[T], MutationDocument[T], NotUsed] =
@@ -243,7 +243,7 @@ object CouchbaseFlow {
   /**
    * Upsert a full document which might or might not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#upsert]]
+   * @see `AsyncCollection#upsert`
    */
   def upsert[T](applyId: JFunction[T, String],
       upsertOptions: UpsertOptions,
@@ -253,7 +253,7 @@ object CouchbaseFlow {
   /**
    * Upsert a full document which might or might not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#upsert]]
+   * @see `AsyncCollection#upsert`
    */
   def upsert[T](applyId: JFunction[T, String],
       asyncCollection: AsyncCollection): Flow[T, T, NotUsed] =
@@ -262,7 +262,7 @@ object CouchbaseFlow {
   /**
    * Upsert a full document which might or might not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#upsert]]
+   * @see `AsyncCollection#upsert`
    * @deprecated Use the overloaded method that takes a java.util.function.Function instead (since 2.0.0)
    */
   @deprecated("Use the overloaded method that takes a java.util.function.Function instead", since = "2.0.0")
@@ -272,7 +272,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.upsert[T](applyId, upsertOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsert]]
+   * reference to `CouchbaseFlow.upsert`
    * use MutationDocument to wrapper id, document and result(MutationResult)
    */
   def upsertDoc[T](
@@ -281,7 +281,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.upsertDoc[T](upsertOptions)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsert]]
+   * reference to `CouchbaseFlow.upsert`
    * use MutationDocument to wrapper id, document and result(MutationResult)
    */
   def upsertDoc[T](
@@ -291,7 +291,7 @@ object CouchbaseFlow {
   /**
    * Removes a Document from a collection with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `remove[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#remove]]
+   * @see `AsyncCollection#remove`
    */
   def remove[T](
       applyId: JFunction[T, String],
@@ -302,7 +302,7 @@ object CouchbaseFlow {
   /**
    * Removes a Document from a collection with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `remove[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#remove]]
+   * @see `AsyncCollection#remove`
    */
   def remove[T](
       applyId: JFunction[T, String],
@@ -312,7 +312,7 @@ object CouchbaseFlow {
   /**
    * Removes a Document from a collection with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `remove[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#remove]]
+   * @see `AsyncCollection#remove`
    * @deprecated Use the overloaded method that takes a java.util.function.Function instead (since 2.0.0)
    */
   @deprecated("Use the overloaded method that takes a java.util.function.Function instead", since = "2.0.0")
@@ -324,7 +324,7 @@ object CouchbaseFlow {
 
   /**
    * Performs mutations to document fragments with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#mutateIn]]
+   * @see `AsyncCollection#mutateIn`
    */
   def mutateIn(specs: java.util.List[MutateInSpec], options: MutateInOptions,
       asyncCollection: AsyncCollection): Flow[String, MutateInResult, NotUsed] =
@@ -332,14 +332,14 @@ object CouchbaseFlow {
 
   /**
    * Performs mutations to document fragments with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#mutateIn]]
+   * @see `AsyncCollection#mutateIn`
    */
   def mutateIn(specs: java.util.List[MutateInSpec],
       asyncCollection: AsyncCollection): Flow[String, MutateInResult, NotUsed] =
     ScalaCouchbaseFlow.mutateIn(specs, MutateInOptions.mutateInOptions())(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.mutateIn]]
+   * reference to `CouchbaseFlow.mutateIn`
    * use MutationDocument to wrapper id, document and result(MutationResult)
    * @return
    */
@@ -350,7 +350,7 @@ object CouchbaseFlow {
     ScalaCouchbaseFlow.mutateInDoc[T](specs, options)(asyncCollection).asJava
 
   /**
-   * reference to [[CouchbaseFlow.mutateIn]]
+   * reference to `CouchbaseFlow.mutateIn`
    * use MutationDocument to wrapper id, document and result(MutationResult)
    * @return
    */
@@ -362,7 +362,7 @@ object CouchbaseFlow {
   /**
    * Checks if the given document ID exists on the active partition with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `exists[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#exists]]
+   * @see `AsyncCollection#exists`
    */
   def exists[T](
       applyId: JFunction[T, String],
@@ -373,7 +373,7 @@ object CouchbaseFlow {
   /**
    * Checks if the given document ID exists on the active partition with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `exists[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#exists]]
+   * @see `AsyncCollection#exists`
    */
   def exists[T](
       applyId: JFunction[T, String],
@@ -383,7 +383,7 @@ object CouchbaseFlow {
   /**
    * Checks if the given document ID exists on the active partition with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `exists[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#exists]]
+   * @see `AsyncCollection#exists`
    * @deprecated Use the overloaded method that takes a java.util.function.Function instead (since 2.0.0)
    */
   @deprecated("Use the overloaded method that takes a java.util.function.Function instead", since = "2.0.0")
@@ -394,7 +394,7 @@ object CouchbaseFlow {
 
   /**
    * Updates the expiry of the document with the given id with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#touch]]
+   * @see `AsyncCollection#touch`
    */
   def touch(expiry: Duration, options: TouchOptions,
       asyncCollection: AsyncCollection): Flow[String, MutationResult, NotUsed] =
@@ -402,7 +402,7 @@ object CouchbaseFlow {
 
   /**
    * Updates the expiry of the document with the given id with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#touch]]
+   * @see `AsyncCollection#touch`
    */
   def touch(expiry: Duration,
       asyncCollection: AsyncCollection): Flow[String, MutationResult, NotUsed] =
@@ -444,7 +444,7 @@ object CouchbaseFlow {
 
   /**
    * Updates the expiry of the document with the given id with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#touch]]
+   * @see `AsyncCollection#touch`
    */
   def touchInstant[T](
       applyId: JFunction[T, String],
@@ -455,7 +455,7 @@ object CouchbaseFlow {
 
   /**
    * Updates the expiry of the document with the given id with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#touch]]
+   * @see `AsyncCollection#touch`
    */
   def touchInstant[T](
       applyId: JFunction[T, String],
@@ -465,7 +465,7 @@ object CouchbaseFlow {
 
   /**
    * Updates the expiry of the document with the given id with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#touch]]
+   * @see `AsyncCollection#touch`
    * @deprecated Use the overloaded method that takes a java.util.function.Function instead (since 2.0.0)
    */
   @deprecated("Use the overloaded method that takes a java.util.function.Function instead", since = "2.0.0")
@@ -478,7 +478,7 @@ object CouchbaseFlow {
 
   /**
    * Appends binary content to the document with custom options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#append]]
+   * @see `AsyncBinaryCollection#append`
    */
   def append(options: AppendOptions,
       asyncCollection: AsyncCollection): Flow[MutationBinaryDocument, MutationResult, NotUsed] =
@@ -486,14 +486,14 @@ object CouchbaseFlow {
 
   /**
    * Appends binary content to the document with custom options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#append]]
+   * @see `AsyncBinaryCollection#append`
    */
   def append(asyncCollection: AsyncCollection): Flow[MutationBinaryDocument, MutationResult, NotUsed] =
     ScalaCouchbaseFlow.append(AppendOptions.appendOptions())(asyncCollection).asJava
 
   /**
    * Prepends binary content to the document with custom options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#prepend]]
+   * @see `AsyncBinaryCollection#prepend`
    */
   def prepend(options: PrependOptions,
       asyncCollection: AsyncCollection): Flow[MutationBinaryDocument, MutationResult, NotUsed] =
@@ -501,14 +501,14 @@ object CouchbaseFlow {
 
   /**
    * Prepends binary content to the document with custom options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#prepend]]
+   * @see `AsyncBinaryCollection#prepend`
    */
   def prepend(asyncCollection: AsyncCollection): Flow[MutationBinaryDocument, MutationResult, NotUsed] =
     ScalaCouchbaseFlow.prepend(PrependOptions.prependOptions())(asyncCollection).asJava
 
   /**
    * Increments the counter document by one or the number defined in the options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#increment]]
+   * @see `AsyncBinaryCollection#increment`
    */
   def increment(options: IncrementOptions,
       asyncCollection: AsyncCollection): Flow[String, CounterResult, NotUsed] =
@@ -516,14 +516,14 @@ object CouchbaseFlow {
 
   /**
    * Increments the counter document by one or the number defined in the options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#increment]]
+   * @see `AsyncBinaryCollection#increment`
    */
   def increment(asyncCollection: AsyncCollection): Flow[String, CounterResult, NotUsed] =
     ScalaCouchbaseFlow.increment(IncrementOptions.incrementOptions())(asyncCollection).asJava
 
   /**
    * Decrements the counter document by one or the number defined in the options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#decrement]]
+   * @see `AsyncBinaryCollection#decrement`
    */
   def decrement(options: DecrementOptions,
       asyncCollection: AsyncCollection): Flow[String, CounterResult, NotUsed] =
@@ -531,7 +531,7 @@ object CouchbaseFlow {
 
   /**
    * Decrements the counter document by one or the number defined in the options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#decrement]]
+   * @see `AsyncBinaryCollection#decrement`
    */
   def decrement(asyncCollection: AsyncCollection): Flow[String, CounterResult, NotUsed] =
     ScalaCouchbaseFlow.decrement(DecrementOptions.decrementOptions())(asyncCollection).asJava

--- a/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/javadsl/CouchbaseSink.scala
+++ b/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/javadsl/CouchbaseSink.scala
@@ -32,7 +32,7 @@ import scala.jdk.FutureConverters._
 object CouchbaseSink {
 
   /**
-   * reference to [[CouchbaseFlow.insertDoc]]
+   * reference to `CouchbaseFlow.insertDoc`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -44,7 +44,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.insertDoc[T](insertOptions)(asyncCollection).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.insertDoc]]
+   * reference to `CouchbaseFlow.insertDoc`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -57,7 +57,7 @@ object CouchbaseSink {
       _.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.insertDoc]]
+   * reference to `CouchbaseFlow.insertDoc`
    * @deprecated Use insertDoc which returns CompletionStage instead
    */
   @deprecated("Use insertDoc which returns CompletionStage instead", since = "2.0.0")
@@ -66,7 +66,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.insertDoc[T](insertOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.insert]]
+   * reference to `CouchbaseFlow.insert`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -79,7 +79,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.insert[T](applyId.apply, insertOptions)(asyncCollection).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.insert]]
+   * reference to `CouchbaseFlow.insert`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -92,7 +92,7 @@ object CouchbaseSink {
       _.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.insert]]
+   * reference to `CouchbaseFlow.insert`
    * @deprecated Use insert which returns CompletionStage instead
    */
   @deprecated("Use insert which returns CompletionStage instead", since = "2.0.0")
@@ -102,7 +102,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.insert[T](applyId, insertOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsertDoc]]
+   * reference to `CouchbaseFlow.upsertDoc`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -114,7 +114,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.upsertDoc[T](upsertOptions)(asyncCollection).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsertDoc]]
+   * reference to `CouchbaseFlow.upsertDoc`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -127,7 +127,7 @@ object CouchbaseSink {
       _.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsertDoc]]
+   * reference to `CouchbaseFlow.upsertDoc`
    * @deprecated Use upsertDoc which returns CompletionStage instead
    */
   @deprecated("Use upsertDoc which returns CompletionStage instead", since = "2.0.0")
@@ -136,7 +136,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.upsertDoc[T](upsertOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsert]]
+   * reference to `CouchbaseFlow.upsert`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -149,7 +149,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.upsert[T](applyId.apply, upsertOptions)(asyncCollection).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsert]]
+   * reference to `CouchbaseFlow.upsert`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -162,7 +162,7 @@ object CouchbaseSink {
       _.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.upsert]]
+   * reference to `CouchbaseFlow.upsert`
    * @deprecated Use upsert which returns CompletionStage instead
    */
   @deprecated("Use upsert which returns CompletionStage instead", since = "2.0.0")
@@ -172,7 +172,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.upsert[T](applyId, upsertOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replaceDoc]]
+   * reference to `CouchbaseFlow.replaceDoc`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -185,7 +185,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.replaceDoc[T](replaceOptions)(asyncCollection).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replaceDoc]]
+   * reference to `CouchbaseFlow.replaceDoc`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -198,7 +198,7 @@ object CouchbaseSink {
       _.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replaceDoc]]
+   * reference to `CouchbaseFlow.replaceDoc`
    * @deprecated Use replaceDoc which returns CompletionStage instead
    */
   @deprecated("Use replaceDoc which returns CompletionStage instead", since = "2.0.0")
@@ -208,7 +208,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.replaceDoc[T](replaceOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replace]]
+   * reference to `CouchbaseFlow.replace`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -221,7 +221,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.replace[T](applyId.apply, replaceOptions)(asyncCollection).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replace]]
+   * reference to `CouchbaseFlow.replace`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -234,7 +234,7 @@ object CouchbaseSink {
       _.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.replace]]
+   * reference to `CouchbaseFlow.replace`
    * @deprecated Use replace which returns CompletionStage instead
    */
   @deprecated("Use replace which returns CompletionStage instead", since = "2.0.0")
@@ -244,7 +244,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.replace[T](applyId, replaceOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.remove]]
+   * reference to `CouchbaseFlow.remove`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -257,7 +257,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.remove[T](applyId.apply, removeOptions)(asyncCollection).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.remove]]
+   * reference to `CouchbaseFlow.remove`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -270,7 +270,7 @@ object CouchbaseSink {
       _.asJava).asJava
 
   /**
-   * reference to [[CouchbaseFlow.remove]]
+   * reference to `CouchbaseFlow.remove`
    * @deprecated Use remove which returns CompletionStage instead
    */
   @deprecated("Use remove which returns CompletionStage instead", since = "2.0.0")
@@ -280,7 +280,7 @@ object CouchbaseSink {
     ScalaCouchbaseSink.remove[T](applyId, removeOptions).asJava
 
   /**
-   * reference to [[CouchbaseFlow.exists]]
+   * reference to `CouchbaseFlow.exists`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -294,7 +294,7 @@ object CouchbaseSink {
       .asJava
 
   /**
-   * reference to [[CouchbaseFlow.exists]]
+   * reference to `CouchbaseFlow.exists`
    * <p>
    *   This function's return type changed in 2.0.0 to return a Sink with a CompletionStage instead of a
    *   Scala Future, to be more consistent with Java usage.
@@ -308,7 +308,7 @@ object CouchbaseSink {
       .asJava
 
   /**
-   * reference to [[CouchbaseFlow.exists]]
+   * reference to `CouchbaseFlow.exists`
    * @deprecated Use exists which returns CompletionStage instead
    */
   @deprecated("Use exists which returns CompletionStage instead", since = "2.0.0")

--- a/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/javadsl/CouchbaseSource.scala
+++ b/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/javadsl/CouchbaseSource.scala
@@ -95,7 +95,7 @@ object CouchbaseSource {
     ScalaCoubaseSource.getAllReplicasType[T](id, target, options).asJava
 
   /**
-   * similar to Get[[CouchbaseSource.get]], batch get documents from collection by ScanType[[ScanType]]
+   * similar to Get[[CouchbaseSource.get]], batch get documents from collection by ScanType`ScanType`
    */
   def scan(scanType: ScanType, options: ScanOptions = ScanOptions.scanOptions())(
       implicit asyncCollection: AsyncCollection): Source[ScanResult, NotUsed] =
@@ -186,7 +186,7 @@ object CouchbaseSource {
 
   /**
    * Fetches all indexes from this collection with custom options.
-   * @see [[com.couchbase.client.java.manager.query.AsyncCollectionQueryIndexManager#getAllIndexes]]
+   * @see `AsyncCollectionQueryIndexManager#getAllIndexes`
    */
   def queryAllIndex(options: GetAllQueryIndexesOptions = GetAllQueryIndexesOptions.getAllQueryIndexesOptions)(
       implicit asyncCollection: AsyncCollection): Source[QueryIndex, NotUsed] =

--- a/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/scaladsl/CouchbaseFlow.scala
+++ b/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/scaladsl/CouchbaseFlow.scala
@@ -99,7 +99,7 @@ object CouchbaseFlow {
   /**
    * Inserts a full document which does not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#insert]]
+   * @see `AsyncCollection#insert`
    */
   def insert[T](applyId: T => String,
       insertOptions: InsertOptions = InsertOptions.insertOptions())(
@@ -126,7 +126,7 @@ object CouchbaseFlow {
   /**
    * Replaces a full document which already exists with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#replace]]
+   * @see `AsyncCollection#replace`
    */
   def replace[T](applyId: T => String,
       replaceOptions: ReplaceOptions = ReplaceOptions.replaceOptions())(
@@ -152,7 +152,7 @@ object CouchbaseFlow {
   /**
    * Upsert a full document which might or might not exist yet with custom options.
    * @param applyId parse id function, which is the document id
-   * @see [[com.couchbase.client.java.AsyncCollection#upsert]]
+   * @see `AsyncCollection#upsert`
    */
   def upsert[T](applyId: T => String,
       upsertOptions: UpsertOptions = UpsertOptions.upsertOptions())(
@@ -179,7 +179,7 @@ object CouchbaseFlow {
   /**
    * Removes a Document from a collection with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `remove[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#remove]]
+   * @see `AsyncCollection#remove`
    */
   def remove[T](
       applyId: T => String,
@@ -194,7 +194,7 @@ object CouchbaseFlow {
 
   /**
    * Performs mutations to document fragments with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#mutateIn]]
+   * @see `AsyncCollection#mutateIn`
    */
   def mutateIn(specs: java.util.List[MutateInSpec], options: MutateInOptions = MutateInOptions.mutateInOptions())(
       implicit asyncCollection: AsyncCollection): Flow[String, MutateInResult, NotUsed] =
@@ -219,7 +219,7 @@ object CouchbaseFlow {
   /**
    * Checks if the given document ID exists on the active partition with custom options.
    * @param applyId parse id function, which is the document id, id streams can use `exists[String](e => e)`
-   * @see [[com.couchbase.client.java.AsyncCollection#exists]]
+   * @see `AsyncCollection#exists`
    */
   def exists[T](applyId: T => String, existsOptions: ExistsOptions = ExistsOptions.existsOptions())(
       implicit asyncCollection: AsyncCollection): Flow[T, Boolean, NotUsed] =
@@ -231,7 +231,7 @@ object CouchbaseFlow {
 
   /**
    * Updates the expiry of the document with the given id with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#touch]]
+   * @see `AsyncCollection#touch`
    */
   def touch(expiry: Duration, options: TouchOptions = TouchOptions.touchOptions())(
       implicit asyncCollection: AsyncCollection): Flow[String, MutationResult, NotUsed] =
@@ -255,7 +255,7 @@ object CouchbaseFlow {
 
   /**
    * Updates the expiry of the document with the given id with custom options.
-   * @see [[com.couchbase.client.java.AsyncCollection#touch]]
+   * @see `AsyncCollection#touch`
    */
   def touchInstant[T](applyId: T => String, expiry: Instant,
       touchOptions: TouchOptions = TouchOptions.touchOptions())(
@@ -268,7 +268,7 @@ object CouchbaseFlow {
 
   /**
    * Appends binary content to the document with custom options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#append]]
+   * @see `AsyncBinaryCollection#append`
    */
   def append(options: AppendOptions = AppendOptions.appendOptions())(
       implicit asyncCollection: AsyncCollection): Flow[MutationBinaryDocument, MutationResult, NotUsed] =
@@ -279,7 +279,7 @@ object CouchbaseFlow {
 
   /**
    * Prepends binary content to the document with custom options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#prepend]]
+   * @see `AsyncBinaryCollection#prepend`
    */
   def prepend(options: PrependOptions = PrependOptions.prependOptions())(
       implicit asyncCollection: AsyncCollection): Flow[MutationBinaryDocument, MutationResult, NotUsed] =
@@ -291,7 +291,7 @@ object CouchbaseFlow {
 
   /**
    * Increments the counter document by one or the number defined in the options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#increment]]
+   * @see `AsyncBinaryCollection#increment`
    */
   def increment(options: IncrementOptions = IncrementOptions.incrementOptions())(
       implicit asyncCollection: AsyncCollection): Flow[String, CounterResult, NotUsed] =
@@ -302,7 +302,7 @@ object CouchbaseFlow {
 
   /**
    * Decrements the counter document by one or the number defined in the options.
-   * @see [[com.couchbase.client.java.AsyncBinaryCollection#decrement]]
+   * @see `AsyncBinaryCollection#decrement`
    */
   def decrement(options: DecrementOptions = DecrementOptions.decrementOptions())(
       implicit asyncCollection: AsyncCollection): Flow[String, CounterResult, NotUsed] =

--- a/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/scaladsl/CouchbaseSource.scala
+++ b/couchbase3/src/main/scala/org/apache/pekko/stream/connectors/couchbase3/scaladsl/CouchbaseSource.scala
@@ -101,7 +101,7 @@ object CouchbaseSource {
       .map(_.contentAs(target))
 
   /**
-   * similar to Get[[CouchbaseSource.get]], batch get documents from collection by ScanType[[ScanType]]
+   * similar to Get[[CouchbaseSource.get]], batch get documents from collection by ScanType`ScanType`
    */
   def scan(scanType: ScanType, options: ScanOptions = ScanOptions.scanOptions())(
       implicit asyncCollection: AsyncCollection): Source[ScanResult, NotUsed] =
@@ -216,7 +216,7 @@ object CouchbaseSource {
 
   /**
    * Fetches all indexes from this collection with custom options.
-   * @see [[com.couchbase.client.java.manager.query.AsyncCollectionQueryIndexManager#getAllIndexes]]
+   * @see `AsyncCollectionQueryIndexManager#getAllIndexes`
    */
   def queryAllIndex(options: GetAllQueryIndexesOptions = GetAllQueryIndexesOptions.getAllQueryIndexesOptions)(
       implicit asyncCollection: AsyncCollection): Source[QueryIndex, NotUsed] =

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteMessage.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/WriteMessage.scala
@@ -148,7 +148,7 @@ object WriteMessage {
  * [[org.apache.pekko.stream.connectors.elasticsearch.testkit.MessageFactory]].
  */
 final class WriteResult[T2, C2] @InternalApi private[elasticsearch] (val message: WriteMessage[T2, C2],
-    /** JSON structure of the Elasticsearch error. */
+    /* JSON structure of the Elasticsearch error. */
     val error: Option[String]) {
   val success: Boolean = error.isEmpty
 

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/javadsl/ElasticsearchFlow.scala
@@ -96,9 +96,9 @@ object ElasticsearchFlow {
 
   /**
    * Create a flow to update Elasticsearch with
-   * [[java.util.List[pekko.stream.connectors.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
+   * `java.util.List[WriteMessage]`s containing type `T`
    * with `passThrough` of type `C`.
-   * The result status is part of the [[java.util.List[pekko.stream.connectors.elasticsearch.WriteResult WriteResult]]]
+   * The result status is part of the `java.util.List[WriteResult]`
    * and must be checked for successful execution.
    *
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
@@ -114,9 +114,9 @@ object ElasticsearchFlow {
 
   /**
    * Create a flow to update Elasticsearch with
-   * [[java.util.List[pekko.stream.connectors.elasticsearch.WriteMessage WriteMessage]]s containing type `T`
+   * `java.util.List[WriteMessage]`s containing type `T`
    * with `passThrough` of type `C`.
-   * The result status is part of the [[java.util.List[pekko.stream.connectors.elasticsearch.WriteResult WriteResult]]]
+   * The result status is part of the `java.util.List[WriteResult]`
    * and must be checked for successful execution.
    *
    * Warning: When settings configure retrying, messages are emitted out-of-order when errors are detected.
@@ -143,7 +143,7 @@ object ElasticsearchFlow {
    * successful execution.
    *
    * @param objectMapper Jackson object mapper converting type `T` to JSON
-   * @throws IllegalArgumentException When settings configure retrying.
+   * @throws java.lang.IllegalArgumentException When settings configure retrying.
    */
   @ApiMayChange
   def createWithContext[T, C](
@@ -160,7 +160,7 @@ object ElasticsearchFlow {
    * successful execution.
    *
    * @param messageWriter converts type `T` to a `String` containing valid JSON
-   * @throws IllegalArgumentException When settings configure retrying.
+   * @throws java.lang.IllegalArgumentException When settings configure retrying.
    */
   @ApiMayChange
   def createWithContext[T, C](

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/scaladsl/ElasticsearchFlow.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/scaladsl/ElasticsearchFlow.scala
@@ -84,9 +84,9 @@ object ElasticsearchFlow {
 
   /**
    * Create a flow to update Elasticsearch with
-   * [[immutable.Seq[pekko.stream.connectors.elasticsearch.WriteMessage WriteMessage]]]s containing type `T`
+   * `immutable.Seq[WriteMessage]`s containing type `T`
    * with `passThrough` of type `C`.
-   * The result status is part of the immutable.Seq[[pekko.stream.connectors.elasticsearch.WriteResult WriteResult]]
+   * The result status is part of the `immutable.Seq[WriteResult]`
    * and must be checked for successful execution.
    *
    * This factory method requires an implicit Spray JSON writer for `T`.
@@ -98,9 +98,9 @@ object ElasticsearchFlow {
 
   /**
    * Create a flow to update Elasticsearch with
-   * [[immutable.Seq[pekko.stream.connectors.elasticsearch.WriteMessage WriteMessage]]]s containing type `T`
+   * `immutable.Seq[WriteMessage]`s containing type `T`
    * with `passThrough` of type `C`.
-   * The result status is part of the immutable.Seq[[pekko.stream.connectors.elasticsearch.WriteResult WriteResult]]
+   * The result status is part of the `immutable.Seq[WriteResult]`
    * and must be checked for successful execution.
    */
   def createBulk[T, C](

--- a/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/scaladsl/ElasticsearchSource.scala
+++ b/elasticsearch/src/main/scala/org/apache/pekko/stream/connectors/elasticsearch/scaladsl/ElasticsearchSource.scala
@@ -31,7 +31,7 @@ object ElasticsearchSource {
   /**
    * Creates a [[pekko.stream.scaladsl.Source]] from Elasticsearch that streams [[ReadResult]]s
    * of Spray's [[spray.json.JsObject]].
-   * Alias of [[create]].
+   * Alias of `create`.
    */
   def apply(
       elasticsearchParams: ElasticsearchParams,
@@ -42,7 +42,7 @@ object ElasticsearchSource {
   /**
    * Creates a [[pekko.stream.scaladsl.Source]] from Elasticsearch that streams [[ReadResult]]s
    * of Spray's [[spray.json.JsObject]].
-   * Alias of [[create]].
+   * Alias of `create`.
    *
    * Example of searchParams-usage:
    *  Map( "query" -> """{"match_all": {}}""" )

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/FileTailSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/FileTailSource.java
@@ -38,10 +38,10 @@ import java.nio.file.StandardOpenOption;
  * <p>Read the entire contents of a file, and then when the end is reached, keep reading newly
  * appended data. Like the unix command `tail -f`.
  *
- * <p>Aborting the stage can be done by combining with a [[org.apache.pekko.stream.KillSwitch]]
+ * <p>Aborting the stage can be done by combining with a `org.apache.pekko.stream.KillSwitch`
  *
- * <p>To use the stage from Scala see the factory methods in {@link
- * org.apache.pekko.stream.connectors.file.scaladsl.FileTailSource}
+ * <p>To use the stage from Scala see the factory methods in
+ * `org.apache.pekko.stream.connectors.file.scaladsl.FileTailSource`
  */
 @InternalApi
 public final class FileTailSource extends GraphStage<SourceShape<ByteString>> {

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
@@ -30,10 +30,10 @@ import scala.jdk.javaapi.DurationConverters;
  * <p>Read the entire contents of a file, and then when the end is reached, keep reading newly
  * appended data. Like the unix command `tail -f`.
  *
- * <p>Aborting the stage can be done by combining with a [[org.apache.pekko.stream.KillSwitch]]
+ * <p>Aborting the stage can be done by combining with a `org.apache.pekko.stream.KillSwitch`
  *
- * <p>To use the stage from Scala see the factory methods in {@link
- * org.apache.pekko.stream.connectors.file.scaladsl.FileTailSource}
+ * <p>To use the stage from Scala see the factory methods in
+ * `org.apache.pekko.stream.connectors.file.scaladsl.FileTailSource`
  */
 public final class FileTailSource {
 
@@ -43,7 +43,7 @@ public final class FileTailSource {
    *
    * <p>Reading text lines can be done with the `createLines` factory methods or by composing with
    * other stages manually depending on your needs. Aborting the stage can be done by combining with
-   * a [[org.apache.pekko.stream.KillSwitch]]
+   * a `org.apache.pekko.stream.KillSwitch`
    *
    * @param path a file path to tail
    * @param maxChunkSize The max emitted size of the `ByteString`s
@@ -63,7 +63,7 @@ public final class FileTailSource {
    *
    * <p>If a line is longer than `maxChunkSize` the stream will fail.
    *
-   * <p>Aborting the stage can be done by combining with a [[org.apache.pekko.stream.KillSwitch]]
+   * <p>Aborting the stage can be done by combining with a `org.apache.pekko.stream.KillSwitch`
    *
    * @param path a file path to tail
    * @param maxLineSize The max emitted size of the `ByteString`s
@@ -79,7 +79,7 @@ public final class FileTailSource {
   }
 
   /**
-   * Same as {@link #createLines(Path, int, java.time.Duration, String, Charset)} but using the OS
+   * Same as `createLines(Path, int, java.time.Duration, String, Charset)` but using the OS
    * default line separator and UTF-8 for charset
    */
   public static Source<String, NotUsed> createLines(

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/javadsl/FileTailSource.java
@@ -79,8 +79,8 @@ public final class FileTailSource {
   }
 
   /**
-   * Same as `createLines(Path, int, java.time.Duration, String, Charset)` but using the OS
-   * default line separator and UTF-8 for charset
+   * Same as `createLines(Path, int, java.time.Duration, String, Charset)` but using the OS default
+   * line separator and UTF-8 for charset
    */
   public static Source<String, NotUsed> createLines(
       Path path, int maxChunkSize, java.time.Duration pollingInterval) {

--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/model.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/model.scala
@@ -37,7 +37,7 @@ final class TarArchiveMetadata private (
     val filePathName: String,
     val size: Long,
     val lastModification: Instant,
-    /**
+    /*
      * See constants `TarchiveMetadata.linkIndicatorNormal`
      */
     val linkIndicatorByte: Byte) {

--- a/ftp/src/main/java/org/apache/commons/net/ftp/LegacyFtpsClient.java
+++ b/ftp/src/main/java/org/apache/commons/net/ftp/LegacyFtpsClient.java
@@ -58,8 +58,8 @@ public final class LegacyFtpsClient extends FTPSClient {
   }
 
   /**
-   * Returns a socket of the data connection. Wrapped as an `SSLSocket`, which carries out
-   * handshake processing.
+   * Returns a socket of the data connection. Wrapped as an `SSLSocket`, which carries out handshake
+   * processing.
    *
    * @param command The textual representation of the FTP command to send.
    * @param arg The arguments to the FTP command. If this parameter is set to null, then the command

--- a/ftp/src/main/java/org/apache/commons/net/ftp/LegacyFtpsClient.java
+++ b/ftp/src/main/java/org/apache/commons/net/ftp/LegacyFtpsClient.java
@@ -58,7 +58,7 @@ public final class LegacyFtpsClient extends FTPSClient {
   }
 
   /**
-   * Returns a socket of the data connection. Wrapped as an {@link SSLSocket}, which carries out
+   * Returns a socket of the data connection. Wrapped as an `SSLSocket`, which carries out
    * handshake processing.
    *
    * @param command The textual representation of the FTP command to send.
@@ -67,7 +67,7 @@ public final class LegacyFtpsClient extends FTPSClient {
    * @return corresponding to the established data connection. Null is returned if an FTP protocol
    *     error is reported at any point during the establishment and initialization of the
    *     connection.
-   * @throws IOException If there is any problem with the connection.
+   * @throws java.io.IOException If there is any problem with the connection.
    * @see FTPClient#_openDataConnection_(int, String)
    * @since 3.2
    */

--- a/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/javadsl/FtpApi.scala
+++ b/ftp/src/main/scala/org/apache/pekko/stream/connectors/ftp/javadsl/FtpApi.scala
@@ -101,9 +101,9 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
    * @param branchSelector a predicate for pruning the tree. Takes a remote folder and return true
    *                       if you want to enter that remote folder.
    *                       Default behaviour is full recursive which is equivalent with calling this function
-   *                       with [[ls(basePath,connectionSettings,f->true)]].
+   *                       with `ls(basePath, connectionSettings, f => true)`.
    *
-   *                       Calling [[ls(basePath,connectionSettings,f->false)]] will emit only the files and folder in
+   *                       Calling `ls(basePath, connectionSettings, f => false)` will emit only the files and folder in
    *                       non-recursive fashion
    *
    * @return A [[pekko.stream.javadsl.Source Source]] of [[FtpFile]]s
@@ -118,9 +118,9 @@ sealed trait FtpApi[FtpClient, S <: RemoteFileSettings] { self: FtpSourceFactory
    * @param branchSelector a predicate for pruning the tree. Takes a remote folder and return true
    *                       if you want to enter that remote folder.
    *                       Default behaviour is full recursive which is equivalent with calling this function
-   *                       with [[ls(basePath,connectionSettings,f->true)]].
+   *                       with `ls(basePath, connectionSettings, f => true)`.
    *
-   *                       Calling [[ls(basePath,connectionSettings,f->false)]] will emit only the files and folder in
+   *                       Calling `ls(basePath, connectionSettings, f => false)` will emit only the files and folder in
    *                       non-recursive fashion
    * @param emitTraversedDirectories whether to include entered directories in the stream
    *

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/BigQuery.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/BigQuery.scala
@@ -210,7 +210,7 @@ object BigQuery extends Google {
    * @param selectedFields subset of fields to return, supports select into sub fields. Example: `selectedFields = List.of("a", "e.d.f")`
    * @param unmarshaller [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.TableDataListResponse]]
    * @tparam Out the data model of each row
-   * @return a [[pekko.stream.javadsl.Source]] that emits an [[Out]] for each row in the table
+   * @return a [[pekko.stream.javadsl.Source]] that emits an `Out` for each row in the table
    */
   def listTableData[Out](
       datasetId: String,
@@ -238,7 +238,7 @@ object BigQuery extends Google {
    * @param templateSuffix if specified, treats the destination table as a base template, and inserts the rows into an instance table named "{destination}{templateSuffix}"
    * @param marshaller [[pekko.http.javadsl.marshalling.Marshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.TableDataInsertAllRequest]]
    * @tparam In the data model for each record
-   * @return a [[pekko.stream.javadsl.Sink]] that inserts each batch of [[In]] into the table
+   * @return a [[pekko.stream.javadsl.Sink]] that inserts each batch of `In` into the table
    */
   def insertAll[In](
       datasetId: String,
@@ -285,7 +285,7 @@ object BigQuery extends Google {
    * @param useLegacySql specifies whether to use BigQuery's legacy SQL dialect for this query
    * @param unmarshaller [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    * @tparam Out the data model of the query results
-   * @return a [[pekko.stream.javadsl.Source]] that emits an [[Out]] for each row of the results and materializes
+   * @return a [[pekko.stream.javadsl.Source]] that emits an `Out` for each row of the results and materializes
    *         a [[java.util.concurrent.CompletionStage]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    */
   def query[Out](
@@ -305,7 +305,7 @@ object BigQuery extends Google {
    * @param query the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryRequest]]
    * @param unmarshaller [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    * @tparam Out the data model of the query results
-   * @return a [[pekko.stream.javadsl.Source]] that emits an [[Out]] for each row of the results and materializes
+   * @return a [[pekko.stream.javadsl.Source]] that emits an `Out` for each row of the results and materializes
    *         a [[java.util.concurrent.CompletionStage]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.JobReference]]
    *         a [[java.util.concurrent.CompletionStage]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    */
@@ -335,7 +335,7 @@ object BigQuery extends Google {
    * @param location the geographic location of the job. Required except for US and EU
    * @param unmarshaller [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    * @tparam Out the data model of the query results
-   * @return a [[pekko.stream.javadsl.Source]] that emits an [[Out]] for each row of the results and materializes a [[java.util.concurrent.CompletionStage]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
+   * @return a [[pekko.stream.javadsl.Source]] that emits an `Out` for each row of the results and materializes a [[java.util.concurrent.CompletionStage]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    */
   def getQueryResults[Out](
       jobId: String,
@@ -364,7 +364,7 @@ object BigQuery extends Google {
    * @param location the geographic location of the job. Required except for US and EU
    * @param settings the [[pekko.stream.connectors.google.GoogleSettings]]
    * @param system the actor system
-   * @return a [[java.util.concurrent.CompletionStage]] containing the [[Job]]
+   * @return a [[java.util.concurrent.CompletionStage]] containing the `Job`
    */
   def getJob(jobId: String,
       location: util.Optional[String],
@@ -395,9 +395,9 @@ object BigQuery extends Google {
    *
    * @param datasetId dataset ID of the table to insert into
    * @param tableId table ID of the table to insert into
-   * @param marshaller [[pekko.http.javadsl.marshalling.Marshaller]] for [[In]]
+   * @param marshaller [[pekko.http.javadsl.marshalling.Marshaller]] for `In`
    * @tparam In the data model for each record
-   * @return a [[pekko.stream.javadsl.Flow]] that uploads each [[In]] and emits a [[Job]] for every upload job created
+   * @return a [[pekko.stream.javadsl.Flow]] that uploads each `In` and emits a `Job` for every upload job created
    */
   def insertAllAsync[In](datasetId: String,
       tableId: String,
@@ -413,9 +413,9 @@ object BigQuery extends Google {
    *
    * @param datasetId dataset ID of the table to insert into
    * @param tableId table ID of the table to insert into
-   * @param marshaller [[pekko.http.javadsl.marshalling.Marshaller]] for [[In]]
+   * @param marshaller [[pekko.http.javadsl.marshalling.Marshaller]] for `In`
    * @tparam In the data model for each record
-   * @return a [[pekko.stream.javadsl.Flow]] that uploads each [[In]] and emits a [[Job]] for every upload job created
+   * @return a [[pekko.stream.javadsl.Flow]] that uploads each `In` and emits a `Job` for every upload job created
    */
   def insertAllAsync[In](datasetId: String,
       tableId: String,
@@ -433,10 +433,10 @@ object BigQuery extends Google {
    * @see [[https://cloud.google.com/bigquery/docs/reference/api-uploads BigQuery reference]]
    *
    * @param job the job to start
-   * @param marshaller [[pekko.http.javadsl.marshalling.Marshaller]] for [[Job]]
-   * @param unmarshaller [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for [[Job]]
+   * @param marshaller [[pekko.http.javadsl.marshalling.Marshaller]] for `Job`
+   * @param unmarshaller [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for `Job`
    * @tparam Job the data model for a job
-   * @return a [[pekko.stream.javadsl.Sink]] that uploads bytes and materializes a [[java.util.concurrent.CompletionStage]] containing the [[Job]] when completed
+   * @return a [[pekko.stream.javadsl.Sink]] that uploads bytes and materializes a [[java.util.concurrent.CompletionStage]] containing the `Job` when completed
    */
   def createLoadJob[@nowarn("msg=shadows") Job](
       job: Job,

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/jackson/BigQueryMarshallers.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/javadsl/jackson/BigQueryMarshallers.scala
@@ -44,7 +44,7 @@ object BigQueryMarshallers {
   /**
    * [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.TableDataListResponse]]
    *
-   * @param mapper an [[ObjectMapper]]
+   * @param mapper an `ObjectMapper`
    * @param `type` the data model for each row
    * @tparam T the data model for each row
    */
@@ -63,7 +63,7 @@ object BigQueryMarshallers {
   /**
    * [[pekko.http.javadsl.marshalling.Marshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.TableDataInsertAllRequest]]
    *
-   * @param mapper an [[ObjectMapper]]
+   * @param mapper an `ObjectMapper`
    * @tparam T the data model for each row
    */
   def tableDataInsertAllRequestMarshaller[T](
@@ -82,7 +82,7 @@ object BigQueryMarshallers {
   /**
    * [[pekko.http.javadsl.unmarshalling.Unmarshaller]] for [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    *
-   * @param mapper an [[ObjectMapper]]
+   * @param mapper an `ObjectMapper`
    * @param `type` the data model for each row
    * @tparam T the data model for each row
    */

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/JobJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/JobJsonProtocol.scala
@@ -66,7 +66,7 @@ object Job {
    * @param configuration describes the job configuration
    * @param jobReference reference describing the unique-per-user name of the job
    * @param status the status of this job
-   * @return a [[Job]]
+   * @return a `Job`
    */
   def create(configuration: util.Optional[JobConfiguration],
       jobReference: util.Optional[JobReference],

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableJsonProtocol.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/model/TableJsonProtocol.scala
@@ -175,7 +175,7 @@ object TableSchema {
    * @see [[https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#tableschema BigQuery reference]]
    *
    * @param fields describes the fields in a table
-   * @return a [[TableSchema]]
+   * @return a `TableSchema`
    */
   def create(fields: util.List[TableFieldSchema]) = TableSchema(fields.asScala.toList)
 
@@ -184,7 +184,7 @@ object TableSchema {
    * @see [[https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#tableschema BigQuery reference]]
    *
    * @param fields describes the fields in a table
-   * @return a [[TableSchema]]
+   * @return a `TableSchema`
    */
   @varargs
   def create(fields: TableFieldSchema*) = TableSchema(fields.toList)

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryJobs.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryJobs.scala
@@ -90,7 +90,7 @@ private[scaladsl] trait BigQueryJobs { this: BigQueryRest =>
    * @param datasetId dataset ID of the table to insert into
    * @param tableId table ID of the table to insert into
    * @tparam In the data model for each record
-   * @return a [[pekko.stream.scaladsl.Flow]] that uploads each [[In]] and emits a [[pekko.stream.connectors.googlecloud.bigquery.model.Job]] for every upload job created
+   * @return a [[pekko.stream.scaladsl.Flow]] that uploads each `In` and emits a [[pekko.stream.connectors.googlecloud.bigquery.model.Job]] for every upload job created
    */
   def insertAllAsync[In: ToEntityMarshaller](datasetId: String, tableId: String): Flow[In, Job, NotUsed] =
     insertAllAsync(datasetId, tableId, None)
@@ -104,7 +104,7 @@ private[scaladsl] trait BigQueryJobs { this: BigQueryRest =>
    * @param tableId table ID of the table to insert into
    * @param labels the labels associated with this job
    * @tparam In the data model for each record
-   * @return a [[pekko.stream.scaladsl.Flow]] that uploads each [[In]] and emits a [[pekko.stream.connectors.googlecloud.bigquery.model.Job]] for every upload job created
+   * @return a [[pekko.stream.scaladsl.Flow]] that uploads each `In` and emits a [[pekko.stream.connectors.googlecloud.bigquery.model.Job]] for every upload job created
    */
   def insertAllAsync[In: ToEntityMarshaller](datasetId: String,
       tableId: String,
@@ -160,7 +160,7 @@ private[scaladsl] trait BigQueryJobs { this: BigQueryRest =>
    *
    * @param job the job to start
    * @tparam Job the data model for a job
-   * @return a [[pekko.stream.scaladsl.Sink]] that uploads bytes and materializes a [[scala.concurrent.Future]] containing the [[Job]] when completed
+   * @return a [[pekko.stream.scaladsl.Sink]] that uploads bytes and materializes a [[scala.concurrent.Future]] containing the `Job` when completed
    */
   def createLoadJob[@nowarn("msg=shadows") Job: ToEntityMarshaller: FromEntityUnmarshaller](
       job: Job): Sink[ByteString, Future[Job]] =

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryQueries.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryQueries.scala
@@ -44,7 +44,7 @@ private[scaladsl] trait BigQueryQueries { this: BigQueryRest =>
    * @param dryRun if set to `true` BigQuery doesn't run the job and instead returns statistics about the job such as how many bytes would be processed
    * @param useLegacySql specifies whether to use BigQuery's legacy SQL dialect for this query
    * @tparam Out the data model of the query results
-   * @return a [[pekko.stream.scaladsl.Source]] that emits an [[Out]] for each row of the result and materializes
+   * @return a [[pekko.stream.scaladsl.Source]] that emits an `Out` for each row of the result and materializes
    *         a [[scala.concurrent.Future]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    */
   def query[Out](query: String, dryRun: Boolean = false, useLegacySql: Boolean = true)(
@@ -59,7 +59,7 @@ private[scaladsl] trait BigQueryQueries { this: BigQueryRest =>
    *
    * @param query the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryRequest]]
    * @tparam Out the data model of the query results
-   * @return a [[pekko.stream.scaladsl.Source]] that emits an [[Out]] for each row of the results and materializes
+   * @return a [[pekko.stream.scaladsl.Source]] that emits an `Out` for each row of the results and materializes
    *         a [[scala.concurrent.Future]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.JobReference]] and
    *         a [[scala.concurrent.Future]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    */
@@ -134,7 +134,7 @@ private[scaladsl] trait BigQueryQueries { this: BigQueryRest =>
    * @param timeout specifies the maximum amount of time that the client is willing to wait for the query to complete
    * @param location the geographic location of the job. Required except for US and EU
    * @tparam Out the data model of the query results
-   * @return a [[pekko.stream.scaladsl.Source]] that emits an [[Out]] for each row of the results and materializes a [[scala.concurrent.Future]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
+   * @return a [[pekko.stream.scaladsl.Source]] that emits an `Out` for each row of the results and materializes a [[scala.concurrent.Future]] containing the [[pekko.stream.connectors.googlecloud.bigquery.model.QueryResponse]]
    */
   def queryResults[Out](
       jobId: String,

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryTableData.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/BigQueryTableData.scala
@@ -51,7 +51,7 @@ private[scaladsl] trait BigQueryTableData { this: BigQueryRest =>
    * @param maxResults row limit of the table
    * @param selectedFields subset of fields to return, supports select into sub fields. Example: `selectedFields = Seq("a", "e.d.f")`
    * @tparam Out the data model of each row
-   * @return a [[pekko.stream.scaladsl.Source]] that emits an [[Out]] for each row in the table
+   * @return a [[pekko.stream.scaladsl.Source]] that emits an `Out` for each row in the table
    */
   def tableData[Out](datasetId: String,
       tableId: String,
@@ -79,7 +79,7 @@ private[scaladsl] trait BigQueryTableData { this: BigQueryRest =>
    * @param retryPolicy [[pekko.stream.connectors.googlecloud.bigquery.InsertAllRetryPolicy]] determining whether to retry and deduplicate
    * @param templateSuffix if specified, treats the destination table as a base template, and inserts the rows into an instance table named "{destination}{templateSuffix}"
    * @tparam In the data model for each record
-   * @return a [[pekko.stream.scaladsl.Sink]] that inserts each batch of [[In]] into the table
+   * @return a [[pekko.stream.scaladsl.Sink]] that inserts each batch of `In` into the table
    */
   def insertAll[In](
       datasetId: String,

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/schema/JavaTimeSchemas.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/schema/JavaTimeSchemas.scala
@@ -23,7 +23,7 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableFieldS
 import java.time.{ Instant, LocalDate, LocalDateTime, LocalTime }
 
 /**
- * Provides BigQuery schemas for [[java.time]] classes.
+ * Provides BigQuery schemas for `java.time` classes.
  */
 trait JavaTimeSchemas {
   implicit val localDateSchemaWriter: SchemaWriter[LocalDate] = new PrimitiveSchemaWriter(Date)

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/schema/Schema.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/schema/Schema.scala
@@ -18,7 +18,7 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableSchema
 object Schema {
 
   /**
-   * Materialize an implicit [[TableSchema]] for `T`
+   * Materialize an implicit `TableSchema` for `T`
    */
   def apply[T](implicit writer: TableSchemaWriter[T]): TableSchema =
     writer.write

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/schema/SchemaWriter.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/schema/SchemaWriter.scala
@@ -22,7 +22,7 @@ import org.apache.pekko.stream.connectors.googlecloud.bigquery.model.{
 import scala.annotation.implicitNotFound
 
 /**
- * Provides a [[org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableFieldSchema]] for type [[T]].
+ * Provides a [[org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableFieldSchema]] for type `T`.
  */
 @implicitNotFound(msg = "Cannot find SchemaWriter type class for ${T}")
 trait SchemaWriter[-T] {
@@ -38,7 +38,7 @@ object SchemaWriter {
 }
 
 /**
- * Provides a [[org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableSchema]] for type [[T]].
+ * Provides a [[org.apache.pekko.stream.connectors.googlecloud.bigquery.model.TableSchema]] for type `T`.
  */
 @implicitNotFound(msg = "Cannot find TableSchemaWriter type class for ${T}")
 trait TableSchemaWriter[-T] extends SchemaWriter[T] {

--- a/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/spray/BigQueryJavaTimeFormats.scala
+++ b/google-cloud-bigquery/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/bigquery/scaladsl/spray/BigQueryJavaTimeFormats.scala
@@ -20,7 +20,7 @@ import java.time.format.DateTimeFormatter.{ ISO_LOCAL_DATE, ISO_LOCAL_DATE_TIME,
 import scala.util.Try
 
 /**
- * Provides the BigQueryJsonFormats for [[java.time]] classes.
+ * Provides the BigQueryJsonFormats for `java.time` classes.
  */
 trait BigQueryJavaTimeFormats {
 

--- a/hdfs/src/main/scala/org/apache/pekko/stream/connectors/hdfs/javadsl/HdfsSource.scala
+++ b/hdfs/src/main/scala/org/apache/pekko/stream/connectors/hdfs/javadsl/HdfsSource.scala
@@ -30,7 +30,7 @@ import scala.jdk.FutureConverters._
 object HdfsSource {
 
   /**
-   * Java API: creates a [[Source]] that consumes as [[ByteString]]
+   * Java API: creates a `Source` that consumes as `ByteString`
    *
    * @param fs Hadoop file system
    * @param path the file to open
@@ -41,7 +41,7 @@ object HdfsSource {
     ScalaHdfsSource.data(fs, path).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * Java API: creates a [[Source]] that consumes as [[ByteString]]
+   * Java API: creates a `Source` that consumes as `ByteString`
    *
    * @param fs Hadoop file system
    * @param path the file to open
@@ -54,7 +54,7 @@ object HdfsSource {
     ScalaHdfsSource.data(fs, path, chunkSize).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * Java API: creates a [[Source]] that consumes as [[ByteString]]
+   * Java API: creates a `Source` that consumes as `ByteString`
    *
    * @param fs Hadoop file system
    * @param path the file to open
@@ -67,7 +67,7 @@ object HdfsSource {
     ScalaHdfsSource.compressed(fs, path, codec).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * Java API: creates a [[Source]] that consumes as [[ByteString]]
+   * Java API: creates a `Source` that consumes as `ByteString`
    *
    * @param fs Hadoop file system
    * @param path the file to open
@@ -82,7 +82,7 @@ object HdfsSource {
     ScalaHdfsSource.compressed(fs, path, codec, chunkSize).mapMaterializedValue(_.asJava).asJava
 
   /**
-   * Java API: creates a [[Source]] that consumes as [[(K, V]]
+   * Java API: creates a `Source` that consumes as `(K, V)`
    *
    * @param fs Hadoop file system
    * @param path the file to open

--- a/hdfs/src/main/scala/org/apache/pekko/stream/connectors/hdfs/model.scala
+++ b/hdfs/src/main/scala/org/apache/pekko/stream/connectors/hdfs/model.scala
@@ -145,7 +145,7 @@ object FilePathGenerator {
    * Scala API: creates [[FilePathGenerator]] to rotate output
    *
    * @param f    a function that takes rotation count and timestamp to return path of output
-   * @param temp the temporary directory that [[org.apache.pekko.stream.connectors.hdfs.impl.HdfsFlowStage]] use
+   * @param temp the temporary directory that `org.apache.pekko.stream.connectors.hdfs.impl.HdfsFlowStage` use
    */
   def apply(f: (Long, Long) => String, temp: String = DefaultTempDirectory): FilePathGenerator =
     new FilePathGenerator {

--- a/hdfs/src/main/scala/org/apache/pekko/stream/connectors/hdfs/scaladsl/HdfsSource.scala
+++ b/hdfs/src/main/scala/org/apache/pekko/stream/connectors/hdfs/scaladsl/HdfsSource.scala
@@ -28,7 +28,7 @@ import scala.concurrent.Future
 object HdfsSource {
 
   /**
-   * Scala API: creates a [[Source]] that consumes as [[ByteString]]
+   * Scala API: creates a `Source` that consumes as `ByteString`
    *
    * @param fs Hadoop file system
    * @param path the file to open
@@ -41,7 +41,7 @@ object HdfsSource {
     StreamConverters.fromInputStream(() => fs.open(path), chunkSize)
 
   /**
-   * Scala API: creates a [[Source]] that consumes as [[ByteString]]
+   * Scala API: creates a `Source` that consumes as `ByteString`
    *
    * @param fs Hadoop file system
    * @param path the file to open
@@ -56,7 +56,7 @@ object HdfsSource {
     StreamConverters.fromInputStream(() => codec.createInputStream(fs.open(path)), chunkSize)
 
   /**
-   * Scala API: creates a [[Source]] that consumes as [[(K, V]]
+   * Scala API: creates a `Source` that consumes as `(K, V)`
    *
    * @param fs Hadoop file system
    * @param path the file to open

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/javadsl/InfluxDbSource.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/javadsl/InfluxDbSource.scala
@@ -31,13 +31,13 @@ import pekko.stream.connectors.influxdb.impl.{ InfluxDbRawSourceStage, InfluxDbS
 object InfluxDbSource {
 
   /**
-   * Java API: creates an [[InfluxDbRawSourceStage]] from a given statement.
+   * Java API: creates an `InfluxDbRawSourceStage` from a given statement.
    */
   def create(influxDB: InfluxDB, query: Query): Source[QueryResult, NotUsed] =
     Source.fromGraph(new InfluxDbRawSourceStage(query, influxDB))
 
   /**
-   * Java API: creates an  [[InfluxDbSourceStage]] of elements of `T` from `query`.
+   * Java API: creates an  `InfluxDbSourceStage` of elements of `T` from `query`.
    */
   def typed[T](clazz: Class[T], settings: InfluxDbReadSettings, influxDB: InfluxDB, query: Query): Source[T, NotUsed] =
     Source.fromGraph(

--- a/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/scaladsl/InfluxDbSource.scala
+++ b/influxdb/src/main/scala/org/apache/pekko/stream/connectors/influxdb/scaladsl/InfluxDbSource.scala
@@ -31,7 +31,7 @@ import org.influxdb.dto.{ Query, QueryResult }
 object InfluxDbSource {
 
   /**
-   * Scala API: creates an [[pekko.stream.connectors.influxdb.impl.InfluxDbRawSourceStage]] from a given statement.
+   * Scala API: creates an `pekko.stream.connectors.influxdb.impl.InfluxDbRawSourceStage` from a given statement.
    */
   def apply(influxDB: InfluxDB, query: Query): Source[QueryResult, NotUsed] =
     Source.fromGraph(new InfluxDbRawSourceStage(query, influxDB))

--- a/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/scaladsl/IronMqProducer.scala
+++ b/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/scaladsl/IronMqProducer.scala
@@ -38,7 +38,7 @@ object IronMqProducer {
     flow(queueName, settings).toMat(Sink.ignore)(Keep.right)
 
   /**
-   * A [[Committable]] aware producer [[pekko.stream.scaladsl.Flow Flow]] that consume [[(PushMessage, Committable)]], push messages on IronMq and
+   * A [[Committable]] aware producer [[pekko.stream.scaladsl.Flow Flow]] that consume `(PushMessage, Committable)`, push messages on IronMq and
    * commit the associated [[Committable]].
    */
   def atLeastOnceFlow(queueName: String,
@@ -47,7 +47,7 @@ object IronMqProducer {
     atLeastOnceFlow(queueName, settings, Flow[Committable].mapAsync(1)(_.commit())).map(_._1)
 
   /**
-   * A [[Committable]] aware producer [[pekko.stream.scaladsl.Sink Sink]] that consume [[(PushMessage, Committable)]] push messages on IronMq and
+   * A [[Committable]] aware producer [[pekko.stream.scaladsl.Sink Sink]] that consume `(PushMessage, Committable)` push messages on IronMq and
    * commit the associated [[Committable]].
    */
   def atLeastOnceSink(queueName: String, settings: IronMqSettings): Sink[(PushMessage, Committable), NotUsed] =

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/AcknowledgeMode.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/AcknowledgeMode.scala
@@ -17,7 +17,7 @@ import jakarta.jms
 
 /**
  * JMS acknowledge modes.
- * See [[jakarta.jms.Connection#createSession-boolean-int-]]
+ * See `jakarta.jms.Connection#createSession(boolean, int)`
  */
 final class AcknowledgeMode(val mode: Int) {
   override def equals(other: Any): Boolean = other match {

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/AcknowledgeMode.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/AcknowledgeMode.scala
@@ -17,7 +17,7 @@ import javax.jms
 
 /**
  * JMS acknowledge modes.
- * See [[javax.jms.Connection#createSession-boolean-int-]]
+ * See `javax.jms.Connection#createSession(boolean, int)`
  */
 final class AcknowledgeMode(val mode: Int) {
   override def equals(other: Any): Boolean = other match {

--- a/json-streaming/src/main/scala/org/apache/pekko/stream/connectors/json/javadsl/JsonReader.scala
+++ b/json-streaming/src/main/scala/org/apache/pekko/stream/connectors/json/javadsl/JsonReader.scala
@@ -39,7 +39,7 @@ object JsonReader {
    * A Flow that consumes incoming json in chunks and produces a stream of parsable json values
    * according to the JsonPath given. The passed String will need to be parsed first.
    *
-   * @see [[#select]]
+   * @see `select`
    */
   def select(path: String): Flow[ByteString, ByteString, NotUsed] = select(JsonPathCompiler.compile(path))
 }

--- a/json-streaming/src/main/scala/org/apache/pekko/stream/connectors/json/scaladsl/JsonReader.scala
+++ b/json-streaming/src/main/scala/org/apache/pekko/stream/connectors/json/scaladsl/JsonReader.scala
@@ -39,7 +39,7 @@ object JsonReader {
    * A Flow that consumes incoming json in chunks and produces a stream of parsable json values
    * according to the JsonPath given. The passed String will need to be parsed first.
    *
-   * @see [[#select]]
+   * @see `select`
    */
   def select(path: String): Flow[ByteString, ByteString, NotUsed] = select(JsonPathCompiler.compile(path))
 }

--- a/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/CommittableRecord.scala
+++ b/kinesis/src/main/scala/org/apache/pekko/stream/connectors/kinesis/CommittableRecord.scala
@@ -87,7 +87,7 @@ object CommittableRecord {
     Ordering[(String, Long)].on(cr => (cr.sequenceNumber, cr.subSequenceNumber))
 
   /**
-   * See [[pekko.stream.connectors.kinesis.impl.ShardProcessor]]
+   * See `pekko.stream.connectors.kinesis.impl.ShardProcessor`
    */
   final class ShardProcessorData(
       val shardId: String,
@@ -95,7 +95,7 @@ object CommittableRecord {
       val pendingCheckpointSequenceNumber: ExtendedSequenceNumber)
 
   /**
-   * See [[pekko.stream.connectors.kinesis.impl.ShardProcessor]]
+   * See `pekko.stream.connectors.kinesis.impl.ShardProcessor`
    */
   final class BatchData(
       val cacheEntryTime: Instant,

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/javadsl/Mqtt.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/javadsl/Mqtt.scala
@@ -26,7 +26,7 @@ object Mqtt {
   /**
    * Create a bidirectional flow that maintains client session state with an MQTT endpoint.
    * The bidirectional flow can be joined with an endpoint flow that receives
-   * [[ByteString]] payloads and independently produces [[ByteString]] payloads e.g.
+   * `ByteString` payloads and independently produces `ByteString` payloads e.g.
    * an MQTT server.
    *
    * @param session the client session to use
@@ -44,7 +44,7 @@ object Mqtt {
   /**
    * Create a bidirectional flow that maintains server session state with an MQTT endpoint.
    * The bidirectional flow can be joined with an endpoint flow that receives
-   * [[ByteString]] payloads and independently produces [[ByteString]] payloads e.g.
+   * `ByteString` payloads and independently produces `ByteString` payloads e.g.
    * an MQTT server.
    *
    * @param session the server session to use

--- a/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/scaladsl/Mqtt.scala
+++ b/mqtt-streaming/src/main/scala/org/apache/pekko/stream/connectors/mqtt/streaming/scaladsl/Mqtt.scala
@@ -26,7 +26,7 @@ object Mqtt {
   /**
    * Create a bidirectional flow that maintains client session state with an MQTT endpoint.
    * The bidirectional flow can be joined with an endpoint flow that receives
-   * [[ByteString]] payloads and independently produces [[ByteString]] payloads e.g.
+   * `ByteString` payloads and independently produces `ByteString` payloads e.g.
    * an MQTT server.
    *
    * @param session the MQTT client session to use
@@ -47,7 +47,7 @@ object Mqtt {
   /**
    * Create a bidirectional flow that maintains server session state with an MQTT endpoint.
    * The bidirectional flow can be joined with an endpoint flow that receives
-   * [[ByteString]] payloads and independently produces [[ByteString]] payloads e.g.
+   * `ByteString` payloads and independently produces `ByteString` payloads e.g.
    * an MQTT server.
    *
    * @param session the MQTT server session to use

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/scaladsl/Pravega.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/scaladsl/Pravega.scala
@@ -32,7 +32,7 @@ object Pravega {
   /**
    * Messages are read from a Pravega stream.
    *
-   * Materialized value is a [[Future]] which completes to [[Done]] as soon as the Pravega reader is open.
+   * Materialized value is a `Future` which completes to [[Done]] as soon as the Pravega reader is open.
    */
   def source[A](readerGroup: ReaderGroup, readerSettings: ReaderSettings[A]): Source[PravegaEvent[A], Future[Done]] =
     Source.fromGraph(new PravegaSource(readerGroup, readerSettings))

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/scaladsl/PravegaTable.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/scaladsl/PravegaTable.scala
@@ -30,7 +30,7 @@ object PravegaTable {
   /**
    * Messages are read from a Pravega stream.
    *
-   * Materialized value is a [[Future]] which completes to [[Done]] as soon as the Pravega reader is open.
+   * Materialized value is a `Future` which completes to [[Done]] as soon as the Pravega reader is open.
    */
   def source[K, V](scope: String,
       tableName: String,

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/javadsl/S3.scala
@@ -278,7 +278,7 @@ object S3 {
       .asJava
 
   /**
-   * Uploads a S3 Object, use this for small files and [[multipartUpload]] for bigger ones
+   * Uploads a S3 Object, use this for small files and `multipartUpload` for bigger ones
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
@@ -303,7 +303,7 @@ object S3 {
       .asJava
 
   /**
-   * Uploads a S3 Object, use this for small files and [[multipartUpload]] for bigger ones
+   * Uploads a S3 Object, use this for small files and `multipartUpload` for bigger ones
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
@@ -320,7 +320,7 @@ object S3 {
     putObject(bucket, key, data, contentLength, contentType, S3Headers.empty.withCannedAcl(CannedAcl.Private))
 
   /**
-   * Uploads a S3 Object, use this for small files and [[multipartUpload]] for bigger ones
+   * Uploads a S3 Object, use this for small files and `multipartUpload` for bigger ones
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
@@ -815,7 +815,7 @@ object S3 {
    *                        with the returned `Sink`.
    * @param contentType an optional [[pekko.http.javadsl.model.ContentType ContentType]]
    * @param s3Headers any headers you want to add
-   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of `C`)'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUploadWithContext[C](
       bucket: String,
@@ -857,7 +857,7 @@ object S3 {
    *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
    *                        with the returned `Sink`.
    * @param contentType an optional [[pekko.http.javadsl.model.ContentType ContentType]]
-   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of `C`)'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUploadWithContext[C](
       bucket: String,
@@ -888,7 +888,7 @@ object S3 {
    *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
    *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
    *                        with the returned `Sink`.
-   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of `C`)'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def multipartUploadWithContext[C](
       bucket: String,
@@ -985,7 +985,7 @@ object S3 {
    *                        with the returned `Sink`.
    * @param contentType an optional [[pekko.http.javadsl.model.ContentType ContentType]]
    * @param s3Headers any headers you want to add
-   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of `C`)'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def resumeMultipartUploadWithContext[C](
       bucket: String,
@@ -1035,7 +1035,7 @@ object S3 {
    *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
    *                        with the returned `Sink`.
    * @param contentType an optional [[pekko.http.javadsl.model.ContentType ContentType]]
-   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of `C`)'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def resumeMultipartUploadWithContext[C](
       bucket: String,
@@ -1073,7 +1073,7 @@ object S3 {
    *                        backpressure is applied to the upload stream if `chunkUploadSink` is too slow, likewise any
    *                        failure will also be propagated to the upload stream. Sink Materialization is also shared
    *                        with the returned `Sink`.
-   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of [[C]])'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.javadsl.Sink Sink]] that accepts [[pekko.japi.Pair Pair]] of ([[pekko.util.ByteString ByteString]] of `C`)'s and materializes to a [[java.util.concurrent.CompletionStage CompletionStage]] of [[MultipartUploadResult]]
    */
   def resumeMultipartUploadWithContext[C](
       bucket: String,

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3.scala
@@ -176,13 +176,13 @@ object S3 {
     deleteObjectsByPrefix(bucket, None, deleteAllVersions, S3Headers.empty)
 
   /**
-   * Uploads a S3 Object, use this for small files and [[multipartUpload]] for bigger ones
+   * Uploads a S3 Object, use this for small files and `multipartUpload` for bigger ones
    *
    * @param bucket the s3 bucket name
    * @param key the s3 object key
-   * @param data a [[Stream]] of [[ByteString]]
+   * @param data a `Source` of `ByteString`
    * @param contentLength the number of bytes that will be uploaded (required!)
-   * @param contentType an optional [[ContentType]]
+   * @param contentType an optional `ContentType`
    * @param s3Headers any headers you want to add
    * @return a [[pekko.stream.scaladsl.Source Source]] containing the [[ObjectMetadata]] of the uploaded S3 Object
    */
@@ -469,10 +469,10 @@ object S3 {
    * @param key the s3 object key
    * @param contentType an optional [[pekko.http.scaladsl.model.ContentType ContentType]]
    * @param metaHeaders any meta-headers you want to add
-   * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
+   * @param cannedAcl a `CannedAcl`, defaults to `CannedAcl.Private`
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
-   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts [[ByteString]]'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts `ByteString`'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def multipartUpload(
       bucket: String,
@@ -534,10 +534,10 @@ object S3 {
    *                        with the returned `Sink`.
    * @param contentType an optional [[pekko.http.scaladsl.model.ContentType ContentType]]
    * @param metaHeaders any meta-headers you want to add
-   * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
+   * @param cannedAcl a `CannedAcl`, defaults to `CannedAcl.Private`
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
-   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts (`ByteString`, `C`)'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def multipartUploadWithContext[C](
       bucket: String,
@@ -582,7 +582,7 @@ object S3 {
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
    * @param s3Headers any headers you want to add
-   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts (`ByteString`, `C`)'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def multipartUploadWithHeadersAndContext[C](
       bucket: String,
@@ -610,10 +610,10 @@ object S3 {
    * @param previousParts The previously uploaded parts ending just before when this upload will commence
    * @param contentType an optional [[pekko.http.scaladsl.model.ContentType ContentType]]
    * @param metaHeaders any meta-headers you want to add
-   * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
+   * @param cannedAcl a `CannedAcl`, defaults to `CannedAcl.Private`
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
-   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts [[ByteString]]'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts `ByteString`'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def resumeMultipartUpload(
       bucket: String,
@@ -661,10 +661,10 @@ object S3 {
    *                        with the returned `Sink`.
    * @param contentType an optional [[pekko.http.scaladsl.model.ContentType ContentType]]
    * @param metaHeaders any meta-headers you want to add
-   * @param cannedAcl a [[CannedAcl]], defaults to [[CannedAcl.Private]]
+   * @param cannedAcl a `CannedAcl`, defaults to `CannedAcl.Private`
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
-   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts (`ByteString`, `C`)'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def resumeMultipartUploadWithContext[C](
       bucket: String,
@@ -751,7 +751,7 @@ object S3 {
    * @param chunkSize the size of the requests sent to S3, minimum [[MinChunkSize]]
    * @param chunkingParallelism the number of parallel requests used for the upload, defaults to 4
    * @param s3Headers any headers you want to add
-   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts ([[ByteString]], [[C]])'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
+   * @return a [[pekko.stream.scaladsl.Sink Sink]] that accepts (`ByteString`, `C`)'s and materializes to a [[scala.concurrent.Future Future]] of [[MultipartUploadResult]]
    */
   def resumeMultipartUploadWithHeadersAndContext[C](
       bucket: String,


### PR DESCRIPTION
## Summary
- Fix all scaladoc warnings across the project (~185 warnings across 45 files)
- Replace unresolvable `[[...]]` links with backtick-quoted code for external types
- Fix incorrect package prefixes and ambiguous overload links
- Fix unmoored doc comments

## Test plan
- [x] `sbt doc` completes with 0 warnings
- [x] No functional changes, documentation only