### PR TITLE
Use StandardCharsets.UTF_8 for UTF-8 encoding

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -19,6 +19,7 @@ package org.apache.pekko.stream.connectors.awsspi
 
 import java.util.Locale
 import java.util.concurrent.{ CompletableFuture, TimeUnit }
+import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
 import javax.net.ssl._
@@ -239,7 +240,8 @@ object PekkoHttpClient {
   lazy val xAmzJson11 = ContentType(MediaType.customBinary("application", "x-amz-json-1.1", Compressible))
   lazy val xAmzCbor11 = ContentType(MediaType.customBinary("application", "x-amz-cbor-1.1", Compressible))
   lazy val formUrlEncoded =
-    ContentType(MediaType.applicationWithOpenCharset("x-www-form-urlencoded"), HttpCharset.custom("utf-8"))
+    ContentType(MediaType.applicationWithOpenCharset("x-www-form-urlencoded"),
+      HttpCharset.custom(StandardCharsets.UTF_8.name))
   lazy val applicationXml = ContentType(MediaType.customBinary("application", "xml", Compressible))
 
   lazy val contentTypeMap: collection.immutable.Map[String, ContentType] = collection.immutable.Map(

--- a/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
+++ b/hbase/src/test/java/docs/javadsl/HBaseStageTest.java
@@ -15,7 +15,7 @@ package docs.javadsl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -61,87 +61,73 @@ public class HBaseStageTest {
   // #create-converter-put
   Function<Person, List<Mutation>> hBaseConverter =
       person -> {
-        try {
-          Put put = new Put("id_%d".formatted(person.id).getBytes("UTF-8"));
-          put.addColumn(
-              "info".getBytes("UTF-8"), "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+        Put put = new Put("id_%d".formatted(person.id).getBytes(StandardCharsets.UTF_8));
+        put.addColumn(
+            "info".getBytes(StandardCharsets.UTF_8),
+            "name".getBytes(StandardCharsets.UTF_8),
+            person.name.getBytes(StandardCharsets.UTF_8));
 
-          return List.of(put);
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
-          return Collections.emptyList();
-        }
+        return List.of(put);
       };
   // #create-converter-put
 
   // #create-converter-append
   Function<Person, List<Mutation>> appendHBaseConverter =
       person -> {
-        try {
-          Append append = new Append("id_%d".formatted(person.id).getBytes("UTF-8"));
-          append.add(
-              "info".getBytes("UTF-8"), "aliases".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+        Append append = new Append("id_%d".formatted(person.id).getBytes(StandardCharsets.UTF_8));
+        append.add(
+            "info".getBytes(StandardCharsets.UTF_8),
+            "aliases".getBytes(StandardCharsets.UTF_8),
+            person.name.getBytes(StandardCharsets.UTF_8));
 
-          return List.of(append);
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
-          return Collections.emptyList();
-        }
+        return List.of(append);
       };
   // #create-converter-append
 
   // #create-converter-delete
   Function<Person, List<Mutation>> deleteHBaseConverter =
       person -> {
-        try {
-          Delete delete = new Delete("id_%d".formatted(person.id).getBytes("UTF-8"));
+        Delete delete = new Delete("id_%d".formatted(person.id).getBytes(StandardCharsets.UTF_8));
 
-          return List.of(delete);
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
-          return Collections.emptyList();
-        }
+        return List.of(delete);
       };
   // #create-converter-delete
 
   // #create-converter-increment
   Function<Person, List<Mutation>> incrementHBaseConverter =
       person -> {
-        try {
-          Increment increment = new Increment("id_%d".formatted(person.id).getBytes("UTF-8"));
-          increment.addColumn("info".getBytes("UTF-8"), "numberOfChanges".getBytes("UTF-8"), 1);
+        Increment increment =
+            new Increment("id_%d".formatted(person.id).getBytes(StandardCharsets.UTF_8));
+        increment.addColumn(
+            "info".getBytes(StandardCharsets.UTF_8),
+            "numberOfChanges".getBytes(StandardCharsets.UTF_8),
+            1);
 
-          return List.of(increment);
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
-          return Collections.emptyList();
-        }
+        return List.of(increment);
       };
   // #create-converter-increment
 
   // #create-converter-complex
   Function<Person, List<Mutation>> complexHBaseConverter =
       person -> {
-        try {
-          byte[] id = "id_%d".formatted(person.id).getBytes("UTF-8");
-          byte[] infoFamily = "info".getBytes("UTF-8");
+        byte[] id = "id_%d".formatted(person.id).getBytes(StandardCharsets.UTF_8);
+        byte[] infoFamily = "info".getBytes(StandardCharsets.UTF_8);
 
-          if (person.id != 0 && person.name.isEmpty()) {
-            Delete delete = new Delete(id);
-            return List.of(delete);
-          } else if (person.id != 0) {
-            Put put = new Put(id);
-            put.addColumn(infoFamily, "name".getBytes("UTF-8"), person.name.getBytes("UTF-8"));
+        if (person.id != 0 && person.name.isEmpty()) {
+          Delete delete = new Delete(id);
+          return List.of(delete);
+        } else if (person.id != 0) {
+          Put put = new Put(id);
+          put.addColumn(
+              infoFamily,
+              "name".getBytes(StandardCharsets.UTF_8),
+              person.name.getBytes(StandardCharsets.UTF_8));
 
-            Increment increment = new Increment(id);
-            increment.addColumn(infoFamily, "numberOfChanges".getBytes("UTF-8"), 1);
+          Increment increment = new Increment(id);
+          increment.addColumn(infoFamily, "numberOfChanges".getBytes(StandardCharsets.UTF_8), 1);
 
-            return List.of(put, increment);
-          } else {
-            return Collections.emptyList();
-          }
-        } catch (UnsupportedEncodingException e) {
-          e.printStackTrace();
+          return List.of(put, increment);
+        } else {
           return Collections.emptyList();
         }
       };
@@ -195,11 +181,7 @@ public class HBaseStageTest {
   }
 
   @Test
-  public void readFromSource()
-      throws InterruptedException,
-          TimeoutException,
-          ExecutionException,
-          UnsupportedEncodingException {
+  public void readFromSource() throws InterruptedException, TimeoutException, ExecutionException {
 
     HTableSettings<Person> tableSettings =
         HTableSettings.create(
@@ -214,7 +196,7 @@ public class HBaseStageTest {
     assertEquals(Done.getInstance(), o.toCompletableFuture().get(5, TimeUnit.SECONDS));
 
     // #source
-    Scan scan = new Scan(new Get("id_300".getBytes("UTF-8")));
+    Scan scan = new Scan(new Get("id_300".getBytes(StandardCharsets.UTF_8)));
 
     CompletionStage<List<Result>> f =
         HTableStage.source(scan, tableSettings).runWith(Sink.seq(), system);

--- a/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
+++ b/hdfs/src/test/scala/org/apache/pekko/stream/connectors/hdfs/util/TestUtils.scala
@@ -15,6 +15,7 @@ package org.apache.pekko.stream.connectors.hdfs.util
 
 import java.io.{ File, InputStream, StringWriter }
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import java.util
 
 import org.apache.pekko
@@ -38,7 +39,7 @@ sealed trait TestUtils {
 
   def read(stream: InputStream): String = {
     val writer = new StringWriter
-    IOUtils.copy(stream, writer, "UTF-8")
+    IOUtils.copy(stream, writer, StandardCharsets.UTF_8)
     writer.toString
   }
 

--- a/pravega/src/test/scala/docs/scaladsl/Serializers.scala
+++ b/pravega/src/test/scala/docs/scaladsl/Serializers.scala
@@ -15,6 +15,7 @@ package docs.scaladsl
 
 import io.pravega.client.stream.Serializer
 import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets
 import io.pravega.client.stream.impl.UTF8StringSerializer
 
 object Serializers {
@@ -23,7 +24,7 @@ object Serializers {
 
   implicit val personSerializer: Serializer[Person] = new Serializer[Person] {
     def serialize(x: Person): ByteBuffer = {
-      val name = x.firstname.getBytes("UTF-8")
+      val name = x.firstname.getBytes(StandardCharsets.UTF_8)
       val buff = ByteBuffer.allocate(4 + name.length).putInt(x.id)
       buff.put(ByteBuffer.wrap(name))
       buff.position(0)

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Marshalling.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Marshalling.scala
@@ -14,6 +14,7 @@
 package org.apache.pekko.stream.connectors.s3.impl
 
 import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
 import java.time.Instant
 
 import org.apache.pekko
@@ -60,7 +61,8 @@ import scala.xml.NodeSeq
       case x             =>
         CompleteMultipartUploadResult(
           Try(Uri((x \ "Location").text))
-            .getOrElse(Uri((x \ "Location").text.split("/").map(s => URLEncoder.encode(s, "utf-8")).mkString("/"))),
+            .getOrElse(Uri(
+              (x \ "Location").text.split("/").map(s => URLEncoder.encode(s, StandardCharsets.UTF_8)).mkString("/"))),
           (x \ "Bucket").text,
           (x \ "Key").text,
           (x \ "ETag").text.drop(1).dropRight(1))

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/scaladsl/S3IntegrationSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.stream.connectors.s3.scaladsl
 
+import java.nio.charset.StandardCharsets
+
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.Http
@@ -771,7 +773,7 @@ trait S3IntegrationSpec
           parts.nonEmpty shouldBe true
           uploadIds.size shouldBe 1
           parts.size shouldBe 3
-          parts.map(_.size) shouldBe inputsUntilAbort.map(_.utf8String.getBytes("UTF-8").length)
+          parts.map(_.size) shouldBe inputsUntilAbort.map(_.utf8String.getBytes(StandardCharsets.UTF_8).length)
           // In S3 the etag's are actually an MD5 hash of the contents of the part so we can use this to check
           // that the data has been uploaded correctly and in the right order, see
           // https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html


### PR DESCRIPTION
Summary: Replace UTF-8 charset string arguments with StandardCharsets.UTF_8 across affected connector code and tests, and remove obsolete UnsupportedEncodingException handling. Verification: ran formatting, targeted compile, git diff --check, and residual charset literal searches.