### PR TITLE
chore: update scala3Next to 3.9.0-RC6

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 
   val Scala213 = "2.13.18" // update even in link-validator.conf
   val Scala3 = "3.3.8"
-  val Scala3Next = "3.9.0-RC1"
+  val Scala3Next = "3.9.0-RC3"
   val PublishedScalaVersions = Seq(Scala213, Scala3)
 
   val PekkoVersion = PekkoCoreDependency.version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 
   val Scala213 = "2.13.18" // update even in link-validator.conf
   val Scala3 = "3.3.8"
-  val Scala3Next = "3.8.4"
+  val Scala3Next = "3.9.0-RC1"
   val PublishedScalaVersions = Seq(Scala213, Scala3)
 
   val PekkoVersion = PekkoCoreDependency.version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,7 +18,7 @@ object Dependencies {
 
   val Scala213 = "2.13.18" // update even in link-validator.conf
   val Scala3 = "3.3.8"
-  val Scala3Next = "3.9.0-RC3"
+  val Scala3Next = "3.9.0-RC6"
   val PublishedScalaVersions = Seq(Scala213, Scala3)
 
   val PekkoVersion = PekkoCoreDependency.version


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC3 is available and should be tested as the next Scala version.

### Modification
Update scala3Next version from 3.8.4 to 3.9.0-RC3.

### Result
Build will use Scala 3.9.0-RC3 as the next Scala version.

### Tests
Not run - version bump only

### References
None - version bump