### PR TITLE
use scalapb grpc scala3 sources in scala 3 builds

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -250,8 +250,8 @@ lazy val googleCloudBigQueryStorage = pekkoConnectorProject(
   Compile / sources := (Compile / sources).value.filterNot { f =>
     f.getPath.replace('\\', '/').contains("/pekko-grpc/main/com/google/protobuf")
   },
-  Compile / PB.targets := Seq(
-    scalapb.gen(scala3Sources = Common.isScala3.value) -> (Compile / sourceManaged).value / "scalapb"
+  Compile / pekkoGrpcCodeGeneratorSettings ++= (
+    if (Common.isScala3.value) Seq("scala3_sources") else Seq.empty
   ),
   Test / fork := true,
   Test / javaOptions ++= Seq("--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED")
@@ -285,8 +285,8 @@ lazy val googleCloudPubSubGrpc = pekkoConnectorProject(
       previousFilter.accept(f) ||
       (Common.isScala3Next.value && f.getAbsolutePath.replace('\\', '/').contains("grpc/reflection/v1alpha")))
   },
-  Compile / PB.targets := Seq(
-    scalapb.gen(scala3Sources = Common.isScala3.value) -> (Compile / sourceManaged).value / "scalapb"
+  Compile / pekkoGrpcCodeGeneratorSettings ++= (
+    if (Common.isScala3.value) Seq("scala3_sources") else Seq.empty
   ),
   // the following is needed to exclude the gRPC generated sources for protobuf-java from the sources,
   // they cause Scaladoc tool fails - https://github.com/apache/pekko-connectors/issues/1440

--- a/build.sbt
+++ b/build.sbt
@@ -250,6 +250,9 @@ lazy val googleCloudBigQueryStorage = pekkoConnectorProject(
   Compile / sources := (Compile / sources).value.filterNot { f =>
     f.getPath.replace('\\', '/').contains("/pekko-grpc/main/com/google/protobuf")
   },
+  Compile / PB.targets := Seq(
+    scalapb.gen(scala3Sources = Common.isScala3.value) -> (Compile / sourceManaged).value / "scalapb"
+  ),
   Test / fork := true,
   Test / javaOptions ++= Seq("--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED")
 ).dependsOn(googleCommon)
@@ -282,6 +285,9 @@ lazy val googleCloudPubSubGrpc = pekkoConnectorProject(
       previousFilter.accept(f) ||
       (Common.isScala3Next.value && f.getAbsolutePath.replace('\\', '/').contains("grpc/reflection/v1alpha")))
   },
+  Compile / PB.targets := Seq(
+    scalapb.gen(scala3Sources = Common.isScala3.value) -> (Compile / sourceManaged).value / "scalapb"
+  ),
   // the following is needed to exclude the gRPC generated sources for protobuf-java from the sources,
   // they cause Scaladoc tool fails - https://github.com/apache/pekko-connectors/issues/1440
   // and issues like https://github.com/apache/pekko-connectors/issues/1457


### PR DESCRIPTION
Seems to work ok. There might be some improvements that we could make to scalapb but this seems ok at the moment