### PR TITLE
require TLS 1.2 min for google and huawei connectors

### DIFF
--- a/google-common/src/main/mima-filters/2.0.x.backwards.excludes/min-tls-version.backwards.excludes
+++ b/google-common/src/main/mima-filters/2.0.x.backwards.excludes/min-tls-version.backwards.excludes
@@ -15,4 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ProblemFilters.exclude[MissingTypesProblem]("org.apache.pekko.stream.connectors.google.ResumableUpload$Chunk$")
+# Add min-tls-version setting
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.connectors.google.ForwardProxy.apply")

--- a/google-common/src/main/resources/reference.conf
+++ b/google-common/src/main/resources/reference.conf
@@ -93,6 +93,8 @@ pekko.connectors.google {
   #     password = "password"
   #   }
   #   trust-pem = "/path/to/file.pem"
+  #   # Minimum TLS version to use. Valid values: TLSv1.2, TLSv1.3
+  #   min-tls-version = "TLSv1.2"
   # }
 
 }

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleExt.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleExt.scala
@@ -32,7 +32,7 @@ import scala.collection.immutable.ListMap
 @InternalApi
 private[google] final class GoogleExt private (sys: ExtendedActorSystem) extends Extension {
   private var cachedSettings: Map[String, GoogleSettings] = ListMap.empty
-  val settings: GoogleSettings = settings(GoogleSettings.ConfigPath)
+  lazy val settings: GoogleSettings = settings(GoogleSettings.ConfigPath)
 
   def settings(path: String): GoogleSettings =
     cachedSettings.getOrElse(path, {

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
@@ -271,6 +271,7 @@ object ForwardProxy {
       system: ClassicActorSystemProvider) =
     apply(scheme, host, port, credentials.toScala.asInstanceOf[Option[BasicHttpCredentials]], trustPem.toScala)(system)
 
+  /** @since 2.0.0 */
   def create(scheme: String,
       host: String,
       port: Int,

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
@@ -279,7 +279,8 @@ object ForwardProxy {
       trustPem: Optional[String],
       minTlsVersion: String,
       system: ClassicActorSystemProvider) =
-    apply(scheme, host, port, credentials.toScala.asInstanceOf[Option[BasicHttpCredentials]], trustPem.toScala, minTlsVersion)(system)
+    apply(scheme, host, port, credentials.toScala.asInstanceOf[Option[BasicHttpCredentials]], trustPem.toScala,
+      minTlsVersion)(system)
 
   def create(connectionContext: jh.HttpConnectionContext, poolSettings: jh.settings.ConnectionPoolSettings) =
     apply(connectionContext.asInstanceOf[HttpsConnectionContext], poolSettings.asInstanceOf[ConnectionPoolSettings])

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
@@ -242,7 +242,11 @@ object ForwardProxy {
       else
         None
 
-    ForwardProxy(scheme, c.getString("host"), c.getInt("port"), maybeCredentials, maybeTrustPem)
+    val minTlsVersion =
+      if (c.hasPath("min-tls-version")) c.getString("min-tls-version")
+      else "TLSv1.2"
+
+    ForwardProxy(scheme, c.getString("host"), c.getInt("port"), maybeCredentials, maybeTrustPem, minTlsVersion)
   }
 
   def create(c: Config, system: ClassicActorSystemProvider) =
@@ -252,9 +256,10 @@ object ForwardProxy {
       host: String,
       port: Int,
       credentials: Option[BasicHttpCredentials],
-      trustPem: Option[String])(implicit system: ClassicActorSystemProvider): ForwardProxy = {
+      trustPem: Option[String],
+      minTlsVersion: String = "TLSv1.2")(implicit system: ClassicActorSystemProvider): ForwardProxy = {
     ForwardProxy(
-      trustPem.fold(Http(system.classicSystem).defaultClientHttpsContext)(ForwardProxyHttpsContext(_)),
+      trustPem.fold(Http(system.classicSystem).defaultClientHttpsContext)(ForwardProxyHttpsContext(_, minTlsVersion)),
       ForwardProxyPoolSettings(scheme, host, port, credentials)(system.classicSystem))
   }
 
@@ -265,6 +270,15 @@ object ForwardProxy {
       trustPem: Optional[String],
       system: ClassicActorSystemProvider) =
     apply(scheme, host, port, credentials.toScala.asInstanceOf[Option[BasicHttpCredentials]], trustPem.toScala)(system)
+
+  def create(scheme: String,
+      host: String,
+      port: Int,
+      credentials: Optional[jm.headers.BasicHttpCredentials],
+      trustPem: Optional[String],
+      minTlsVersion: String,
+      system: ClassicActorSystemProvider) =
+    apply(scheme, host, port, credentials.toScala.asInstanceOf[Option[BasicHttpCredentials]], trustPem.toScala, minTlsVersion)(system)
 
   def create(connectionContext: jh.HttpConnectionContext, poolSettings: jh.settings.ConnectionPoolSettings) =
     apply(connectionContext.asInstanceOf[HttpsConnectionContext], poolSettings.asInstanceOf[ConnectionPoolSettings])

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
@@ -43,7 +43,8 @@ private[google] object ForwardProxyHttpsContext {
     val trustManagers = tmf.getTrustManagers
     sslContext.init(null, trustManagers, null)
     val protocols = TlsVersions.getOrElse(minTlsVersion,
-      throw new IllegalArgumentException(s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
+      throw new IllegalArgumentException(
+        s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
     sslContext.getDefaultSSLParameters.setProtocols(protocols)
     ConnectionContext.httpsClient(sslContext)
   }

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
@@ -27,7 +27,8 @@ private[google] object ForwardProxyHttpsContext {
 
   def apply(trustPemPath: String): HttpsConnectionContext = {
     val certificate = x509Certificate(trustPemPath: String)
-    val sslContext = SSLContext.getInstance("SSL")
+    val sslContext = SSLContext.getInstance("TLS")
+    sslContext.getDefaultSSLParameters.setProtocols(Array("TLSv1.2", "TLSv1.3"))
 
     val alias = certificate.getIssuerX500Principal.getName
     val trustStore = KeyStore.getInstance(KeyStore.getDefaultType)

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
@@ -25,10 +25,13 @@ import javax.net.ssl.{ SSLContext, TrustManagerFactory }
 @InternalApi
 private[google] object ForwardProxyHttpsContext {
 
-  def apply(trustPemPath: String): HttpsConnectionContext = {
+  private val TlsVersions = Map(
+    "TLSv1.2" -> Array("TLSv1.2", "TLSv1.3"),
+    "TLSv1.3" -> Array("TLSv1.3"))
+
+  def apply(trustPemPath: String, minTlsVersion: String = "TLSv1.2"): HttpsConnectionContext = {
     val certificate = x509Certificate(trustPemPath: String)
     val sslContext = SSLContext.getInstance("TLS")
-    sslContext.getDefaultSSLParameters.setProtocols(Array("TLSv1.2", "TLSv1.3"))
 
     val alias = certificate.getIssuerX500Principal.getName
     val trustStore = KeyStore.getInstance(KeyStore.getDefaultType)
@@ -39,6 +42,9 @@ private[google] object ForwardProxyHttpsContext {
     tmf.init(trustStore)
     val trustManagers = tmf.getTrustManagers
     sslContext.init(null, trustManagers, null)
+    val protocols = TlsVersions.getOrElse(minTlsVersion,
+      throw new IllegalArgumentException(s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
+    sslContext.getDefaultSSLParameters.setProtocols(protocols)
     ConnectionContext.httpsClient(sslContext)
   }
 

--- a/huawei-push-kit/src/main/mima-filters/2.0.x.backwards.excludes/min-tls-version.backwards.excludes
+++ b/huawei-push-kit/src/main/mima-filters/2.0.x.backwards.excludes/min-tls-version.backwards.excludes
@@ -15,4 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-ProblemFilters.exclude[MissingTypesProblem]("org.apache.pekko.stream.connectors.google.ResumableUpload$Chunk$")
+# Add min-tls-version setting
+ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.stream.connectors.huawei.pushkit.ForwardProxy.unapply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.connectors.huawei.pushkit.ForwardProxy.apply")
+ProblemFilters.exclude[DirectMissingMethodProblem]("org.apache.pekko.stream.connectors.huawei.pushkit.ForwardProxy.copy")

--- a/huawei-push-kit/src/main/resources/reference.conf
+++ b/huawei-push-kit/src/main/resources/reference.conf
@@ -15,5 +15,7 @@ pekko.connectors.huawei.pushkit {
   #     password = "password"
   #   }
   #   trust-pem = "/path/to/file.pem"
+  #   # Minimum TLS version to use. Valid values: TLSv1.2, TLSv1.3
+  #   min-tls-version = "TLSv1.2"
   # }
 }

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
@@ -59,7 +59,8 @@ private[pushkit] object ForwardProxyHttpsContext {
     val trustManagers = tmf.getTrustManagers
     sslContext.init(null, trustManagers, null)
     val protocols = TlsVersions.getOrElse(minTlsVersion,
-      throw new IllegalArgumentException(s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
+      throw new IllegalArgumentException(
+        s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
     sslContext.getDefaultSSLParameters.setProtocols(protocols)
     ConnectionContext.httpsClient(sslContext)
   }

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
@@ -29,7 +29,6 @@ import javax.net.ssl.{ SSLContext, TrustManagerFactory }
 @InternalApi
 private[pushkit] object ForwardProxyHttpsContext {
 
-  val SSL = "SSL"
   val X509 = "X509"
 
   implicit class ForwardProxyHttpsContext(forwardProxy: ForwardProxy) {
@@ -44,7 +43,8 @@ private[pushkit] object ForwardProxyHttpsContext {
 
   private def createHttpsContext(trustPem: ForwardProxyTrustPem) = {
     val certificate = x509Certificate(trustPem)
-    val sslContext = SSLContext.getInstance(SSL)
+    val sslContext = SSLContext.getInstance("TLS")
+    sslContext.getDefaultSSLParameters.setProtocols(Array("TLSv1.2", "TLSv1.3"))
 
     val alias = certificate.getIssuerX500Principal.getName
     val trustStore = KeyStore.getInstance(KeyStore.getDefaultType)

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
@@ -31,20 +31,23 @@ private[pushkit] object ForwardProxyHttpsContext {
 
   val X509 = "X509"
 
+  private val TlsVersions = Map(
+    "TLSv1.2" -> Array("TLSv1.2", "TLSv1.3"),
+    "TLSv1.3" -> Array("TLSv1.3"))
+
   implicit class ForwardProxyHttpsContext(forwardProxy: ForwardProxy) {
 
     def httpsContext(system: ActorSystem): HttpsConnectionContext = {
       forwardProxy.trustPem match {
-        case Some(trustPem) => createHttpsContext(trustPem)
+        case Some(trustPem) => createHttpsContext(trustPem, forwardProxy.minTlsVersion)
         case None           => Http()(system).defaultClientHttpsContext
       }
     }
   }
 
-  private def createHttpsContext(trustPem: ForwardProxyTrustPem) = {
+  private def createHttpsContext(trustPem: ForwardProxyTrustPem, minTlsVersion: String) = {
     val certificate = x509Certificate(trustPem)
     val sslContext = SSLContext.getInstance("TLS")
-    sslContext.getDefaultSSLParameters.setProtocols(Array("TLSv1.2", "TLSv1.3"))
 
     val alias = certificate.getIssuerX500Principal.getName
     val trustStore = KeyStore.getInstance(KeyStore.getDefaultType)
@@ -55,6 +58,9 @@ private[pushkit] object ForwardProxyHttpsContext {
     tmf.init(trustStore)
     val trustManagers = tmf.getTrustManagers
     sslContext.init(null, trustManagers, null)
+    val protocols = TlsVersions.getOrElse(minTlsVersion,
+      throw new IllegalArgumentException(s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
+    sslContext.getDefaultSSLParameters.setProtocols(protocols)
     ConnectionContext.httpsClient(sslContext)
   }
 

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
@@ -227,12 +227,16 @@ final case class ForwardProxy @InternalApi private (host: String,
   def getPort = port
   def getCredentials = credentials
   def getForwardProxyTrustPem = trustPem
+
+  /** @since 2.0.0 */
   def getMinTlsVersion = minTlsVersion
 
   def withHost(host: String) = copy(host = host)
   def withPort(port: Int) = copy(port = port)
   def withCredentials(credentials: ForwardProxyCredentials) = copy(credentials = Option(credentials))
   def withTrustPem(trustPem: ForwardProxyTrustPem) = copy(trustPem = Option(trustPem))
+
+  /** @since 2.0.0 */
   def withMinTlsVersion(minTlsVersion: String) = copy(minTlsVersion = minTlsVersion)
 }
 

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
@@ -171,7 +171,10 @@ object ForwardProxy {
         Some(ForwardProxyTrustPem(c.getString("trust-pem")))
       else
         None
-    ForwardProxy(c.getString("host"), c.getInt("port"), maybeCredentials, maybeTrustPem)
+    val minTlsVersion =
+      if (c.hasPath("min-tls-version")) c.getString("min-tls-version")
+      else "TLSv1.2"
+    ForwardProxy(c.getString("host"), c.getInt("port"), maybeCredentials, maybeTrustPem, minTlsVersion)
   }
 
   /**
@@ -182,8 +185,9 @@ object ForwardProxy {
   def apply(host: String,
       port: Int,
       credentials: Option[ForwardProxyCredentials],
-      trustPem: Option[ForwardProxyTrustPem]) =
-    new ForwardProxy(host, port, credentials, trustPem)
+      trustPem: Option[ForwardProxyTrustPem],
+      minTlsVersion: String = "TLSv1.2") =
+    new ForwardProxy(host, port, credentials, trustPem, minTlsVersion)
 
   /**
    * Java API.
@@ -216,17 +220,20 @@ object ForwardProxy {
 final case class ForwardProxy @InternalApi private (host: String,
     port: Int,
     credentials: Option[ForwardProxyCredentials],
-    trustPem: Option[ForwardProxyTrustPem]) {
+    trustPem: Option[ForwardProxyTrustPem],
+    minTlsVersion: String = "TLSv1.2") {
 
   def getHost = host
   def getPort = port
   def getCredentials = credentials
   def getForwardProxyTrustPem = trustPem
+  def getMinTlsVersion = minTlsVersion
 
   def withHost(host: String) = copy(host = host)
   def withPort(port: Int) = copy(port = port)
   def withCredentials(credentials: ForwardProxyCredentials) = copy(credentials = Option(credentials))
   def withTrustPem(trustPem: ForwardProxyTrustPem) = copy(trustPem = Option(trustPem))
+  def withMinTlsVersion(minTlsVersion: String) = copy(minTlsVersion = minTlsVersion)
 }
 
 object ForwardProxyCredentials {


### PR DESCRIPTION
google-common/.../ForwardProxyHttpsContext.scala
- SSLContext.getInstance("SSL") → SSLContext.getInstance("TLS")
- Added sslContext.getDefaultSSLParameters.setProtocols(Array("TLSv1.2", "TLSv1.3"))

huawei-push-kit/.../ForwardProxyHttpsContext.scala
- Removed unused val SSL = "SSL" constant
- SSLContext.getInstance(SSL) → SSLContext.getInstance("TLS")
- Added sslContext.getDefaultSSLParameters.setProtocols(Array("TLSv1.2", "TLSv1.3"))