### PR TITLE
mask sensitive values in toString

### DIFF
--- a/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectionProvider.scala
+++ b/amqp/src/main/scala/org/apache/pekko/stream/connectors/amqp/AmqpConnectionProvider.scala
@@ -53,10 +53,12 @@ final class AmqpUriConnectionProvider private (val uri: String) extends AmqpConn
     factory.newConnection
   }
 
-  override def toString: String =
+  override def toString: String = {
+    val maskedUri = uri.replaceAll("://([^@]*)@", "://*****@")
     "AmqpUriConnectionProvider(" +
-    s"uri=$uri" +
+    s"uri=$maskedUri" +
     ")"
+  }
 }
 
 object AmqpUriConnectionProvider {

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/AccessToken.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/AccessToken.scala
@@ -26,6 +26,10 @@ import scala.concurrent.duration._
 private[auth] final case class AccessToken(token: String, expiresAt: Long) {
   def expiresSoon(in: FiniteDuration = 1.minute)(implicit clock: Clock): Boolean =
     expiresAt < JwtTime.nowSeconds + in.toSeconds
+
+  override def toString: String =
+    "AccessToken(token=*****," +
+    s"expiresAt=$expiresAt)"
 }
 
 @InternalApi
@@ -39,7 +43,12 @@ private[auth] object AccessToken {
 }
 
 @InternalApi
-private[auth] final case class AccessTokenResponse(access_token: String, token_type: String, expires_in: Int)
+private[auth] final case class AccessTokenResponse(access_token: String, token_type: String, expires_in: Int) {
+  override def toString: String =
+    "AccessTokenResponse(access_token=*****," +
+    s"token_type=$token_type," +
+    s"expires_in=$expires_in)"
+}
 
 @InternalApi
 private[auth] object AccessTokenResponse {

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/AccessTokenCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/AccessTokenCredentials.scala
@@ -33,6 +33,11 @@ private[auth] object AccessTokenCredentials {
 private[auth] final case class AccessTokenCredentials(projectId: String, accessToken: String) extends Credentials
     with RetrievableCredentials {
 
+  override def toString: String =
+    "AccessTokenCredentials(" +
+    s"projectId=$projectId," +
+    s"accessToken=*****)"
+
   private val futureToken = Future.successful(OAuth2BearerToken(accessToken))
 
   override def get()(implicit ec: ExecutionContext, settings: RequestSettings): Future[OAuth2BearerToken] =

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
@@ -53,7 +53,13 @@ private[connectors] object ServiceAccountCredentials {
     apply(projectId, clientEmail, privateKey, scopes)
   }
 
-  final case class ServiceAccountCredentialsFile(project_id: String, client_email: String, private_key: String)
+  final case class ServiceAccountCredentialsFile(project_id: String, client_email: String, private_key: String) {
+    override def toString: String =
+      "ServiceAccountCredentialsFile(" +
+      s"project_id=$project_id," +
+      s"client_email=$client_email," +
+      s"private_key=*****)"
+  }
   implicit val serviceAccountCredentialsFormat: RootJsonFormat[ServiceAccountCredentialsFile] = jsonFormat3(
     ServiceAccountCredentialsFile.apply)
 }

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/UserAccessCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/UserAccessCredentials.scala
@@ -59,7 +59,14 @@ private[connectors] object UserAccessCredentials {
   final case class UserAccessCredentialsFile(client_id: String,
       client_secret: String,
       refresh_token: String,
-      quota_project_id: String)
+      quota_project_id: String) {
+    override def toString: String =
+      "UserAccessCredentialsFile(" +
+      s"client_id=$client_id," +
+      s"client_secret=*****," +
+      s"refresh_token=*****," +
+      s"quota_project_id=$quota_project_id)"
+  }
   implicit val userAccessCredentialsFormat: RootJsonFormat[UserAccessCredentialsFile] = jsonFormat4(
     UserAccessCredentialsFile.apply)
 }

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/HmsSettings.scala
@@ -143,6 +143,14 @@ final case class HmsSettings @InternalApi private (
     maxConcurrentConnections: Int,
     forwardProxy: Option[ForwardProxy]) {
 
+  override def toString: String =
+    "HmsSettings(" +
+    s"appId=$appId," +
+    s"appSecret=*****," +
+    s"test=$test," +
+    s"maxConcurrentConnections=$maxConcurrentConnections," +
+    s"forwardProxy=$forwardProxy)"
+
   def getAppId = appId
   def getAppSecret = appSecret
   def isTest = test
@@ -242,6 +250,11 @@ object ForwardProxyCredentials {
 }
 
 final case class ForwardProxyCredentials @InternalApi private (username: String, password: String) {
+
+  override def toString: String =
+    "ForwardProxyCredentials(" +
+    s"username=$username," +
+    s"password=*****)"
 
   def getUsername: String = username
   def getPassword: String = password

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/impl/HmsTokenApi.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/impl/HmsTokenApi.scala
@@ -72,6 +72,15 @@ private[pushkit] class HmsTokenApi(http: => HttpExt, system: ActorSystem, forwar
  */
 @InternalApi
 private[pushkit] object HmsTokenApi {
-  case class AccessTokenExpiry(accessToken: String, expiresAt: Long)
-  case class OAuthResponse(access_token: String, token_type: String, expires_in: Int)
+  case class AccessTokenExpiry(accessToken: String, expiresAt: Long) {
+    override def toString: String =
+      "AccessTokenExpiry(accessToken=*****," +
+      s"expiresAt=$expiresAt)"
+  }
+  case class OAuthResponse(access_token: String, token_type: String, expires_in: Int) {
+    override def toString: String =
+      "OAuthResponse(access_token=*****," +
+      s"token_type=$token_type," +
+      s"expires_in=$expires_in)"
+  }
 }

--- a/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/IronMqSettings.scala
+++ b/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/IronMqSettings.scala
@@ -57,7 +57,7 @@ final class IronMqSettings private (
     "IronMqSettings(" +
     s"endpoint=$endpoint," +
     s"projectId=$projectId," +
-    s"token=$token," +
+    s"token=*****," +
     s"consumerSettings=$consumerSettings" +
     ")"
 }

--- a/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Credentials.scala
+++ b/jakartams/src/main/scala/org/apache/pekko/stream/connectors/jakartams/Credentials.scala
@@ -31,7 +31,7 @@ final class Credentials private (
   override def toString =
     "Credentials(" +
     s"username=$username," +
-    s"password=${"*" * password.length}" +
+    s"password=*****" +
     ")"
 
   override def equals(other: Any): Boolean = other match {

--- a/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/Credentials.scala
+++ b/jms/src/main/scala/org/apache/pekko/stream/connectors/jms/Credentials.scala
@@ -31,7 +31,7 @@ final class Credentials private (
   override def toString =
     "Credentials(" +
     s"username=$username," +
-    s"password=${"*" * password.length}" +
+    s"password=*****" +
     ")"
 
   override def equals(other: Any): Boolean = other match {

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/model.scala
@@ -46,7 +46,7 @@ final class MFA private (val serialNumber: String, val tokenCode: String) {
   override def toString: String =
     "MFA(" +
     s"serialNumber=$serialNumber," +
-    s"tokenCode=$tokenCode" +
+    s"tokenCode=*****" +
     ")"
 
   override def equals(other: Any): Boolean = other match {


### PR DESCRIPTION
This commit updates 11 files across multiple connector modules to mask sensitive credentials and tokens when converting objects to their string representation. The change prevents accidental exposure of secrets (API keys, tokens, passwords) in logs or debug output.

Modules affected:
- AMQP — AmqpConnectionProvider
- Google (common) — AccessToken, AccessTokenCredentials, ServiceAccountCredentials, UserAccessCredentials
- Huawei Push Kit — HmsSettings, HmsTokenApi
- IronMQ — IronMqSettings
- Jakarta Messaging — Credentials
- JMS — Credentials
- AWS S3 — model

Each file had 1–13 lines added to replace sensitive field values with masked placeholders (e.g., "***") in toString methods.