### PR TITLE
kudu: change default encryptionPolicy to "REQUIRED_REMOTE"

### DIFF
--- a/kudu/src/main/resources/reference.conf
+++ b/kudu/src/main/resources/reference.conf
@@ -6,6 +6,8 @@ pekko.connectors.kudu {
   master-address = ""
   # options: OPTIONAL,REQUIRED_REMOTE,REQUIRED
   # reference to org.apache.kudu.client.AsyncKuduClient.EncryptionPolicy
-  encryptionPolicy = "OPTIONAL"
+  # REQUIRED_REMOTE enforces encryption for remote connections while allowing
+  # unencrypted connections to localhost (useful for local development/testing)
+  encryptionPolicy = "REQUIRED_REMOTE"
 
 }


### PR DESCRIPTION
Changed default from OPTIONAL to REQUIRED_REMOTE — enforces encryption for remote connections while allowing localhost unencrypted (useful for local dev/test).