### PR TITLE
googleCloudPubSubGrpc: filter out deprecated grpc classes that are not needed

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -279,11 +279,14 @@ lazy val googleCloudPubSubGrpc = pekkoConnectorProject(
   Compile / scalacOptions ++= Seq(
     "-Wconf:src=.+/pekko-grpc/main/.+:s",
     "-Wconf:src=.+/pekko-grpc/test/.+:s"),
+  // grpc/reflection/v1alpha/reflection.proto is marked `option deprecated = true` upstream and is
+  // superseded by grpc/reflection/v1, which is still generated. Nothing in this connector uses either,
+  // they are collateral from unpacking the google-cloud-pubsub protobuf-src artifact.
   PB.generate / excludeFilter := {
     val previousFilter = (PB.generate / excludeFilter).value
     new SimpleFileFilter(f =>
       previousFilter.accept(f) ||
-      (Common.isScala3Next.value && f.getAbsolutePath.replace('\\', '/').contains("grpc/reflection/v1alpha")))
+      f.getAbsolutePath.replace('\\', '/').contains("grpc/reflection/v1alpha"))
   },
   Compile / pekkoGrpcCodeGeneratorSettings ++= (
     if (Common.isScala3.value) Seq("scala3_sources") else Seq.empty

--- a/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.x.backwards.excludes/grpc-reflection-v1alpha.excludes
+++ b/google-cloud-pub-sub-grpc/src/main/mima-filters/2.0.x.backwards.excludes/grpc-reflection-v1alpha.excludes
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# grpc/reflection/v1alpha/reflection.proto is deprecated upstream (option deprecated = true) and is
+# no longer code generated; grpc/reflection/v1 remains. These classes were only ever collateral from
+# unpacking the google-cloud-pubsub protobuf-src artifact and are not used by this connector.
+ProblemFilters.exclude[MissingClassProblem]("io.grpc.reflection.v1alpha.*")


### PR DESCRIPTION
We already filter them out for Scala 3.8 builds but we can filter them out everywhere.
They are unused and lead to compile warnings.