### PR TITLE
unix-domain-socket: replace deprecated use of Source.queue

### DIFF
--- a/unix-domain-socket/src/main/scala/org/apache/pekko/stream/connectors/unixdomainsocket/impl/UnixDomainSocketImpl.scala
+++ b/unix-domain-socket/src/main/scala/org/apache/pekko/stream/connectors/unixdomainsocket/impl/UnixDomainSocketImpl.scala
@@ -245,7 +245,7 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
 
   private def acceptKey(
       localAddress: JnrUnixSocketAddress,
-      incomingConnectionQueue: SourceQueueWithComplete[IncomingConnection],
+      incomingConnectionQueue: BoundedSourceQueue[IncomingConnection],
       halfClose: Boolean,
       receiveBufferSize: Int,
       sendBufferSize: Int)(sel: Selector, key: SelectionKey)(implicit mat: Materializer, ec: ExecutionContext): Unit = {
@@ -262,12 +262,17 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
       try {
         acceptedChannel.register(sel, SelectionKey.OP_READ, context)
       } catch { case _: IOException => }
-      incomingConnectionQueue.offer(
+      val queued = incomingConnectionQueue.offer(
         IncomingConnection(
           localAddress = UnixSocketAddress(Paths.get(localAddress.path())),
           remoteAddress = UnixSocketAddress(
             Paths.get(Option(acceptingChannel.getRemoteSocketAddress).getOrElse(new JnrUnixSocketAddress("")).path())),
           flow = connectionFlow))
+      if (queued != QueueOfferResult.Enqueued) {
+        // the connection could not be handed to the stream - close it rather than leaving it dangling
+        try acceptedChannel.close()
+        catch { case _: IOException => }
+      }
     }
   }
 
@@ -394,9 +399,10 @@ private[unixdomainsocket] abstract class UnixDomainSocketImpl(system: ExtendedAc
       halfClose: Boolean = false): Source[IncomingConnection, Future[ServerBinding]] = {
 
     val bind: () => Source[IncomingConnection, Future[ServerBinding]] = { () =>
-      val (incomingConnectionQueue, incomingConnectionSource) =
+      val ((incomingConnectionQueue, incomingConnectionTermination), incomingConnectionSource) =
         Source
-          .queue[IncomingConnection](2, OverflowStrategy.backpressure)
+          .queue[IncomingConnection](backlog)
+          .watchTermination(Keep.both)
           .prefixAndTail(0)
           .map {
             case (_, source) =>
@@ -433,21 +439,21 @@ private[unixdomainsocket] abstract class UnixDomainSocketImpl(system: ExtendedAc
           ServerBinding(UnixSocketAddress(Paths.get(address.path))) { () =>
             registeredKey.cancel()
             channel.close()
-            incomingConnectionQueue.complete()
-            incomingConnectionQueue.watchCompletion().map(_ => ())
+            if (!incomingConnectionQueue.isCompleted) incomingConnectionQueue.complete()
+            incomingConnectionTermination.map(_ => ())
           })
       } catch {
         case e: IOException =>
           val withAddress = new IOException(e.getMessage + s" ($address)", e)
           registeredKey.cancel()
           channel.close()
-          incomingConnectionQueue.fail(withAddress)
+          if (!incomingConnectionQueue.isCompleted) incomingConnectionQueue.fail(withAddress)
           serverBinding.failure(withAddress)
 
         case NonFatal(e) =>
           registeredKey.cancel()
           channel.close()
-          incomingConnectionQueue.fail(e)
+          if (!incomingConnectionQueue.isCompleted) incomingConnectionQueue.fail(e)
           serverBinding.failure(e)
       }
 

--- a/unix-domain-socket/src/main/scala/org/apache/pekko/stream/connectors/unixdomainsocket/impl/UnixDomainSocketImpl.scala
+++ b/unix-domain-socket/src/main/scala/org/apache/pekko/stream/connectors/unixdomainsocket/impl/UnixDomainSocketImpl.scala
@@ -15,7 +15,16 @@ package org.apache.pekko.stream.connectors.unixdomainsocket
 package impl
 
 import org.apache.pekko
-import pekko.actor.{ Cancellable, CoordinatedShutdown, ExtendedActorSystem, Extension }
+import pekko.actor.{
+  Actor,
+  ActorRef,
+  Cancellable,
+  CoordinatedShutdown,
+  ExtendedActorSystem,
+  Extension,
+  PoisonPill,
+  Props
+}
 import pekko.annotation.InternalApi
 import pekko.event.{ Logging, LoggingAdapter }
 import pekko.stream._
@@ -24,7 +33,7 @@ import pekko.stream.connectors.unixdomainsocket.scaladsl.UnixDomainSocket.{
   OutgoingConnection,
   ServerBinding
 }
-import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source, SourceQueueWithComplete }
+import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
 import pekko.util.ByteString
 import pekko.{ Done, NotUsed }
 import jnr.enxio.channels.NativeSelectorProvider
@@ -34,6 +43,7 @@ import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.channels.{ SelectionKey, Selector }
 import java.nio.file.{ Files, Path, Paths }
+import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NonFatal
@@ -46,15 +56,83 @@ import scala.util.{ Failure, Success, Try }
 private[unixdomainsocket] object UnixDomainSocketImpl {
 
   private sealed abstract class ReceiveContext(
-      val queue: SourceQueueWithComplete[ByteString],
+      val queue: ReceiveQueue,
       val buffer: ByteBuffer)
   private case class ReceiveAvailable(
-      override val queue: SourceQueueWithComplete[ByteString],
+      override val queue: ReceiveQueue,
       override val buffer: ByteBuffer) extends ReceiveContext(queue, buffer)
   private case class PendingReceiveAck(
-      override val queue: SourceQueueWithComplete[ByteString],
+      override val queue: ReceiveQueue,
       override val buffer: ByteBuffer,
-      pendingResult: Future[QueueOfferResult]) extends ReceiveContext(queue, buffer)
+      pendingResult: Future[Done]) extends ReceiveContext(queue, buffer)
+
+  private case object ReceiveAck
+  private case object ReceiveComplete
+
+  private val receiveAckActorCounter = new AtomicLong()
+
+  /**
+   * Receives the acknowledgements of [[Source.actorRefWithBackpressure]] on behalf of the io thread. The
+   * acknowledgement is only sent once the read-side stream has taken the element, so completing `pendingAck`
+   * is what tells the io thread that it may read from the socket again.
+   */
+  private final class ReceiveAckActor(pendingAck: AtomicReference[Promise[Done]], sel: Selector) extends Actor {
+    override def receive: Receive = {
+      case _ =>
+        val ack = pendingAck.getAndSet(null)
+        if (ack ne null) ack.trySuccess(Done)
+        sel.wakeup()
+    }
+  }
+
+  /**
+   * Hands bytes read from the socket to the read-side stream, one element at a time. `offer` must not be
+   * called again until the returned future has completed - the io thread enforces this by clearing
+   * `OP_READ` until then.
+   */
+  private final class ReceiveQueue(
+      ref: ActorRef,
+      ackReceiver: ActorRef,
+      pendingAck: AtomicReference[Promise[Done]],
+      val completion: Future[Done]) {
+
+    def offer(bytes: ByteString): Future[Done] = {
+      val ack = Promise[Done]()
+      pendingAck.set(ack)
+      ref.tell(bytes, ackReceiver)
+      ack.future
+    }
+
+    def complete(): Unit = ref.tell(ReceiveComplete, ackReceiver)
+  }
+
+  private def receiveStructures(sel: Selector, system: ExtendedActorSystem)(
+      implicit mat: Materializer,
+      ec: ExecutionContext): (ReceiveQueue, Source[ByteString, NotUsed]) = {
+    val pendingAck = new AtomicReference[Promise[Done]]()
+    val ackReceiver = system.systemActorOf(
+      Props(new ReceiveAckActor(pendingAck, sel)),
+      s"unix-domain-socket-receive-ack-${receiveAckActorCounter.incrementAndGet()}")
+
+    val ((ref, completion), receiveSource) =
+      Source
+        .actorRefWithBackpressure[ByteString](
+          ReceiveAck,
+          { case ReceiveComplete => CompletionStrategy.draining },
+          PartialFunction.empty)
+        .watchTermination(Keep.both)
+        .preMaterialize()
+
+    completion.onComplete { _ =>
+      // no further acknowledgement can arrive, so release the io thread rather than leaving OP_READ cleared
+      val outstanding = pendingAck.getAndSet(null)
+      if (outstanding ne null) outstanding.tryFailure(new IOException("Read-side stream terminated"))
+      ackReceiver ! PoisonPill
+      sel.wakeup()
+    }
+
+    (new ReceiveQueue(ref, ackReceiver, pendingAck, completion), receiveSource)
+  }
 
   private sealed abstract class SendContext(
       val buffer: ByteBuffer)
@@ -200,7 +278,7 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
                       queue.complete()
                       try {
                         if (!sendReceiveContext.halfClose || sendReceiveContext.isOutputShutdown) {
-                          queue.watchCompletion().onComplete { _ =>
+                          queue.completion.onComplete { _ =>
                             log.debug("Read-side is shutting down")
                             key.cancel()
                             try {
@@ -220,7 +298,7 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
                   case _: ReceiveAvailable                                                                        =>
                   case PendingReceiveAck(receiveQueue, receiveBuffer, pendingResult) if pendingResult.isCompleted =>
                     pendingResult.value.get match {
-                      case Success(QueueOfferResult.Enqueued) =>
+                      case Success(_) =>
                         key.interestOps(key.interestOps() | SelectionKey.OP_READ)
                         sendReceiveContext.receive = ReceiveAvailable(receiveQueue, receiveBuffer)
                       case e =>
@@ -245,6 +323,7 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
 
   private def acceptKey(
       localAddress: JnrUnixSocketAddress,
+      system: ExtendedActorSystem,
       incomingConnectionQueue: BoundedSourceQueue[IncomingConnection],
       halfClose: Boolean,
       receiveBufferSize: Int,
@@ -258,7 +337,7 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
 
     if (acceptedChannel != null) {
       acceptedChannel.configureBlocking(false)
-      val (context, connectionFlow) = sendReceiveStructures(sel, receiveBufferSize, sendBufferSize, halfClose)
+      val (context, connectionFlow) = sendReceiveStructures(sel, system, receiveBufferSize, sendBufferSize, halfClose)
       try {
         acceptedChannel.register(sel, SelectionKey.OP_READ, context)
       } catch { case _: IOException => }
@@ -297,17 +376,16 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
     }
   }
 
-  private def sendReceiveStructures(sel: Selector, receiveBufferSize: Int, sendBufferSize: Int, halfClose: Boolean)(
+  private def sendReceiveStructures(
+      sel: Selector,
+      system: ExtendedActorSystem,
+      receiveBufferSize: Int,
+      sendBufferSize: Int,
+      halfClose: Boolean)(
       implicit mat: Materializer,
       ec: ExecutionContext): (SendReceiveContext, Flow[ByteString, ByteString, NotUsed]) = {
 
-    val (receiveQueue, receiveSource) =
-      Source
-        .queue[ByteString](2, OverflowStrategy.backpressure)
-        .prefixAndTail(0)
-        .map(_._2)
-        .toMat(Sink.head)(Keep.both)
-        .run()
+    val (receiveQueue, receiveSource) = receiveStructures(sel, system)
     val sendReceiveContext =
       new SendReceiveContext(
         SendAvailable(ByteBuffer.allocate(sendBufferSize)),
@@ -360,7 +438,7 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
         }
         .to(Sink.ignore))
 
-    (sendReceiveContext, Flow.fromSinkAndSource(sendSink, Source.futureSource(receiveSource)))
+    (sendReceiveContext, Flow.fromSinkAndSource(sendSink, receiveSource))
   }
 }
 
@@ -431,7 +509,7 @@ private[unixdomainsocket] abstract class UnixDomainSocketImpl(system: ExtendedAc
       val registeredKey =
         channel.register(sel,
           SelectionKey.OP_ACCEPT,
-          acceptKey(address, incomingConnectionQueue, halfClose, receiveBufferSize, sendBufferSize) _)
+          acceptKey(address, system, incomingConnectionQueue, halfClose, receiveBufferSize, sendBufferSize) _)
       try {
         channel.socket().bind(address, backlog)
         sel.wakeup()
@@ -481,7 +559,7 @@ private[unixdomainsocket] abstract class UnixDomainSocketImpl(system: ExtendedAc
           case d: FiniteDuration => Some(system.scheduler.scheduleOnce(d, () => channel.close()))
           case _                 => None
         }
-      val (context, connectionFlow) = sendReceiveStructures(sel, receiveBufferSize, sendBufferSize, halfClose)
+      val (context, connectionFlow) = sendReceiveStructures(sel, system, receiveBufferSize, sendBufferSize, halfClose)
       val ra = new JnrUnixSocketAddress(remoteAddress.path.toFile)
       val log = system.log
       val registeredKey =

--- a/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
@@ -20,6 +20,8 @@ import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.stream.connectors.unixdomainsocket.UnixSocketAddress
 import pekko.stream.connectors.unixdomainsocket.scaladsl.UnixDomainSocket
 import pekko.stream.scaladsl.{ Flow, Keep, Sink, Source }
+import pekko.stream.testkit.TestSubscriber
+import pekko.stream.testkit.scaladsl.TestSink
 import pekko.stream.{ Materializer, OverflowStrategy }
 import pekko.testkit._
 import pekko.util.ByteString
@@ -100,6 +102,52 @@ class UnixDomainSocketSpec
 
         }
       result.futureValue shouldBe sendBytes
+      binding.futureValue.unbind().futureValue should be(())
+    }
+
+    "not deliver received bytes before the consumer asks for them, and resume reading afterwards" in {
+      val path = dir.resolve("sock-backpressure")
+
+      val serverProbe = Promise[TestSubscriber.Probe[ByteString]]()
+
+      // Source.maybe keeps the server side of the connection open, the probe gives us manual demand
+      val binding: Future[UnixDomainSocket.ServerBinding] =
+        UnixDomainSocket()
+          .bind(path)
+          .map { connection =>
+            serverProbe.trySuccess(connection.flow.runWith(Source.maybe[ByteString], TestSink[ByteString]())._2)
+            ()
+          }
+          .to(Sink.ignore)
+          .run()
+
+      binding.futureValue
+
+      // enough separate writes to outlast the stream buffers between the socket and the consumer,
+      // so the connector really has to stop reading and resume, but far short of filling a socket buffer
+      val chunks = (1 to 50).map(i => ByteString(f"chunk-$i%03d-" + "x" * 90)).toList
+      val expected = chunks.reduce(_ ++ _)
+
+      Source(chunks)
+        .throttle(5, 10.millis)
+        .via(UnixDomainSocket().outgoingConnection(path))
+        .runWith(Sink.ignore)
+
+      val server = serverProbe.future.futureValue
+      server.ensureSubscription()
+
+      // the writes have been made, but nothing may be emitted while the consumer has no demand
+      server.expectNoMessage(300.millis)
+
+      // once demand arrives everything that was written is delivered, in order and without loss,
+      // which also means reading from the socket resumed as elements were acknowledged
+      @annotation.tailrec
+      def receiveAtLeast(received: ByteString): ByteString =
+        if (received.size >= expected.size) received else receiveAtLeast(received ++ server.requestNext())
+
+      receiveAtLeast(ByteString.empty) shouldBe expected
+
+      server.cancel()
       binding.futureValue.unbind().futureValue should be(())
     }
 


### PR DESCRIPTION
UnixDomainSocketImpl has no deprecated Source.queue usage left, and SourceQueueWithComplete is gone from the file entirely.

Receive side → Source.actorRefWithBackpressure. The ack protocol maps exactly onto the existing OP_READ gating: pekko sends the ack only after push(out, e), i.e. once the stream has actually taken the element — the same guarantee QueueOfferResult.Enqueued gave. The io thread's state machine is untouched in shape:

- ReceiveQueue.offer(bytes) sets a Promise[Done], then ref.tell(bytes, ackReceiver), returning the future the loop already polls via pendingResult.isCompleted.
- A per-connection ReceiveAckActor receives the ack, completes that promise, and calls sel.wakeup() — the same wake-up the old pendingResult.onComplete did. The actor only completes a promise; the io thread remains the sole mutator of context.receive, preserving the existing threading discipline.
- complete() sends ReceiveComplete, matched by the completion matcher as CompletionStrategy.draining. I checked ActorRefBackpressureSource: the completion matcher is tested before the element branch, so the send-side's receiveQueue.complete() is safe even while an ack is outstanding.
- queue.watchCompletion() → a watchTermination(Keep.both) future carried on ReceiveQueue.completion.
- Source.futureSource(...) and the prefixAndTail(0)/Sink.head pre-materialisation trick are replaced by preMaterialize().

One failure mode the old code got for free needed explicit handling: if the read-side stream terminates (downstream cancels), no ack will ever arrive, so the io thread would sit forever with OP_READ cleared. The termination hook now fails any outstanding ack promise, which drives the loop's existing shutdown branch, stops the ack actor, and wakes the selector.

Verified: unix-domain-socket/test — 6 passed, 1 ignored, Java test passes; MiMa clean (the class is under impl, covered by the *.impl.* filter); scalafmt applied and clean.