### PR TITLE
Google/Huawei: apply min TLS version to the SSLEngine

### DIFF
--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContext.scala
@@ -20,7 +20,7 @@ import pekko.http.scaladsl.{ ConnectionContext, HttpsConnectionContext }
 import java.io.FileInputStream
 import java.security.KeyStore
 import java.security.cert.{ CertificateFactory, X509Certificate }
-import javax.net.ssl.{ SSLContext, TrustManagerFactory }
+import javax.net.ssl.{ SSLContext, SSLEngine, TrustManagerFactory }
 
 @InternalApi
 private[google] object ForwardProxyHttpsContext {
@@ -30,6 +30,10 @@ private[google] object ForwardProxyHttpsContext {
     "TLSv1.3" -> Array("TLSv1.3"))
 
   def apply(trustPemPath: String, minTlsVersion: String = "TLSv1.2"): HttpsConnectionContext = {
+    val protocols = TlsVersions.getOrElse(minTlsVersion,
+      throw new IllegalArgumentException(
+        s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
+
     val certificate = x509Certificate(trustPemPath: String)
     val sslContext = SSLContext.getInstance("TLS")
 
@@ -42,11 +46,25 @@ private[google] object ForwardProxyHttpsContext {
     tmf.init(trustStore)
     val trustManagers = tmf.getTrustManagers
     sslContext.init(null, trustManagers, null)
-    val protocols = TlsVersions.getOrElse(minTlsVersion,
-      throw new IllegalArgumentException(
-        s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
-    sslContext.getDefaultSSLParameters.setProtocols(protocols)
-    ConnectionContext.httpsClient(sslContext)
+
+    // The enabled protocols have to be set on each SSLEngine. Setting them on the
+    // SSLParameters returned by SSLContext.getDefaultSSLParameters has no effect,
+    // because that method returns a fresh copy on every call.
+    ConnectionContext.httpsClient(createSSLEngine(sslContext, protocols, _, _))
+  }
+
+  private[http] def createSSLEngine(sslContext: SSLContext,
+      protocols: Array[String],
+      host: String,
+      port: Int): SSLEngine = {
+    val engine = sslContext.createSSLEngine(host, port)
+    engine.setUseClientMode(true)
+    val params = engine.getSSLParameters
+    params.setProtocols(protocols)
+    // retain the hostname verification that ConnectionContext.httpsClient(SSLContext) sets up
+    params.setEndpointIdentificationAlgorithm("https")
+    engine.setSSLParameters(params)
+    engine
   }
 
   private def x509Certificate(trustPemPath: String): X509Certificate = {

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContextSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/http/ForwardProxyHttpsContextSpec.scala
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.google.http
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import javax.net.ssl.SSLContext
+
+class ForwardProxyHttpsContextSpec extends AnyWordSpec with Matchers {
+
+  private def sslContext(): SSLContext = {
+    val ctx = SSLContext.getInstance("TLS")
+    ctx.init(null, null, null)
+    ctx
+  }
+
+  "ForwardProxyHttpsContext.createSSLEngine" should {
+
+    "enable only the requested protocols" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.3"), "example.com", 443)
+      engine.getEnabledProtocols.toSeq shouldBe Seq("TLSv1.3")
+    }
+
+    "enable TLSv1.2 and TLSv1.3 when TLSv1.2 is the minimum" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getEnabledProtocols.toSet shouldBe Set("TLSv1.2", "TLSv1.3")
+    }
+
+    "never enable protocols older than TLSv1.2" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getEnabledProtocols should contain noneOf ("SSLv3", "TLSv1", "TLSv1.1")
+    }
+
+    "use client mode" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getUseClientMode shouldBe true
+    }
+
+    "retain https endpoint identification so hostname verification stays enabled" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getSSLParameters.getEndpointIdentificationAlgorithm shouldBe "https"
+    }
+  }
+
+  "ForwardProxyHttpsContext.apply" should {
+
+    "reject an unsupported TLS version" in {
+      val ex = the[IllegalArgumentException] thrownBy {
+        ForwardProxyHttpsContext(getClass.getResource("/cert.pem").getPath, "TLSv1.1")
+      }
+      ex.getMessage should include("TLSv1.1")
+    }
+
+    "build a connection context for a supported TLS version" in {
+      ForwardProxyHttpsContext(getClass.getResource("/cert.pem").getPath, "TLSv1.3") should not be null
+    }
+  }
+}

--- a/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
+++ b/huawei-push-kit/src/main/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContext.scala
@@ -21,7 +21,7 @@ import pekko.http.scaladsl.{ ConnectionContext, Http, HttpsConnectionContext }
 import java.io.FileInputStream
 import java.security.KeyStore
 import java.security.cert.{ CertificateFactory, X509Certificate }
-import javax.net.ssl.{ SSLContext, TrustManagerFactory }
+import javax.net.ssl.{ SSLContext, SSLEngine, TrustManagerFactory }
 
 /**
  * INTERNAL API
@@ -46,6 +46,10 @@ private[pushkit] object ForwardProxyHttpsContext {
   }
 
   private def createHttpsContext(trustPem: ForwardProxyTrustPem, minTlsVersion: String) = {
+    val protocols = TlsVersions.getOrElse(minTlsVersion,
+      throw new IllegalArgumentException(
+        s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
+
     val certificate = x509Certificate(trustPem)
     val sslContext = SSLContext.getInstance("TLS")
 
@@ -58,11 +62,25 @@ private[pushkit] object ForwardProxyHttpsContext {
     tmf.init(trustStore)
     val trustManagers = tmf.getTrustManagers
     sslContext.init(null, trustManagers, null)
-    val protocols = TlsVersions.getOrElse(minTlsVersion,
-      throw new IllegalArgumentException(
-        s"Unsupported TLS version: $minTlsVersion. Minimum supported is TLSv1.2. Valid values: ${TlsVersions.keys.mkString(", ")}"))
-    sslContext.getDefaultSSLParameters.setProtocols(protocols)
-    ConnectionContext.httpsClient(sslContext)
+
+    // The enabled protocols have to be set on each SSLEngine. Setting them on the
+    // SSLParameters returned by SSLContext.getDefaultSSLParameters has no effect,
+    // because that method returns a fresh copy on every call.
+    ConnectionContext.httpsClient(createSSLEngine(sslContext, protocols, _, _))
+  }
+
+  private[pushkit] def createSSLEngine(sslContext: SSLContext,
+      protocols: Array[String],
+      host: String,
+      port: Int): SSLEngine = {
+    val engine = sslContext.createSSLEngine(host, port)
+    engine.setUseClientMode(true)
+    val params = engine.getSSLParameters
+    params.setProtocols(protocols)
+    // retain the hostname verification that ConnectionContext.httpsClient(SSLContext) sets up
+    params.setEndpointIdentificationAlgorithm("https")
+    engine.setSSLParameters(params)
+    engine
   }
 
   private def x509Certificate(trustPem: ForwardProxyTrustPem) = {

--- a/huawei-push-kit/src/test/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContextSpec.scala
+++ b/huawei-push-kit/src/test/scala/org/apache/pekko/stream/connectors/huawei/pushkit/ForwardProxyHttpsContextSpec.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.huawei.pushkit
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import javax.net.ssl.SSLContext
+
+class ForwardProxyHttpsContextSpec extends AnyWordSpec with Matchers {
+
+  private def sslContext(): SSLContext = {
+    val ctx = SSLContext.getInstance("TLS")
+    ctx.init(null, null, null)
+    ctx
+  }
+
+  "ForwardProxyHttpsContext.createSSLEngine" should {
+
+    "enable only the requested protocols" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.3"), "example.com", 443)
+      engine.getEnabledProtocols.toSeq shouldBe Seq("TLSv1.3")
+    }
+
+    "enable TLSv1.2 and TLSv1.3 when TLSv1.2 is the minimum" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getEnabledProtocols.toSet shouldBe Set("TLSv1.2", "TLSv1.3")
+    }
+
+    "never enable protocols older than TLSv1.2" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getEnabledProtocols should contain noneOf ("SSLv3", "TLSv1", "TLSv1.1")
+    }
+
+    "use client mode" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getUseClientMode shouldBe true
+    }
+
+    "retain https endpoint identification so hostname verification stays enabled" in {
+      val engine =
+        ForwardProxyHttpsContext.createSSLEngine(sslContext(), Array("TLSv1.2", "TLSv1.3"), "example.com", 443)
+      engine.getSSLParameters.getEndpointIdentificationAlgorithm shouldBe "https"
+    }
+  }
+}


### PR DESCRIPTION
**Motivation:**

The `min-tls-version` setting added in #1808 has no effect. Both forward proxy HTTPS contexts configure the enabled protocols via:

```scala
sslContext.getDefaultSSLParameters.setProtocols(protocols)
```

`SSLContext.getDefaultSSLParameters()` returns a fresh defensive copy on every call, so mutating it is discarded. Connections are negotiated with the JDK defaults regardless of the configured value, meaning `min-tls-version = "TLSv1.3"` is silently ignored and TLSv1.2 remains enabled.

Demonstrated on JDK 17:

```
before: [TLSv1.3, TLSv1.2]
after : [TLSv1.3, TLSv1.2]     <- setProtocols(["TLSv1.3"]) had no effect
```

**Modification:**

Build the `HttpsConnectionContext` from a client `SSLEngine` factory instead of from the `SSLContext`, and set the protocols on each engine's own `SSLParameters`.

`ConnectionContext.httpsClient(SSLContext)` sets the `"https"` endpoint identification algorithm internally; taking the engine-factory overload bypasses that, so it is set explicitly to keep hostname verification enabled.

The `minTlsVersion` lookup is moved ahead of the certificate load, so an invalid value fails before any file IO.

**Result:**

`min-tls-version` is honoured. With the default `TLSv1.2` the enabled set is `TLSv1.2, TLSv1.3`; with `TLSv1.3` only `TLSv1.3` is enabled. Hostname verification is unchanged.

**Tests:**

Added `ForwardProxyHttpsContextSpec` to `google-common` and `huawei-push-kit`, asserting the engine's enabled protocols, client mode and endpoint identification algorithm (12 tests, all passing).

Verified the protocol assertion fails against the previous `getDefaultSSLParameters` implementation and passes with this change, so the test genuinely covers the regression.

Ran `google-common/mimaReportBinaryIssues` and `huawei-push-kit/mimaReportBinaryIssues` (both clean) and `scalafmtCheckAll`.

**References:**

Follow-up to #1808. The JDK javadoc for `SSLContext.getDefaultSSLParameters` specifies that the returned parameters are a copy.