### PR TITLE
Google Cloud Pub/Sub gRPC: subscribe() must not echo initial-only StreamingPullRequest fields on keepalive ticks (#1625)

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: "Code style, compile tests, MiMa. Run locally with: sbt \"javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues\""
         run: sbt "javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues"
@@ -80,7 +80,7 @@ jobs:
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: "Create all API docs and create site with Paradox"
         run: sbt docs/makeSite
@@ -168,7 +168,7 @@ jobs:
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: ${{ matrix.connector }}
         env:

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -45,10 +45,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: "Code style, compile tests, MiMa. Run locally with: sbt \"javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues\""
         run: sbt "javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues"
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -77,10 +77,10 @@ jobs:
           java-version: 11
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: "Create all API docs and create site with Paradox"
         run: sbt docs/makeSite
@@ -153,7 +153,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -165,10 +165,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: ${{ matrix.connector }}
         env:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'apache/pekko-connectors'    
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7.0.1
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18      
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
       - uses: scalacenter/sbt-dependency-submission@f43202114d7522a4b233e052f82c2eea8d658134 # v3.2.1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -43,7 +43,7 @@ jobs:
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: Check headers
         run: |-

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -40,10 +40,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: Check headers
         run: |-

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'apache/pekko-connectors'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -31,10 +31,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: Setup Coursier
         uses: coursier/setup-action@7acb5c9ea69bc1a1bb185ec45ebce2ac114f3628 # v2.0.3

--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -49,10 +49,10 @@ jobs:
           java-version: ${{ matrix.JDK }}
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: "compile, including  tests. Run locally with: sbt +Test/compile"
         run: sbt +Test/compile
@@ -63,7 +63,7 @@ jobs:
     if: github.repository == 'apache/pekko-connectors'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -74,10 +74,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: S3 Integration tests
         run:  |-

--- a/.github/workflows/nightly-pekko-1.0-builds.yaml
+++ b/.github/workflows/nightly-pekko-1.0-builds.yaml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -55,10 +55,10 @@ jobs:
           java-version: ${{ matrix.JDK }}
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: "compile, including  tests. Run locally with: sbt -Dpekko.build.pekko.version=1.0.x -Dpekko.build.pekko.http.version=1.0.x +Test/compile"
         run: sbt -Dpekko.build.pekko.version=1.0.x -Dpekko.build.pekko.http.version=1.0.x +Test/compile

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -30,7 +30,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Build Documentation
         run: |-

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -30,7 +30,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Build Documentation
         run: |-

--- a/.github/workflows/publish-1.3-docs.yml
+++ b/.github/workflows/publish-1.3-docs.yml
@@ -30,7 +30,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@6bec67c98f542b9e17369bfca0ec822ac1363194 # v1.1.19
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Build Documentation
         run: |-

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -36,7 +36,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Publish to Apache Maven repo
         env:

--- a/.github/workflows/stage-release-candidate.yml
+++ b/.github/workflows/stage-release-candidate.yml
@@ -66,7 +66,7 @@ jobs:
           REF: ${{ github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.1
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -141,7 +141,7 @@ jobs:
           REF: ${{ github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.1
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -199,7 +199,7 @@ jobs:
           REF: ${{ github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.1
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -212,7 +212,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@6bec67c98f542b9e17369bfca0ec822ac1363194 # v1.1.19
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Install Graphviz
         run: |-

--- a/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/javadsl/GooglePubSub.scala
@@ -56,10 +56,13 @@ object GooglePubSub {
       .fromMaterializer { (mat, attr) =>
         val cancellable = new CompletableFuture[Cancellable]()
 
-        val subsequentRequest = request.toBuilder
-          .setSubscription("")
-          .setStreamAckDeadlineSeconds(0)
-          .build()
+        // Don't echo initial-only fields on keepalive requests. Pub/Sub allows only
+        // ackIds, modifyDeadlineSeconds, and modifyDeadlineAckIds on subsequent
+        // StreamingPullRequests; anything else from the initial request (subscription,
+        // streamAckDeadlineSeconds, clientId, maxOutstandingMessages, maxOutstandingBytes)
+        // gets back INVALID_ARGUMENT. defaultInstance clears them all at once and stays
+        // safe if the proto grows more initial-only fields.
+        val subsequentRequest = StreamingPullRequest.getDefaultInstance
 
         subscriber(mat, attr).client
           .streamingPull(

--- a/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/scaladsl/GooglePubSub.scala
@@ -58,9 +58,13 @@ object GooglePubSub {
       .fromMaterializer { (mat, attr) =>
         val cancellable = Promise[Cancellable]()
 
-        val subsequentRequest = request
-          .withSubscription("")
-          .withStreamAckDeadlineSeconds(0)
+        // Don't echo initial-only fields on keepalive requests. Pub/Sub allows only
+        // ackIds, modifyDeadlineSeconds, and modifyDeadlineAckIds on subsequent
+        // StreamingPullRequests; anything else from the initial request (subscription,
+        // streamAckDeadlineSeconds, clientId, maxOutstandingMessages, maxOutstandingBytes)
+        // gets back INVALID_ARGUMENT. defaultInstance clears them all at once and stays
+        // safe if the proto grows more initial-only fields.
+        val subsequentRequest = StreamingPullRequest.defaultInstance
 
         subscriber(mat, attr).client
           .streamingPull(
@@ -68,8 +72,7 @@ object GooglePubSub {
               .single(request)
               .concat(
                 Source
-                  .tick(0.seconds, pollInterval, ())
-                  .map(_ => subsequentRequest)
+                  .tick(0.seconds, pollInterval, subsequentRequest)
                   .mapMaterializedValue(cancellable.success)))
           .mapConcat(_.receivedMessages.toVector)
           .mapMaterializedValue(_ => cancellable.future)

--- a/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/scaladsl/GrpcSubscriber.scala
+++ b/google-cloud-pub-sub-grpc/src/main/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/scaladsl/GrpcSubscriber.scala
@@ -31,28 +31,24 @@ import com.google.pubsub.v1.pubsub.{ SubscriberClient => ScalaSubscriberClient }
 /**
  * Holds the gRPC scala subscriber client instance.
  */
-final class GrpcSubscriber private (settings: PubSubSettings, googleSettings: GoogleSettings, sys: ActorSystem) {
-
-  @ApiMayChange
-  final val client =
-    ScalaSubscriberClient(PekkoGrpcSettings.fromPubSubSettings(settings, googleSettings)(sys))(sys)
-
-  sys.registerOnTermination(client.close())
-}
+final class GrpcSubscriber private[grpc] (@ApiMayChange final val client: ScalaSubscriberClient)
 
 object GrpcSubscriber {
   def apply(settings: PubSubSettings,
       googleSettings: GoogleSettings)(implicit sys: ClassicActorSystemProvider): GrpcSubscriber =
-    new GrpcSubscriber(settings, googleSettings, sys.classicSystem)
+    apply(settings, googleSettings, sys.classicSystem)
 
-  def apply(settings: PubSubSettings, googleSettings: GoogleSettings, sys: ActorSystem): GrpcSubscriber =
-    new GrpcSubscriber(settings, googleSettings, sys)
+  def apply(settings: PubSubSettings, googleSettings: GoogleSettings, sys: ActorSystem): GrpcSubscriber = {
+    val c = ScalaSubscriberClient(PekkoGrpcSettings.fromPubSubSettings(settings, googleSettings)(sys))(sys)
+    sys.registerOnTermination(c.close())
+    new GrpcSubscriber(c)
+  }
 
   def apply(settings: PubSubSettings)(implicit sys: ClassicActorSystemProvider): GrpcSubscriber =
-    new GrpcSubscriber(settings, GoogleSettings(), sys.classicSystem)
+    apply(settings, GoogleSettings())
 
   def apply(settings: PubSubSettings, sys: ActorSystem): GrpcSubscriber =
-    new GrpcSubscriber(settings, GoogleSettings(sys), sys)
+    apply(settings, GoogleSettings(sys), sys)
 
   def apply()(implicit sys: ClassicActorSystemProvider): GrpcSubscriber =
     apply(PubSubSettings(sys))

--- a/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/SubscribeRequestFieldsSpec.scala
+++ b/google-cloud-pub-sub-grpc/src/test/scala/org/apache/pekko/stream/connectors/googlecloud/pubsub/grpc/SubscribeRequestFieldsSpec.scala
@@ -1,0 +1,154 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.googlecloud.pubsub.grpc
+
+import org.apache.pekko
+import pekko.{ Done, NotUsed }
+import pekko.actor.ActorSystem
+import pekko.stream.Materializer
+import pekko.stream.scaladsl.{ Keep, Sink, Source }
+import pekko.stream.connectors.googlecloud.pubsub.grpc.scaladsl.{ GooglePubSub, GrpcSubscriber, PubSubAttributes }
+import com.google.pubsub.v1.pubsub._
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.concurrent.{ Future, Promise }
+import scala.concurrent.duration._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.{ Eventually, ScalaFutures }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.{ Millis, Seconds, Span }
+import org.scalatest.wordspec.AnyWordSpec
+
+class SubscribeRequestFieldsSpec
+    extends AnyWordSpec
+    with Matchers
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with Eventually {
+
+  implicit val system: ActorSystem = ActorSystem("SubscribeRequestFieldsSpec")
+  implicit val patience: PatienceConfig = PatienceConfig(10.seconds, 100.millis)
+
+  val subscription = "projects/test/subscriptions/test-sub"
+
+  "GooglePubSub.subscribe" should {
+    "send only allowed fields on subsequent StreamingPullRequest messages" in {
+      // Regression test: the keepalive tick must NOT echo initial-only fields
+      // (clientId, maxOutstandingMessages, maxOutstandingBytes) back to the server,
+      // which would otherwise return INVALID_ARGUMENT on the first tick.
+      val captured = new ConcurrentLinkedQueue[StreamingPullRequest]()
+      val testSubscriber = new GrpcSubscriber(new CapturingStreamingPullClient(captured)(system))
+
+      val initial = StreamingPullRequest()
+        .withSubscription(subscription)
+        .withStreamAckDeadlineSeconds(60)
+        .withClientId("test-client")
+        .withMaxOutstandingMessages(100L)
+        .withMaxOutstandingBytes(10485760L)
+
+      val cancellableFut = GooglePubSub
+        .subscribe(initial, 100.millis)
+        .withAttributes(PubSubAttributes.subscriber(testSubscriber))
+        .toMat(Sink.ignore)(Keep.left)
+        .run()
+
+      // Wait until the initial request plus at least 2 keepalive ticks have landed,
+      // then cancel.
+      eventually(timeout(Span(5, Seconds)), interval(Span(50, Millis))) {
+        captured.size should be >= 3
+      }
+      cancellableFut.futureValue.cancel()
+
+      val first = captured.poll()
+      first should not be null
+      withClue("initial request must carry caller-supplied fields verbatim: ") {
+        first.subscription shouldBe subscription
+        first.streamAckDeadlineSeconds shouldBe 60
+        first.clientId shouldBe "test-client"
+        first.maxOutstandingMessages shouldBe 100L
+        first.maxOutstandingBytes shouldBe 10485760L
+      }
+
+      val subsequent = Iterator
+        .continually(Option(captured.poll()))
+        .takeWhile(_.isDefined)
+        .flatten
+        .toList
+      subsequent should not be empty
+      subsequent.zipWithIndex.foreach { case (req, idx) =>
+        withClue(s"subsequent request #${idx + 1} must be the default instance: ") {
+          req.subscription shouldBe ""
+          req.streamAckDeadlineSeconds shouldBe 0
+          req.clientId shouldBe ""
+          req.maxOutstandingMessages shouldBe 0L
+          req.maxOutstandingBytes shouldBe 0L
+        }
+      }
+    }
+  }
+
+  override def afterAll(): Unit =
+    system.terminate()
+}
+
+/**
+ * Stub that captures every StreamingPullRequest sent on the client → server stream
+ * and keeps the response stream open indefinitely (so the polling tick keeps firing).
+ */
+class CapturingStreamingPullClient(captured: ConcurrentLinkedQueue[StreamingPullRequest])(
+    implicit sys: ActorSystem) extends TestSubscriberClientBase {
+  private implicit val mat: Materializer = Materializer.matFromSystem(sys)
+
+  override def streamingPull(
+      in: Source[StreamingPullRequest, NotUsed])
+      : Source[StreamingPullResponse, NotUsed] =
+    Source
+      .maybe[StreamingPullResponse]
+      .mapMaterializedValue { _ =>
+        in.runForeach(req => captured.add(req))
+        NotUsed
+      }
+}
+
+/**
+ * Base stub for [[SubscriberClient]] that provides default implementations
+ * for all methods. Tests override only the methods they need.
+ */
+trait TestSubscriberClientBase extends SubscriberClient {
+  override def createSubscription(in: Subscription): Future[Subscription] = ???
+  override def getSubscription(in: GetSubscriptionRequest): Future[Subscription] = ???
+  override def updateSubscription(in: UpdateSubscriptionRequest): Future[Subscription] = ???
+  override def listSubscriptions(in: ListSubscriptionsRequest): Future[ListSubscriptionsResponse] = ???
+  override def deleteSubscription(in: DeleteSubscriptionRequest): Future[com.google.protobuf.empty.Empty] = ???
+  override def modifyAckDeadline(in: ModifyAckDeadlineRequest): Future[com.google.protobuf.empty.Empty] = ???
+  override def acknowledge(in: AcknowledgeRequest): Future[com.google.protobuf.empty.Empty] = ???
+  override def pull(in: PullRequest): Future[PullResponse] = ???
+  override def streamingPull(
+      in: Source[StreamingPullRequest, NotUsed])
+      : Source[StreamingPullResponse, NotUsed] = ???
+  override def modifyPushConfig(in: ModifyPushConfigRequest): Future[com.google.protobuf.empty.Empty] = ???
+  override def getSnapshot(in: GetSnapshotRequest): Future[Snapshot] = ???
+  override def listSnapshots(in: ListSnapshotsRequest): Future[ListSnapshotsResponse] = ???
+  override def createSnapshot(in: CreateSnapshotRequest): Future[Snapshot] = ???
+  override def updateSnapshot(in: UpdateSnapshotRequest): Future[Snapshot] = ???
+  override def deleteSnapshot(in: DeleteSnapshotRequest): Future[com.google.protobuf.empty.Empty] = ???
+  override def seek(in: SeekRequest): Future[SeekResponse] = ???
+
+  override def close(): Future[Done] = Future.successful(Done)
+  override def closed: Future[Done] = Promise[Done]().future
+}


### PR DESCRIPTION
Backport of #1625 to `1.4.x`.

**Motivation:**

`subscribe(...)` cleared only `subscription` and `streamAckDeadlineSeconds` on the keepalive request, leaving `clientId`, `maxOutstandingMessages`, and `maxOutstandingBytes` from the initial one. Pub/Sub rejects those three on subsequent requests with `INVALID_ARGUMENT`, so any caller setting `maxOutstandingMessages` loses the whole stream about a second after start.

**Modification:**

Use `StreamingPullRequest.defaultInstance` (Scala) / `getDefaultInstance` (Java) for the keepalive request. This clears every initial-only field at once and stays safe if the proto grows more of them later.

Both production files cherry-picked cleanly. Two adjustments were needed for `1.4.x`:

1. The upstream commit also modified `AutoExtendAckDeadlinesSpec`, which does not exist on `1.4.x` — the `autoExtendAckDeadlines` operator was never backported. The regression test is instead added as a standalone `SubscribeRequestFieldsSpec` carrying the stubs it needs (`CapturingStreamingPullClient`, `TestSubscriberClientBase`).

2. That test injects a capturing client, which requires the same `GrpcSubscriber` seam `main` has: the client becomes a constructor parameter and the `apply` overloads build it. The previous constructor was `private`, so this is binary compatible — `mimaReportBinaryIssues` is clean.

**Result:**

Keepalive ticks carry no initial-only fields, so long-lived subscriptions that set `maxOutstandingMessages` no longer fail with `INVALID_ARGUMENT`.

**Tests:**

Added `SubscribeRequestFieldsSpec`, asserting the initial request keeps all five caller-supplied fields verbatim and that every subsequent request has them cleared.

Verified the test fails against the pre-fix code on this branch:

```
subsequent request #1 must be the default instance: "[test-client]" was not equal to "[]"
```

and passes with the fix. Ran `google-cloud-pub-sub-grpc/mimaReportBinaryIssues` (clean) and the module's scalafmt checks.

**References:**

Backport of #1625, which fixed #1624. Bug present since `3f1a4f7f28` (Jan 2019, alpakka era). The same code path is still in alpakka: akka/alpakka#3468.