### PR TITLE
File: use int for the Java API zip compression level

### DIFF
--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/javadsl/Archive.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/javadsl/Archive.scala
@@ -32,22 +32,28 @@ object Archive {
 
   /**
    * Flow for compressing multiple files into one ZIP file.
-   * @param deflateCompression optional compression level, 0-9, where 0 is no compression and 9 is maximum compression.
-   * If not specified, the default compression level of the underlying library will be used.
+   *
+   * @param deflateCompression compression level, 0-9, where 0 is no compression and 9 is maximum compression.
+   * Pass `Deflater.DEFAULT_COMPRESSION` (-1) to use the default compression level of the underlying library.
    * @since 2.0.0
    */
   def zip(
+      deflateCompression: Int): Flow[Pair[ArchiveMetadata, Source[ByteString, NotUsed]], ByteString, NotUsed] =
+    zipFlow(Some(deflateCompression))
+
+  /**
+   * Flow for compressing multiple files into one ZIP file, using the default
+   * compression level of the underlying library.
+   */
+  def zip(): Flow[Pair[ArchiveMetadata, Source[ByteString, NotUsed]], ByteString, NotUsed] =
+    zipFlow(None)
+
+  private def zipFlow(
       deflateCompression: Option[Int]): Flow[Pair[ArchiveMetadata, Source[ByteString, NotUsed]], ByteString, NotUsed] =
     Flow
       .create[Pair[ArchiveMetadata, Source[ByteString, NotUsed]]]()
       .map(func(pair => (pair.first, pair.second.asScala)))
       .via(scaladsl.Archive.zip(deflateCompression).asJava)
-
-  /**
-   * Flow for compressing multiple files into one ZIP file.
-   */
-  def zip(): Flow[Pair[ArchiveMetadata, Source[ByteString, NotUsed]], ByteString, NotUsed] =
-    zip(None)
 
   /**
    * Flow for reading ZIP files.

--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/scaladsl/Archive.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/scaladsl/Archive.scala
@@ -22,6 +22,7 @@ import pekko.util.ByteString
 
 import java.io.File
 import java.nio.charset.{ Charset, StandardCharsets }
+import java.util.zip.Deflater
 
 /**
  * Scala API.
@@ -30,16 +31,28 @@ object Archive {
 
   /**
    * Flow for compressing multiple files into one ZIP file.
+   *
    * @param deflateCompression optional compression level, 0-9, where 0 is no compression and 9 is maximum compression.
-   * If not specified, the default compression level of the underlying library will be used.
+   * `Deflater.DEFAULT_COMPRESSION` (-1) is also accepted. If not specified, the default compression
+   * level of the underlying library is used.
    * @since 2.0.0
    */
   def zip(
-      deflateCompression: Option[Int]): Flow[(ArchiveMetadata, Source[ByteString, Any]), ByteString, NotUsed] =
+      deflateCompression: Option[Int]): Flow[(ArchiveMetadata, Source[ByteString, Any]), ByteString, NotUsed] = {
+    deflateCompression.foreach { level =>
+      require(
+        level == Deflater.DEFAULT_COMPRESSION ||
+        (level >= Deflater.NO_COMPRESSION &&
+        level <= Deflater.BEST_COMPRESSION),
+        s"deflateCompression must be between ${Deflater.NO_COMPRESSION} and ${Deflater.BEST_COMPRESSION}, " +
+        s"or ${Deflater.DEFAULT_COMPRESSION} for the default, was $level")
+    }
     ZipArchiveManager.zipFlow(deflateCompression)
+  }
 
   /**
-   * Flow for compressing multiple files into one ZIP file.
+   * Flow for compressing multiple files into one ZIP file, using the default
+   * compression level of the underlying library.
    */
   def zip(): Flow[(ArchiveMetadata, Source[ByteString, Any]), ByteString, NotUsed] =
     zip(None)

--- a/file/src/test/java/docs/javadsl/ArchiveTest.java
+++ b/file/src/test/java/docs/javadsl/ArchiveTest.java
@@ -16,6 +16,7 @@ package docs.javadsl;
 import static org.apache.pekko.util.ByteString.emptyByteString;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.net.URISyntaxException;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
+import java.util.zip.Deflater;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
@@ -135,6 +137,54 @@ public class ArchiveTest {
 
     // cleanup
     new File("logo.zip").delete();
+  }
+
+  @Test
+  public void flowShouldCreateZIPArchiveWithCompressionLevel() throws Exception {
+    ByteString fileContent1 = readFileAsByteString(getFileFromResource("pekko.svg"));
+    ByteString fileContent2 = readFileAsByteString(getFileFromResource("foundation.svg"));
+
+    Source<ByteString, NotUsed> source1 = toSource(fileContent1);
+    Source<ByteString, NotUsed> source2 = toSource(fileContent2);
+
+    Pair<ArchiveMetadata, Source<ByteString, NotUsed>> pair1 =
+        Pair.create(ArchiveMetadata.create("pekko.svg"), source1);
+    Pair<ArchiveMetadata, Source<ByteString, NotUsed>> pair2 =
+        Pair.create(ArchiveMetadata.create("foundation.svg"), source2);
+
+    Source<Pair<ArchiveMetadata, Source<ByteString, NotUsed>>, NotUsed> source =
+        Source.from(List.of(pair1, pair2));
+
+    // the compression level is a plain int, so it is callable from Java
+    // without wrapping it in a scala.Option
+    Sink<ByteString, CompletionStage<IOResult>> fileSink =
+        FileIO.toPath(Paths.get("logo-stored.zip"));
+    CompletionStage<IOResult> ioResult =
+        source.via(Archive.zip(Deflater.NO_COMPRESSION)).runWith(fileSink, system);
+
+    ioResult.toCompletableFuture().get(3, TimeUnit.SECONDS);
+
+    Map<String, ByteString> inputFiles =
+        new HashMap<String, ByteString>() {
+          {
+            put("pekko.svg", fileContent1);
+            put("foundation.svg", fileContent2);
+          }
+        };
+
+    ByteString resultFileContent = readFileAsByteString(Paths.get("logo-stored.zip"));
+    Map<String, ByteString> unzip = archiveHelper.unzip(resultFileContent);
+
+    assertThat(inputFiles, is(unzip));
+
+    // cleanup
+    new File("logo-stored.zip").delete();
+  }
+
+  @Test
+  public void zipShouldRejectInvalidCompressionLevel() {
+    assertThrows(IllegalArgumentException.class, () -> Archive.zip(10));
+    assertThrows(IllegalArgumentException.class, () -> Archive.zip(-2));
   }
 
   @Test

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -135,6 +135,24 @@ class ArchiveSpec
         archiveHelper.unzip(pekkoZipped.futureValue).asScala shouldBe inputFiles
       }
 
+      "reject an out-of-range compression level" in {
+        an[IllegalArgumentException] should be thrownBy Archive.zip(Some(10))
+        an[IllegalArgumentException] should be thrownBy Archive.zip(Some(-2))
+      }
+
+      "accept the Deflater default compression level" in {
+        val inputFiles = generateInputFiles(5, 100)
+        val inputStream = filesToStream(inputFiles)
+        val zipFlow = Archive.zip(Some(Deflater.DEFAULT_COMPRESSION))
+
+        val pekkoZipped: Future[ByteString] =
+          inputStream
+            .via(zipFlow)
+            .runWith(Sink.fold(ByteString.empty)(_ ++ _))
+
+        archiveHelper.unzip(pekkoZipped.futureValue).asScala shouldBe inputFiles
+      }
+
       "unarchive files" in {
         val inputFiles = generateInputFiles(5, 100)
         val inputStream = filesToStream(inputFiles)


### PR DESCRIPTION
**Motivation:**

`Archive.zip(deflateCompression)` added in #1829 exposes `scala.Option[Int]` in the **javadsl**. A Java caller has to write:

```java
Archive.zip(Some$.MODULE$.apply(Deflater.NO_COMPRESSION))
```

with the boxing that implies. Every other javadsl in the repo uses `java.util.Optional` or a plain value for this kind of parameter (`LogRotatorSink`, `s3/javadsl/S3`, `GoogleSettings`).

The overload is new in 2.0.0 and has not appeared in a release (not in any tag), so the signature can still be corrected without a compatibility story.

Neither DSL validated the level either. An out-of-range value reached `ZipOutputStream.setLevel` inside `preStart`, so the stream failed at materialization with `invalid compression level` rather than at the call site.

**Modification:**

The javadsl overload now takes a plain `Int`. The compression domain is `0-9` plus `Deflater.DEFAULT_COMPRESSION` (-1), so `Optional` adds nothing over an int — there is no "absent" case that -1 does not already express. Both overloads delegate to a private `zipFlow` that keeps the `Option`-based scaladsl call.

The scaladsl keeps `Option[Int]`, which is idiomatic there, and gains a `require` that rejects a level outside `0-9` and `DEFAULT_COMPRESSION`, so an invalid value now fails at the call site with a message naming the bound.

**Result:**

Java callers write `Archive.zip(Deflater.NO_COMPRESSION)`. An invalid level is rejected when the flow is constructed rather than when it is materialized.

**Tests:**

Added two tests to the Java `ArchiveTest`:
- one builds a zip via `Archive.zip(Deflater.NO_COMPRESSION)` and round-trips it through `ArchiveHelper.unzip` — this is precisely the call the old signature made awkward from Java, so it is the test that would have caught the problem
- one asserts levels `10` and `-2` are rejected

Added matching scaladsl tests for the rejection and for `Deflater.DEFAULT_COMPRESSION` being accepted.

Java tests: 6 total, 0 failed. Scala: 26 total, 0 failed. Ran `file/mimaReportBinaryIssues` (clean), the module scalafmt checks and `javafmtCheckAll`.

**References:**

Follow-up to #1829.