### PR TITLE
IronMQ: build request paths from escaped URI segments

### DIFF
--- a/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqClient.scala
+++ b/ironmq/src/main/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqClient.scala
@@ -110,7 +110,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
         x +: q
       }
 
-    makeRequest(Get(Uri(s"$queuesPath").withQuery(query))).flatMap(Unmarshal(_).to[Json]).map(parseQueues).collect {
+    makeRequest(Get(Uri(path = queuesPath).withQuery(query))).flatMap(Unmarshal(_).to[Json]).map(parseQueues).collect {
       case Right(xs) => xs
     }
   }
@@ -119,7 +119,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
    * Create a new queue, with default parameters, with the given name.
    */
   def createQueue(name: String)(implicit ec: ExecutionContext): Future[String] =
-    makeRequest(Put(Uri(s"$queuesPath/${name}"), Json.obj()))
+    makeRequest(Put(queueUri(name), Json.obj()))
       .flatMap(Unmarshal(_).to[Json])
       .map(_.hcursor.downField("queue").as[Queue])
       .collect {
@@ -130,7 +130,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
    * Delete the queue with the given name.
    */
   def deleteQueue(name: String)(implicit ec: ExecutionContext): Future[Done] =
-    makeRequest(Delete(Uri(s"$queuesPath/${name}"))).map(_ => Done)
+    makeRequest(Delete(queueUri(name))).map(_ => Done)
 
   /**
    * Produce the given messages to the queue with the given name. Return the ids ot the produced messages.
@@ -143,7 +143,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
           Json.obj("body" -> Json.fromString(pm.body), "delay" -> Json.fromLong(pm.delay.toSeconds))
         }))
 
-    makeRequest(Post(Uri(s"$queuesPath/${queueName}/messages"), payload)).flatMap(Unmarshal(_).to[Message.Ids])
+    makeRequest(Post(queueUri(queueName, "messages"), payload)).flatMap(Unmarshal(_).to[Message.Ids])
   }
 
   /**
@@ -174,7 +174,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
     }).deepMerge(Json.obj("n" -> Json.fromInt(noOfMessages),
       "delete" -> Json.fromBoolean(false)))
 
-    makeRequest(Post(Uri(s"$queuesPath/${queueName}/reservations"), payload))
+    makeRequest(Post(queueUri(queueName, "reservations"), payload))
       .flatMap(Unmarshal(_).to[Json])
       .map { json =>
         json.hcursor.downField("messages").as[Iterable[ReservedMessage]]
@@ -202,7 +202,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
                      Json.Null
                    }).deepMerge(Json.obj("n" -> Json.fromInt(noOfMessages), "delete" -> Json.fromBoolean(true)))
 
-    makeRequest(Post(Uri(s"$queuesPath/${queueName}/reservations"), payload))
+    makeRequest(Post(queueUri(queueName, "reservations"), payload))
       .flatMap(Unmarshal(_).to[Json])
       .map { json =>
         json.hcursor.downField("messages").as[Iterable[Message]]
@@ -228,7 +228,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
                      Json.Null
                    }).deepMerge(Json.obj("reservation_id" -> reservation.reservationId.asJson))
 
-    makeRequest(Post(s"$queuesPath/${queueName}/messages/${reservation.messageId}/touch", payload))
+    makeRequest(Post(queueUri(queueName, "messages", reservation.messageId.value, "touch"), payload))
       .flatMap(Unmarshal(_).to[Json])
       .map { json =>
         for {
@@ -254,7 +254,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
   def peekMessages(queueName: String,
       numberOfMessages: Int = 1)(implicit ec: ExecutionContext): Future[Iterable[Message]] =
     makeRequest(
-      Get(Uri(s"$queuesPath/${queueName}/messages").withQuery(Uri.Query("n" -> numberOfMessages.toString)))).flatMap(
+      Get(queueUri(queueName, "messages").withQuery(Uri.Query("n" -> numberOfMessages.toString)))).flatMap(
       Unmarshal(_).to[Json])
       .map { json =>
         json.hcursor.downField("messages").as[Iterable[Message]]
@@ -273,7 +273,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
 
     val payload = Json.obj("ids" -> Json.fromValues(reservations.map(_.asJson)))
 
-    makeRequest(Delete(Uri(s"$queuesPath/${queueName}/messages"), payload)).map(_ => ())
+    makeRequest(Delete(queueUri(queueName, "messages"), payload)).map(_ => ())
 
   }
 
@@ -289,7 +289,7 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
 
     val payload = Json.obj("reservation_id" -> reservation.reservationId.asJson, "delay" -> delay.toSeconds.asJson)
 
-    makeRequest(Post(Uri(s"$queuesPath/${queueName}/messages/${reservation.messageId.value}/release"), payload))
+    makeRequest(Post(queueUri(queueName, "messages", reservation.messageId.value, "release"), payload))
       .map(_ => ())
   }
 
@@ -301,9 +301,20 @@ private[ironmq] final class IronMqClient(settings: IronMqSettings)(implicit acto
    * @param queueName The queue to be purged.
    */
   def clearMessages(queueName: String)(implicit ec: ExecutionContext): Future[Unit] =
-    makeRequest(Delete(Uri(s"$queuesPath/${queueName}/messages"), Json.obj())).map(_ => ())
+    makeRequest(Delete(queueUri(queueName, "messages"), Json.obj())).map(_ => ())
 
-  private val queuesPath = s"/3/projects/${settings.projectId}/queues"
+  // Path.Segment escapes each segment, so a queue name containing '/', '?', '#'
+  // or '..' cannot alter the request path, query or fragment. Building the path
+  // by string interpolation and handing it to Uri(...) would let it do exactly
+  // that, because Uri parses the result as URI syntax.
+  private val queuesPath: Uri.Path =
+    Uri.Path.Empty / "3" / "projects" / settings.projectId / "queues"
+
+  private[impl] def queuePath(queueName: String, rest: String*): Uri.Path =
+    rest.foldLeft(queuesPath / queueName)(_ / _)
+
+  private def queueUri(queueName: String, rest: String*): Uri =
+    Uri(path = queuePath(queueName, rest: _*))
 
   private def makeRequest(request: HttpRequest): Future[HttpResponse] =
     Source.single(request).via(pipeline).runWith(Sink.head)

--- a/ironmq/src/test/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqClientPathSpec.scala
+++ b/ironmq/src/test/scala/org/apache/pekko/stream/connectors/ironmq/impl/IronMqClientPathSpec.scala
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.ironmq.impl
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.stream.Materializer
+import org.apache.pekko.stream.connectors.ironmq.IronMqSettings
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import com.typesafe.config.ConfigFactory
+
+class IronMqClientPathSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+
+  private implicit val system: ActorSystem = ActorSystem("IronMqClientPathSpec")
+  private implicit val mat: Materializer = Materializer.matFromSystem(system)
+
+  private val settings =
+    IronMqSettings(ConfigFactory.load().getConfig(IronMqSettings.ConfigPath))
+      .withEndpoint(Uri("http://localhost:8080"))
+      .withProjectId("proj")
+      .withToken("token")
+
+  // no requests are made; only the path construction is exercised
+  private val client = new IronMqClient(settings)
+
+  "IronMqClient.queuePath" should {
+
+    "build the expected path for a normal queue name" in {
+      client.queuePath("my-queue", "messages").toString shouldBe
+      "/3/projects/proj/queues/my-queue/messages"
+    }
+
+    "escape a slash so it cannot add path segments" in {
+      // without escaping this would become .../queues/a/../../admin/messages
+      val path = client.queuePath("a/../../admin", "messages").toString
+      path shouldBe "/3/projects/proj/queues/a%2F..%2F..%2Fadmin/messages"
+      path should startWith("/3/projects/proj/queues/")
+    }
+
+    "escape a question mark so it cannot start a query string" in {
+      val uri = Uri(path = client.queuePath("a?x=1", "messages"))
+      uri.rawQueryString shouldBe None
+      uri.path.toString shouldBe "/3/projects/proj/queues/a%3Fx=1/messages"
+    }
+
+    "escape a hash so it cannot start a fragment" in {
+      val uri = Uri(path = client.queuePath("a#frag", "messages"))
+      uri.fragment shouldBe None
+      uri.path.toString shouldBe "/3/projects/proj/queues/a%23frag/messages"
+    }
+
+    "accept a queue name with a space" in {
+      // Uri(s"...$name...") would throw IllegalUriException for this name
+      client.queuePath("a b", "messages").toString shouldBe
+      "/3/projects/proj/queues/a%20b/messages"
+    }
+
+    "keep every queue name under the queues path" in {
+      val hostile =
+        Seq("a/../../admin", "a?x=1", "a#frag", "../../other", "a b", "..", "/etc/passwd")
+      hostile.foreach { name =>
+        withClue(s"queue name '$name': ") {
+          client.queuePath(name, "messages").toString should startWith("/3/projects/proj/queues/")
+        }
+      }
+    }
+  }
+
+  override def afterAll(): Unit = {
+    system.terminate()
+    ()
+  }
+}


### PR DESCRIPTION
**Motivation:**

`IronMqClient` built every request path by interpolating the queue name into a string and handing the result to `Uri(...)`:

```scala
makeRequest(Post(Uri(s"$queuesPath/${queueName}/messages"), payload))
```

`Uri` parses that string as URI *syntax*, so characters in the queue name are not treated as data. Probing the actual parse with `base = "/3/projects/PID/queues"`:

```
normal        -> path=/3/projects/PID/queues/normal/messages
a/../../admin -> path=/3/projects/PID/queues/a/../../admin/messages
a?x=1         -> path=/3/projects/PID/queues/a   query=Some(x=1/messages)
a#frag        -> path=/3/projects/PID/queues/a   fragment=Some(frag/messages)
a b           -> IllegalUriException
```

A queue name can therefore add path segments, truncate the path and inject a query string, or make an otherwise valid name throw. `queueName` reaches this straight from the public API — `IronMqConsumer.atMostOnceSource`, `IronMqConsumer.atLeastOnceSource`, `IronMqProducer.flow`/`sink`/`atLeastOnceFlow` — and nothing validates it on the way.

**Modification:**

Build the path with `Uri.Path` segments, which escape each segment, via a `queuePath`/`queueUri` helper used by all eleven call sites. `projectId` becomes a segment too. `queuePath` is `private[impl]` so the escaping can be tested without a live server.

One inconsistency fixed in passing: the touch endpoint interpolated `${reservation.messageId}` where the release endpoint used `.value`; both now pass `.value`. `Message.Id` overrides `toString` to return `value`, so this is a no-op — just consistent.

**Result:**

A queue name containing `/`, `?`, `#` or `..` is escaped and cannot alter the request target. Names containing spaces now work instead of throwing `IllegalUriException`.

**Tests:**

Added `IronMqClientPathSpec`, which needs no IronMQ server — it exercises path construction only. It asserts the path for a normal name, that `/`, `?` and `#` are escaped and produce no query or fragment, that a name with a space is accepted, and that a range of hostile names all stay under the queues path. 6 tests pass.

Ran `ironmq/mimaReportBinaryIssues` (clean) and the module scalafmt checks.

**References:**

Found while auditing for injection issues after #1817 and #1821.