### PR TITLE
Pravega: release the key value table factory when the table is unset

### DIFF
--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableCleanup.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableCleanup.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.pravega.impl
+
+import org.apache.pekko
+import pekko.annotation.InternalApi
+
+import scala.util.control.NonFatal
+
+/**
+ * INTERNAL API
+ *
+ * Shared cleanup for the stages that open a `KeyValueTableFactory` and a
+ * `KeyValueTable` from it.
+ */
+@InternalApi private[pravega] object PravegaTableCleanup {
+
+  /**
+   * Close the table and then the factory.
+   *
+   * `preStart` creates the factory first and the table from it, so a failure in
+   * between leaves the factory open and the table unset. Both are therefore
+   * closed defensively and independently: the factory owns the connection pool
+   * and has to be released even when closing the table fails or was never
+   * needed.
+   *
+   * Failures are reported to `onError` and not rethrown; the stage has already
+   * stopped, so failing here would only mask why it stopped.
+   */
+  def closeTableAndFactory(closeTable: => Unit, closeFactory: => Unit)(
+      onError: (String, Throwable) => Unit): Unit = {
+    def attempt(what: String, close: => Unit): Unit =
+      try close
+      catch {
+        case NonFatal(exc) => onError(what, exc)
+      }
+
+    attempt("table", closeTable)
+    attempt("key value table factory", closeFactory)
+  }
+}

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableReadFlow.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableReadFlow.scala
@@ -123,8 +123,10 @@ import scala.util.control.NonFatal
    */
   override def postStop(): Unit = {
     log.debug("Closing table {}", tableName)
-    table.close()
-    keyValueTableFactory.close()
+    PravegaTableCleanup.closeTableAndFactory(
+      if (table ne null) table.close(),
+      if (keyValueTableFactory ne null) keyValueTableFactory.close())((what, exc) =>
+      log.error(exc, "Error while closing {} for [{}]", what, tableName))
   }
 
 }

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableSource.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableSource.scala
@@ -140,8 +140,10 @@ import io.pravega.common.util.AsyncIterator
 
   override def postStop(): Unit = {
     log.debug("Stopping reader {}", tableName)
-    table.close()
-    keyValueTableFactory.close()
+    PravegaTableCleanup.closeTableAndFactory(
+      if (table ne null) table.close(),
+      if (keyValueTableFactory ne null) keyValueTableFactory.close())((what, exc) =>
+      log.error(exc, "Error while closing {} for [{}]", what, tableName))
   }
 
 }

--- a/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableWriteFlow.scala
+++ b/pravega/src/main/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableWriteFlow.scala
@@ -132,13 +132,10 @@ import scala.util.control.NonFatal
    */
   override def postStop(): Unit = {
     log.debug("Closing table {}", tableName)
-    Try(table.close()) match {
-      case Failure(exception) =>
-        log.error(exception, "Error while closing table [{}]", tableName)
-      case Success(value) =>
-        log.debug("Closed table [{}]", tableName)
-    }
-    keyValueTableFactory.close()
+    PravegaTableCleanup.closeTableAndFactory(
+      if (table ne null) table.close(),
+      if (keyValueTableFactory ne null) keyValueTableFactory.close())((what, exc) =>
+      log.error(exc, "Error while closing {} for [{}]", what, tableName))
   }
 
 }

--- a/pravega/src/test/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableCleanupSpec.scala
+++ b/pravega/src/test/scala/org/apache/pekko/stream/connectors/pravega/impl/PravegaTableCleanupSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.stream.connectors.pravega.impl
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.collection.mutable.ListBuffer
+
+class PravegaTableCleanupSpec extends AnyWordSpec with Matchers {
+
+  "PravegaTableCleanup.closeTableAndFactory" should {
+
+    "close the table and then the factory" in {
+      val closed = ListBuffer.empty[String]
+      PravegaTableCleanup.closeTableAndFactory(closed += "table", closed += "factory")((_, _) =>
+        fail("no error expected"))
+      closed.toList shouldBe List("table", "factory")
+    }
+
+    "still close the factory when closing the table fails" in {
+      // the factory owns the connection pool, so it must be released even
+      // when the table close throws
+      val closed = ListBuffer.empty[String]
+      val errors = ListBuffer.empty[String]
+      PravegaTableCleanup.closeTableAndFactory(
+        throw new RuntimeException("table boom"),
+        closed += "factory")((what, _) => errors += what)
+
+      closed.toList shouldBe List("factory")
+      errors.toList shouldBe List("table")
+    }
+
+    "close the factory when the table was never opened" in {
+      // preStart creates the factory first: if forKeyValueTable throws, the
+      // table field is still null and only the factory needs closing
+      val table: AutoCloseable = null
+      val closed = ListBuffer.empty[String]
+      noException should be thrownBy {
+        PravegaTableCleanup.closeTableAndFactory(
+          if (table ne null) table.close(),
+          closed += "factory")((_, _) => fail("no error expected"))
+      }
+      closed.toList shouldBe List("factory")
+    }
+
+    "report both failures and not rethrow" in {
+      val errors = ListBuffer.empty[String]
+      noException should be thrownBy {
+        PravegaTableCleanup.closeTableAndFactory(
+          throw new RuntimeException("a"),
+          throw new RuntimeException("b"))((what, _) => errors += what)
+      }
+      errors.toList shouldBe List("table", "key value table factory")
+    }
+  }
+}


### PR DESCRIPTION
**Motivation:**

`PravegaTableReadFlow` and `PravegaTableSource` cleaned up with:

```scala
override def postStop(): Unit = {
  log.debug("Closing table {}", tableName)
  table.close()
  keyValueTableFactory.close()
}
```

`preStart` creates the factory first and the table from it:

```scala
keyValueTableFactory = KeyValueTableFactory.withScope(scope, tableSettings.clientConfig)
table = keyValueTableFactory.forKeyValueTable(tableName, kvtClientConfig)
```

If `forKeyValueTable` throws — wrong table name or scope, auth failure: all ordinary production misconfigurations — the factory is open and holds a connection pool (Netty channels to the segment store) while `table` is still `null`. `postStop` then throws a `NullPointerException` on `table.close()` and **never reaches** `keyValueTableFactory.close()`, so the pool leaks.

`PravegaTableWriteFlow` already wrapped the table close in `Try`, so its factory was released — but it still logged a spurious NPE for a table that was never opened.

**Modification:**

Guard both closes with a null check and close each independently, so a failure to close the table cannot prevent the factory close. Failures are logged rather than rethrown, matching `PravegaSource.postStop`: the stage has already stopped, so failing here would only mask why it stopped.

The three copies of this sequence are extracted to `PravegaTableCleanup.closeTableAndFactory`, which also makes the ordering testable without a Pravega cluster.

**Result:**

The connection pool is released even when `preStart` fails between creating the factory and the table.

**Tests:**

Added `PravegaTableCleanupSpec` covering the ordinary path, a table that fails to close, a table that was never opened, and both failing.

It needs no Pravega server — which matters here, because this path is reached only when `preStart` fails partway, so the Docker-based integration tests never exercise it.

4 tests pass. Ran `pravega/mimaReportBinaryIssues` (clean) and the module scalafmt checks.

**References:**

Compare `PravegaSource.postStop`, which guards each close.