### PR TITLE
Unix Domain Socket: fix large-transfer stall from lost readiness events

### DIFF
--- a/unix-domain-socket/src/main/scala/org/apache/pekko/stream/connectors/unixdomainsocket/impl/UnixDomainSocketImpl.scala
+++ b/unix-domain-socket/src/main/scala/org/apache/pekko/stream/connectors/unixdomainsocket/impl/UnixDomainSocketImpl.scala
@@ -122,7 +122,12 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
               case null                                   =>
               case sendReceiveContext: SendReceiveContext =>
                 sendReceiveContext.send match {
-                  case SendRequested(buffer, sent) if keySelectable && key.isWritable =>
+                  // Attempt the write whenever the key is selected, not only when it reports
+                  // writable. The underlying jnr-enxio selectors register edge-triggered kqueue
+                  // filters and can lose a write-readiness event when a read event for the same
+                  // channel arrives in the same batch - a non-blocking write simply returns 0
+                  // when the socket has no space, so trying is always safe.
+                  case SendRequested(buffer, sent) if keySelectable =>
                     val channel = key.channel().asInstanceOf[UnixSocketChannel]
 
                     val written =
@@ -142,10 +147,14 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
 
                     log.debug("written: {} remaining: {}", written, remaining)
 
-                    if (written >= 0 && remaining == 0) {
-                      sendReceiveContext.send = SendAvailable(buffer)
-                      key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE)
-                      sent.success(Done)
+                    if (written >= 0) {
+                      if (remaining == 0) {
+                        sendReceiveContext.send = SendAvailable(buffer)
+                        key.interestOps(key.interestOps() & ~SelectionKey.OP_WRITE)
+                        sent.success(Done)
+                      } else {
+                        key.interestOps(key.interestOps() | SelectionKey.OP_WRITE)
+                      }
                     }
                   case _: SendRequested =>
                     key.interestOps(key.interestOps() | SelectionKey.OP_WRITE)
@@ -175,7 +184,11 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
                     } catch { case _: IOException => }
                 }
                 sendReceiveContext.receive match {
-                  case ReceiveAvailable(queue, buffer) if keySelectable && key.isReadable =>
+                  // As for writes above, attempt the read whenever the key is selected so that a
+                  // read-readiness event lost to the edge-triggered selector is recovered by the
+                  // event that clobbered it. A read of 0 bytes means "no data yet" and leaves the
+                  // registered read interest as it is.
+                  case ReceiveAvailable(queue, buffer) if keySelectable =>
                     buffer.clear()
 
                     val channel = key.channel.asInstanceOf[UnixSocketChannel]
@@ -190,12 +203,14 @@ private[unixdomainsocket] object UnixDomainSocketImpl {
 
                     log.debug("read: {}", read)
 
-                    if (read >= 0) {
+                    if (read > 0) {
                       buffer.flip()
                       val pendingResult = queue.offer(ByteString(buffer))
                       pendingResult.onComplete(_ => sel.wakeup())
                       sendReceiveContext.receive = PendingReceiveAck(queue, buffer, pendingResult)
                       key.interestOps(key.interestOps() & ~SelectionKey.OP_READ)
+                    } else if (read == 0) {
+                      // No data available - the key was selected for another reason
                     } else {
                       queue.complete()
                       try {

--- a/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
+++ b/unix-domain-socket/src/test/scala/docs/scaladsl/UnixDomainSocketSpec.scala
@@ -82,7 +82,7 @@ class UnixDomainSocketSpec
       binding.futureValue.unbind().futureValue should be(())
     }
 
-    "send and receive more ten times the size of a buffer" ignore {
+    "send and receive more ten times the size of a buffer" in {
       val BufferSizeBytes = 64 * 1024
 
       val path = dir.resolve("sock2")


### PR DESCRIPTION
### Motivation
`UnixDomainSocketSpec`'s "send and receive more ten times the size of a buffer" test (disabled since 2019) stalls part way through the transfer: the echoing server never writes a byte, its receive queue then fills, backpressure disables its reads, and both directions deadlock.

The root cause is in jnr-enxio's `KQSelector` (macOS/BSD): it registers kqueue filters edge-triggered (`EV_ADD|EV_ENABLE|EV_CLEAR`), and its `poll()` **overwrites** a key's `readyOps` for each returned kevent entry instead of OR-ing them. When `EVFILT_READ` and `EVFILT_WRITE` for the same channel arrive in one batch, the entry processed last clobbers the other's readiness — and since the filter is edge-triggered, the consumed edge never fires again. The connector's NIO event loop gated writes on `key.isWritable` and reads on `key.isReadable`, so a clobbered event stalled that direction forever. Debug logs of the stalled test show the server's key repeatedly selected `readable=true, writable=false` with a pending `SendRequested` and `OP_WRITE` registered, while its socket was empty and trivially writable.

### Modification
In `UnixDomainSocketImpl.nioEventLoop`, attempt a pending write or read whenever the key is selected, rather than only when the (unreliable) ready ops report readiness. A non-blocking operation on a not-ready socket returns 0, which is now handled: an unfinished write keeps `OP_WRITE` registered, and a 0-byte read is a no-op instead of being mistaken for EOF. This is self-healing by construction: a readiness edge can only be lost to another event on the same key arriving in the same batch, and that event now triggers the retry.

Re-enable the throughput test.

### Result
Sustained transfers complete. The re-enabled test passes in ~250ms instead of timing out after a minute, and the rest of the spec is unaffected. Linux was likely unaffected (jnr-enxio uses the level-triggered poll(2) selector there), so CI exercising this test on Linux should be safe; the fix removes the macOS/BSD stall.

### Tests
- `sbt "unix-domain-socket/testOnly docs.scaladsl.UnixDomainSocketSpec"` — all 7 tests pass, stable over 5 consecutive runs (macOS). The re-enabled test reproduced the stall before the fix and is the directional regression test.

### References
Fixes #1858