### PR TITLE
Solr: run tests with slf4j v2, drop legacy slf4j/logback pins

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,11 +45,8 @@ object Dependencies {
   val scalaCheckVersion = "1.19.0"
   val HadoopVersion = "3.4.3"
 
-  // Legacy versions support Slf4J v1 for compatibility with older libs
   val Slf4jVersion = "2.0.18"
-  val Slf4jLegacyVersion = "1.7.36"
   val LogbackVersion = "1.6.3"
-  val LogbackLegacyVersion = "1.2.13"
 
   /**
    * Calculates the scalatest version in a format that is used for `org.scalatestplus` scalacheck artifacts
@@ -509,12 +506,11 @@ object Dependencies {
   val Solr = Seq(
     libraryDependencies ++= Seq(
       "org.apache.solr" % "solr-solrj" % SolrjVersion,
-      ("org.apache.solr" % "solr-test-framework" % SolrjVersion % Test).exclude("org.apache.logging.log4j",
-        "log4j-slf4j-impl"),
-      "org.slf4j" % "log4j-over-slf4j" % Slf4jLegacyVersion % Test),
-    dependencyOverrides ++= Seq(
-      "org.slf4j" % "slf4j-api" % Slf4jLegacyVersion,
-      "ch.qos.logback" % "logback-classic" % LogbackLegacyVersion))
+      ("org.apache.solr" % "solr-test-framework" % SolrjVersion % Test)
+        // exclude the slf4j providers backed by log4j2 so that logback
+        // (used by pekko-connectors-testkit's log capturing) stays the only provider
+        .exclude("org.apache.logging.log4j", "log4j-slf4j-impl")
+        .exclude("org.apache.logging.log4j", "log4j-slf4j2-impl")))
 
   val Sqs = Seq(
     libraryDependencies ++= Seq(


### PR DESCRIPTION
### Motivation
The Solr module was the last one pinned to slf4j 1.7 / logback 1.2 via `dependencyOverrides`, dating from the solr-solrj 8.x days when the Solr client libs did not work with slf4j v2 (#539, #611). Since the upgrade to solrj 9.x (#1813) that pin is obsolete: the Solr 9 ecosystem is slf4j-2-native.

### Modification
- Remove the slf4j/logback legacy `dependencyOverrides` and the `log4j-over-slf4j` bridge (nothing on the classpath uses the log4j 1.x API any more).
- Exclude `log4j-slf4j2-impl` from `solr-test-framework`, alongside the existing `log4j-slf4j-impl` exclusion. Under the v1 pin it was inert, but with slf4j v2 it competes with logback for provider selection, and the tests rely on the testkit's logback-based log capturing — which provider wins would otherwise be classpath-order luck. (`log4j-core` stays for solr-test-framework's own internal logging.)
- Delete the now-unused `Slf4jLegacyVersion` and `LogbackLegacyVersion` vals — Solr was their last user.

### Result
Solr tests run on slf4j-api 2.0.18 / logback-classic 1.6.3 with logback as the sole slf4j provider, matching every other connector. No trace of slf4j v1 remains in the build, and users no longer need to consider slf4j v1 `dependencyOverrides` for the Solr connector.

### Tests
- `sbt solr/test` — 21/21 pass, verified both before and after the change (embedded `MiniSolrCloudCluster`, no external services).
- Verified via `show solr/Test/fullClasspath` that slf4j-api 2.0.18 / logback-classic 1.6.3 are resolved and `logback-classic` is the only slf4j provider on the test classpath.

### References
Fixes #611