### PR TITLE
File: drop obsolete SensitivityWatchEventModifier

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -162,11 +162,11 @@ jobs:
           fetch-tags: true
           fetch-depth: 0
 
-      - name: Setup Java 17
+      - name: Setup Java 25
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 25
 
       - name: Install sbt
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8

--- a/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
+++ b/file/src/main/java/org/apache/pekko/stream/connectors/file/impl/DirectoryChangesSource.java
@@ -15,7 +15,6 @@ package org.apache.pekko.stream.connectors.file.impl;
 
 import static java.nio.file.StandardWatchEventKinds.*;
 
-import com.sun.nio.file.SensitivityWatchEventModifier;
 import java.io.IOException;
 import java.nio.file.*;
 import java.util.ArrayDeque;
@@ -95,13 +94,14 @@ public final class DirectoryChangesSource<T> extends GraphStage<SourceShape<T>> 
       private final Queue<T> buffer = new ArrayDeque<>();
       private final WatchService service = directoryPath.getFileSystem().newWatchService();
 
-      @SuppressWarnings({"deprecation", "removal"})
+      // The com.sun.nio.file.SensitivityWatchEventModifier.HIGH modifier historically passed
+      // here is unnecessary on the JDKs this project supports: since JDK 17 the polling
+      // WatchService used on macOS defaults to the 2s interval that HIGH selected, and JDK 21+
+      // ignores the (terminally deprecated) modifier altogether.
       private final WatchKey watchKey =
           directoryPath.register(
               service,
-              new WatchEvent.Kind<?>[] {ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE, OVERFLOW},
-              // this is com.sun internal, but the service is useless on OSX without it
-              SensitivityWatchEventModifier.HIGH);
+              new WatchEvent.Kind<?>[] {ENTRY_CREATE, ENTRY_MODIFY, ENTRY_DELETE, OVERFLOW});
 
       {
         setHandler(


### PR DESCRIPTION
### Motivation
`DirectoryChangesSource` passed `com.sun.nio.file.SensitivityWatchEventModifier.HIGH` when registering its `WatchKey`. The class is terminally deprecated since JDK 21 and compiling it fails under `-Werror` on JDK 21+ (#296): besides the `[removal]` lint warning (which `@SuppressWarnings` can silence), javac emits an unsuppressable *"SensitivityWatchEventModifier is internal proprietary API and may be removed in a future release"* warning on both the import and the usage — no annotation placement can get past `-Werror`. It also affects users of the module system, and the class may be removed from the JDK at any time.

The modifier is a no-op on every JDK this project supports (build baseline is `-release:17`), verified against the OpenJDK sources:
- JDK 17–20: `PollingWatchService.DEFAULT_POLLING_INTERVAL` is already 2s — identical to what `HIGH` selected. The 10s default that made `HIGH` worthwhile ("the service is useless on OSX without it") existed only up to JDK 11.
- JDK 21+: the polling service ignores sensitivity modifiers altogether and the interval is hardcoded to 2s (JDK-8307097).

### Modification
Remove the modifier from the `register` call, along with the import and the now-unneeded `@SuppressWarnings({"deprecation", "removal"})` annotation. A short comment explains why no sensitivity modifier is needed. This was the only reference in the repository. Formatted with `sbt javafmtAll` on JDK 17.

### Result
The file module compiles warning-free with `-Xlint:deprecation -Werror` on JDK 21, with no behavior change on any supported JDK, and the code is immune to the class's eventual removal from the JDK.

A possible follow-up is re-enabling the commented-out `-Xlint:removal` in `project/Common.scala`, after sweeping the other modules for removal warnings.

### Tests
- `sbt file/test` — 79/79 pass on JDK 17 and on JDK 21 (the directory-watching specs exercise the changed registration path).
- `javac -Xlint:deprecation -Werror` (JDK 21) on the changed file against the module classpath compiles clean; the previous version emits the internal-proprietary-API warning.

### References
Fixes #296