### PR TITLE
FTP: backport test timeout fix to 1.4.x (#1629)

### DIFF
--- a/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
+++ b/ftp/src/test/scala/docs/scaladsl/FtpExamplesSpec.scala
@@ -77,7 +77,7 @@ class FtpExamplesSpec
         .runWith(Ftp.toPath("file.txt", ftpSettings))
       // #storing
 
-      val ioResult = result.futureValue(timeout(Span(1, Seconds)))
+      val ioResult = result.futureValue(timeout(Span(8, Seconds)))
       ioResult should be(IOResult.createSuccessful(25))
 
       val p = fileExists("file.txt")
@@ -101,7 +101,7 @@ class FtpExamplesSpec
         .runWith(Ftp.toPath("file.txt.gz", ftpSettings))
       // #storing
 
-      val ioResult = result.futureValue(timeout(Span(1, Seconds)))
+      val ioResult = result.futureValue(timeout(Span(8, Seconds)))
       ioResult should be(IOResult.createSuccessful(61))
 
       val p = fileExists("file.txt.gz")


### PR DESCRIPTION
### Motivation
The `1.4.x` branch carries the Docker-based FTP tests (backport of #1668) but not the follow-up fix #1629 that raised `FtpExamplesSpec`'s `futureValue` timeout from 1 second to 8 seconds. With the 1-second timeout, the "should be stored" and "should be gzipped" tests fail near-deterministically against the Dockerized FTP server on loaded CI runners — the `connectors (ftp)` job on 1.4.x-targeted PRs fails repeatedly and re-running the job cannot help (e.g. all 3 attempts of the CI run for #1872 failed on exactly these two tests).

### Modification
Clean cherry-pick of 98f26fd80 (`Fix unit test related to ftp timeout (#1629)`) from `main` onto `1.4.x`, with original authorship preserved. Raises the two `futureValue` timeouts in `FtpExamplesSpec` from 1s to 8s.

### Result
The ftp CI job on 1.4.x-targeted PRs stops failing on `FtpExamplesSpec` timeouts, matching `main`. After this merges, #1872 needs a fresh merge commit (rebase or close/reopen) to pick it up — re-running its existing failed job will still test the old frozen merge commit.

### Tests
- `sbt ftp/Test/compile` passes on the 1.4.x toolchain.
- The FTP integration tests need the Docker servers (`./scripts/ftp-servers.sh`); Docker was not available locally, so relying on this PR's CI ftp job — the change is a byte-identical cherry-pick of a fix already green on `main` CI.

### References
Refs #1629 - backport of the test timeout fix (main commit 98f26fd80) to 1.4.x