### PR TITLE
CI: update action SHA pins on 1.4.x to allowlisted versions

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -45,10 +45,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: "Code style, compile tests, MiMa. Run locally with: sbt \"javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues\""
         run: sbt "javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues"
@@ -77,10 +77,10 @@ jobs:
           java-version: 11
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: "Create all API docs and create site with Paradox"
         run: sbt docs/makeSite
@@ -165,10 +165,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: ${{ matrix.connector }}
         env:

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -48,7 +48,7 @@ jobs:
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: "Code style, compile tests, MiMa. Run locally with: sbt \"javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues\""
         run: sbt "javafmtCheckAll; +Test/compile; +mimaReportBinaryIssues"
@@ -80,7 +80,7 @@ jobs:
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: "Create all API docs and create site with Paradox"
         run: sbt docs/makeSite

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -40,10 +40,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: Check headers
         run: |-

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -43,7 +43,7 @@ jobs:
         uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: Check headers
         run: |-


### PR DESCRIPTION
### Motivation
Every fresh `CI` and `Headers` run for 1.4.x-targeted PRs currently fails with `startup_failure` and zero jobs (e.g. both runs for #1883). The run page banner states the cause:

> The actions `sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb` and `coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7` are not allowed in apache/pekko-connectors because all actions must be from a repository owned by your enterprise, created by GitHub, or match one of the patterns: …

The ASF org allowlists third-party actions by exact SHA, and the old pins on this branch have dropped off the list. `main`'s workflows pin newer SHAs of the same actions and run fine (GitHub-owned actions like `actions/checkout` / `actions/setup-java` are always allowed, and `format.yml` passes because its `jrouly/scalafmt-native-action` SHA matches `main`'s). Re-runs of runs created before the allowlist change still execute — policy is applied when a run is created — which masked the breakage until a new PR was opened against 1.4.x.

### Modification
Update `check-build-test.yml` and `headers.yml` on 1.4.x to the allowlisted SHAs already used on `main`:
- `sbt/setup-sbt` `1cad58d5` (v1.1.18) → `c7d2d625` (v1.5.8)
- `coursier/cache-action` `e47d7d35` → `95e5b102`

No functional change to what the jobs do (JDK versions, sbt commands and matrix untouched). `dependency-graph.yml` also carries an old pin but only triggers on push to the default branch, so it never runs from 1.4.x and is left alone.

### Result
CI and Headers workflows start again for 1.4.x-targeted PRs. After this merges, existing 1.4.x PRs (#1883, and #1872 for its separate ftp-timeout failure) need a fresh merge commit — close/reopen or rebase — since re-running an existing run reuses its frozen merge snapshot and old workflow files.

### Tests
- This PR's own CI run is the verification: `pull_request` runs take workflow definitions from the merge commit, so its jobs starting (rather than `startup_failure`) proves the fix.

### References
None - unblocks CI for 1.4.x PRs such as #1883