### PR TITLE
AMQP: update rabbitmq docker test image to v4

### DIFF
--- a/amqp/src/test/travis/rabbitmq.conf
+++ b/amqp/src/test/travis/rabbitmq.conf
@@ -1,0 +1,4 @@
+# RabbitMQ 4.x deprecates transient (non-durable) non-exclusive queues and
+# refuses to declare them by default. The AMQP connector tests declare such
+# queues, so permit the deprecated feature until the tests move off it.
+deprecated_features.permit.transient_nonexcl_queues = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
     image: rabbitmq:4
     ports:
       - "5672:5672"
+    volumes:
+      - ./amqp/src/test/travis/rabbitmq.conf:/etc/rabbitmq/conf.d/20-pekko-connectors.conf
   cassandra:
     image: cassandra:4.0
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     volumes:
     - ./sns/src/test/travis/:/conf/
   amqp:
-    image: rabbitmq:3
+    image: rabbitmq:4
     ports:
       - "5672:5672"
   cassandra:


### PR DESCRIPTION
### Motivation
The `amqp` docker-compose service pins `rabbitmq:3`, which resolves to RabbitMQ 3.13 — a series that has reached end of life. RabbitMQ 4.x is the current supported series.

### Modification
- Bump the `amqp` service image in `docker-compose.yml` from `rabbitmq:3` to `rabbitmq:4` (currently 4.3.x).
- RabbitMQ 4.x refuses to declare transient (non-durable) non-exclusive queues by default (connection closed with reply-code 541, `Feature 'transient_nonexcl_queues' is deprecated`), which the AMQP test suites rely on. Add `amqp/src/test/travis/rabbitmq.conf` setting `deprecated_features.permit.transient_nonexcl_queues = true` and mount it into the broker's `conf.d`, following the pattern of the `mqtt` service. RabbitMQ will remove this feature in a future major version, so the tests should eventually move to durable or exclusive queue declarations.

### Result
The AMQP integration tests run against a supported RabbitMQ version.

### Tests
- Reproduced the RabbitMQ 4 failure locally (`AmqpDocsSpec`: 6/6 failed with the 541 deprecation error) and verified the `deprecated_features.permit` config fixes it (5/6 pass; the remaining `pub-sub from one source with multiple sinks` failure also occurs locally against `rabbitmq:3`, so it is a pre-existing local-environment flake, not a v4 regression — it passed on v4 in this PR's earlier CI run).
- `connectors (amqp)` CI integration job validates the full suite against the new image.

### References
None - test docker image maintenance