### PR TITLE
Google Cloud Pub/Sub: update google/cloud-sdk docker test image to 583.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       - ./geode/scripts/:/scripts/
     command: /scripts/geode.sh
   gcloud-pubsub-emulator:
-    image: google/cloud-sdk:554.0.0
+    image: google/cloud-sdk:583.0.0
     ports:
       - "8538:8538"
     command: gcloud beta emulators pubsub start --project=pekko-connectors --host-port=0.0.0.0:8538


### PR DESCRIPTION
### Motivation
The `gcloud-pubsub-emulator` docker-compose service pins `google/cloud-sdk:554.0.0`, which is well behind the current Cloud SDK release.

### Modification
Bump the `gcloud-pubsub-emulator` service image in `docker-compose.yml` from `google/cloud-sdk:554.0.0` to `google/cloud-sdk:583.0.0`.

### Result
The Pub/Sub emulator used by the integration tests runs on a current Cloud SDK version.

### Tests
- Not run locally - Docker unavailable in this environment; the `connectors (google-cloud-pub-sub)` and `connectors (google-cloud-pub-sub-grpc)` CI integration jobs start this service (`docker compose up -d gcloud-pubsub-emulator_prep`) and run their suites against it.

### References
None - test docker image maintenance