### PR TITLE
OrientDB: update orientdb docker test image to 3.2.55

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,7 +182,7 @@ services:
     volumes:
       - ./mqtt/src/test/travis:/mosquitto/config
   orientdb:
-    image: orientdb:3.2.51
+    image: orientdb:3.2.55
     ports:
       - "2424:2424"
     environment:


### PR DESCRIPTION
### Motivation
The `orientdb` docker-compose service pins `orientdb:3.2.51`; 3.2.55 is the latest 3.2.x release.

### Modification
Bump the `orientdb` service image in `docker-compose.yml` from `orientdb:3.2.51` to `orientdb:3.2.55`.

### Result
The OrientDB integration tests run against the latest 3.2.x patch release.

### Tests
- Not run locally - Docker unavailable in this environment; the `connectors (orientdb)` CI integration job starts this service (`docker compose up -d orientdb`) and runs the OrientDB test suite against it.

### References
None - test docker image maintenance