### PR TITLE
Couchbase3: test against couchbase community-8.0.2

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -106,7 +106,7 @@ jobs:
           - { connector: azure-storage-queue }
           - { connector: cassandra,                    pre_cmd: 'docker compose up -d cassandra' }
           - { connector: couchbase,                    pre_cmd: 'docker compose up -d couchbase_prep' }
-          - { connector: couchbase3,                   pre_cmd: 'docker compose up -d couchbase_prep' }
+          - { connector: couchbase3,                   pre_cmd: 'docker compose up -d couchbase3_prep' }
           - { connector: csv }
           - { connector: dynamodb,                     pre_cmd: 'docker compose up -d dynamodb' }
           - { connector: elasticsearch,                pre_cmd: 'docker compose up -d elasticsearch6 elasticsearch7 opensearch1' }

--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -105,8 +105,8 @@ jobs:
           - { connector: aws-event-bridge,             pre_cmd: 'docker compose up -d amazoneventbridge' }
           - { connector: azure-storage-queue }
           - { connector: cassandra,                    pre_cmd: 'docker compose up -d cassandra' }
-          - { connector: couchbase,                    pre_cmd: 'docker compose up -d couchbase_prep' }
-          - { connector: couchbase3,                   pre_cmd: 'docker compose up -d couchbase3_prep' }
+          - { connector: couchbase,                    pre_cmd: 'docker compose up -d couchbase7_prep' }
+          - { connector: couchbase3,                   pre_cmd: 'docker compose up -d couchbase8_prep' }
           - { connector: csv }
           - { connector: dynamodb,                     pre_cmd: 'docker compose up -d dynamodb' }
           - { connector: elasticsearch,                pre_cmd: 'docker compose up -d elasticsearch6 elasticsearch7 opensearch1' }

--- a/couchbase3/src/test/scala/docs/scaladsl/CouchbaseTestSourceSpec.scala
+++ b/couchbase3/src/test/scala/docs/scaladsl/CouchbaseTestSourceSpec.scala
@@ -26,7 +26,7 @@ import org.apache.pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import org.apache.pekko.stream.scaladsl.Sink
 import org.apache.pekko.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, Inspectors }
-import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.concurrent.{ IntegrationPatience, ScalaFutures }
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -36,6 +36,7 @@ class CouchbaseTestSourceSpec extends AnyWordSpec
     with BeforeAndAfterEach
     with Matchers
     with ScalaFutures
+    with IntegrationPatience
     with Inspectors
     with LogCapturing {
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,6 +257,47 @@ services:
       
       sleep 2 # just wait a tiny bit more after creating the bucket
       "
+  # couchbase3 shares host ports with the couchbase service above (the SDK
+  # requires the standard ports), so only one of the two can run at a time
+  couchbase3:
+    image: couchbase:community-8.0.2
+    ports:
+      - "8091-8096:8091-8096"
+      - "11210-11211:11210-11211"
+  couchbase3_prep:
+    image: couchbase:community-8.0.2
+    links:
+      - "couchbase3"
+    entrypoint: ""
+    command: >
+      bash -c
+      "echo 'waiting until couchbase is up'
+
+      until `curl --output /dev/null --silent --head --fail http://couchbase3:8091`; do
+            printf '.'
+            sleep 2
+      done
+
+      couchbase-cli cluster-init -c couchbase3
+      --cluster-username Administrator
+      --cluster-password password
+      --cluster-ramsize 300
+      --cluster-index-ramsize 256
+      --cluster-fts-ramsize 256
+      --cluster-query-ramsize 256
+      --services data,index,query,fts
+
+      couchbase-cli bucket-create -c couchbase3
+      -u Administrator -p password
+      --bucket pekko
+      --bucket-type couchbase
+      --storage-backend couchstore
+      --bucket-ramsize 120
+      --bucket-replica 0
+      --wait
+
+      sleep 2 # just wait a tiny bit more after creating the bucket
+      "
 
 volumes:
   kudu-tserver-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -210,27 +210,27 @@ services:
       - 9090:9090
       - 12345:12345
     command: standalone
-  couchbase:
+  couchbase7:
     image: couchbase:community-7.6.1
     ports:
       - "8091-8096:8091-8096"
       - "11210-11211:11210-11211"
-  couchbase_prep:
+  couchbase7_prep:
     image: couchbase:community-7.6.1
     links:
-      - "couchbase"
+      - "couchbase7"
     entrypoint: ""
     # when we drop couchbase2, we don't need to create bucket pekkoquery
     command: >
       bash -c 
       "echo 'waiting until couchbase is up'
       
-      until `curl --output /dev/null --silent --head --fail http://couchbase:8091`; do
+      until `curl --output /dev/null --silent --head --fail http://couchbase7:8091`; do
             printf '.'
             sleep 2
       done
       
-      couchbase-cli cluster-init -c couchbase
+      couchbase-cli cluster-init -c couchbase7
       --cluster-username Administrator
       --cluster-password password
       --cluster-ramsize 300
@@ -239,7 +239,7 @@ services:
       --cluster-query-ramsize 256
       --services data,index,query,fts
       
-      couchbase-cli bucket-create -c couchbase
+      couchbase-cli bucket-create -c couchbase7
       -u Administrator -p password
       --bucket pekko
       --bucket-type couchbase
@@ -247,7 +247,7 @@ services:
       --bucket-replica 1
       --wait
       
-      couchbase-cli bucket-create -c couchbase
+      couchbase-cli bucket-create -c couchbase7
       -u Administrator -p password
       --bucket pekkoquery
       --bucket-type couchbase
@@ -257,28 +257,28 @@ services:
       
       sleep 2 # just wait a tiny bit more after creating the bucket
       "
-  # couchbase3 shares host ports with the couchbase service above (the SDK
+  # couchbase8 shares host ports with the couchbase7 service above (the SDK
   # requires the standard ports), so only one of the two can run at a time
-  couchbase3:
+  couchbase8:
     image: couchbase:community-8.0.2
     ports:
       - "8091-8096:8091-8096"
       - "11210-11211:11210-11211"
-  couchbase3_prep:
+  couchbase8_prep:
     image: couchbase:community-8.0.2
     links:
-      - "couchbase3"
+      - "couchbase8"
     entrypoint: ""
     command: >
       bash -c
       "echo 'waiting until couchbase is up'
 
-      until `curl --output /dev/null --silent --head --fail http://couchbase3:8091`; do
+      until `curl --output /dev/null --silent --head --fail http://couchbase8:8091`; do
             printf '.'
             sleep 2
       done
 
-      couchbase-cli cluster-init -c couchbase3
+      couchbase-cli cluster-init -c couchbase8
       --cluster-username Administrator
       --cluster-password password
       --cluster-ramsize 300
@@ -287,7 +287,7 @@ services:
       --cluster-query-ramsize 256
       --services data,index,query,fts
 
-      couchbase-cli bucket-create -c couchbase3
+      couchbase-cli bucket-create -c couchbase8
       -u Administrator -p password
       --bucket pekko
       --bucket-type couchbase


### PR DESCRIPTION
### Motivation
Couchbase Server 8.0 is the current community release line, but the `couchbase` module's Couchbase Java SDK 2.x (EOL) cannot realistically move to it. Testing the newer `couchbase3` module (SDK 3.x) against Server 8 is achievable, so the two modules now use separate docker-compose setups.

### Modification
- `couchbase`/`couchbase_prep` services are unchanged from main (`couchbase:community-7.6.1`); the `couchbase` CI job keeps using them.
- New `couchbase3`/`couchbase3_prep` services run `couchbase:community-8.0.2`, and the `couchbase3` CI job now starts `couchbase3_prep`. Server 8 needed two provisioning fixes: `bucket-create` defaults to the enterprise-only magma storage backend (`--storage-backend couchstore` added), and `--bucket-replica 1` on a single node is now a hard error (dropped to 0). Only the `pekko` bucket is created — `pekkoquery` is only needed by the old module.
- The two service pairs share host ports (the SDK requires the standard Couchbase ports), so only one pair can run at a time; noted in a comment.
- `CouchbaseTestSourceSpec` gains `IntegrationPatience`: the KV sampling scan consistently takes ~2.3s on Server 8 (measured locally) versus well under the default 600ms patience on 7.6 — a real server-side behavior change, not a flake.

### Result
The couchbase3 integration tests run against Couchbase Server community 8.0; the legacy couchbase module keeps its 7.6 coverage.

### Tests
- Locally with Docker: `couchbase3_prep` provisioning succeeds on community-8.0.2 (it failed before the storage-backend/replica fixes), and `sbt couchbase3/test` passes 14/14 against it.
- `scalafmt --list --mode diff-ref=upstream/main` - clean.
- The `connectors (couchbase)` and `connectors (couchbase3)` CI jobs validate both setups.

### References
None - test docker image maintenance