### PR TITLE
Cassandra: update cassandra docker test image to 5.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     ports:
       - "5672:5672"
   cassandra:
-    image: cassandra:4.0
+    image: cassandra:5.0
     ports:
       - "9042:9042"
   elasticmq:


### PR DESCRIPTION
### Motivation
The `cassandra` docker-compose service pins `cassandra:4.0`, an aging release line. Cassandra 5.0 is the current stable series.

### Modification
Bump the `cassandra` service image in `docker-compose.yml` from `cassandra:4.0` to `cassandra:5.0` (currently 5.0.9).

### Result
The Cassandra integration tests run against Cassandra 5.0.

### Tests
- Not run locally - Docker unavailable in this environment; the `connectors (cassandra)` CI integration job starts this service (`docker compose up -d cassandra`) and runs the Cassandra test suite against it.

### References
None - test docker image maintenance