### PR TITLE
AWS S3: update minio docker test image to RELEASE.2025-09-07T16-13-09Z

### DIFF
--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
@@ -20,7 +20,7 @@ import java.time.Duration
 
 class MinioContainer(accessKey: String, secretKey: String, domain: String)
     extends GenericContainer(
-      "minio/minio:RELEASE.2023-04-13T03-08-07Z",
+      "minio/minio:RELEASE.2024-12-18T13-15-44Z",
       exposedPorts = List(9000),
       waitStrategy = Some(Wait.forHttp("/minio/health/ready").forPort(9000).withStartupTimeout(Duration.ofSeconds(10))),
       command = List("server", "/data"),

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
@@ -20,7 +20,7 @@ import java.time.Duration
 
 class MinioContainer(accessKey: String, secretKey: String, domain: String)
     extends GenericContainer(
-      "minio/minio:RELEASE.2024-12-18T13-15-44Z",
+      "minio/minio:RELEASE.2025-09-07T16-13-09Z",
       exposedPorts = List(9000),
       waitStrategy = Some(Wait.forHttp("/minio/health/ready").forPort(9000).withStartupTimeout(Duration.ofSeconds(10))),
       command = List("server", "/data"),


### PR DESCRIPTION
### Motivation
The S3 tests' `MinioContainer` pins `minio/minio:RELEASE.2023-04-13T03-08-07Z`, which is over three years old.

### Modification
Bump the testcontainers image in `s3/src/test/scala/.../MinioContainer.scala` to `minio/minio:RELEASE.2025-09-07T16-13-09Z`, the latest MinIO release.

### Result
The S3 MinIO-backed integration tests run against the latest MinIO release.

### Tests
- `scalafmt --list --mode diff-ref=upstream/main` - clean.
- The `connectors (s3)` CI integration job runs the MinIO-backed specs via testcontainers.

### References
None - test docker image maintenance