### PR TITLE
Kudu: update kudu docker test image to 1.18.1-ubuntu

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,7 +138,7 @@ services:
     ports:
       - "8080:8080"
   kudu-master:
-    image: apache/kudu:1.17.0
+    image: apache/kudu:1.18.1-ubuntu
     ports:
       - "7051:7051"
     command: [ "master" ]
@@ -151,7 +151,7 @@ services:
         --use_hybrid_clock=false
         --unlock_unsafe_flags=true
   kudu-tserver:
-    image: apache/kudu:1.17.0
+    image: apache/kudu:1.18.1-ubuntu
     links:
       - kudu-master
     ports:


### PR DESCRIPTION
### Motivation
The `kudu-master` and `kudu-tserver` docker-compose services pin `apache/kudu:1.17.0`. Kudu 1.18.1 is the latest release; note the image tag scheme changed - plain numeric tags stop at 1.17, and newer releases are published as `<version>-ubuntu`.

### Modification
Bump both services in `docker-compose.yml` from `apache/kudu:1.17.0` to `apache/kudu:1.18.1-ubuntu`.

### Result
The Kudu integration tests run against Kudu 1.18.1.

### Tests
- Not run locally - Docker unavailable in this environment; the `connectors (kudu)` CI integration job starts these services (`docker compose up -d kudu-master kudu-tserver`) and runs the Kudu test suite against them.

### References
None - test docker image maintenance