### PR TITLE
SNS: switch goaws test image to maintained admiralpiett fork

### DIFF
--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/BaseAwsClientTest.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/BaseAwsClientTest.scala
@@ -67,7 +67,7 @@ trait GoAwsSNSBaseAwsClientTest[C <: SdkClient] extends BaseAwsClientTest[C] {
 
   override lazy val container: GenericContainer =
     new GenericContainer(
-      dockerImage = "pafortin/goaws:v0.3.1",
+      dockerImage = "admiralpiett/goaws:v0.5.4",
       exposedPorts = Seq(exposedServicePort),
       waitStrategy = Some(TimeoutWaitStrategy(10.seconds)))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,12 @@ services:
     ports:
       - "4587:4587"
   amazonsns:
-    image: pafortin/goaws
+    image: admiralpiett/goaws:v0.5.4
     ports:
       - "4100:4100"
     volumes:
     - ./sns/src/test/travis/:/conf/
+    command: ["-config", "/conf/goaws.yaml"]
   amqp:
     image: rabbitmq:3
     ports:


### PR DESCRIPTION
### Motivation
The `amazonsns` docker-compose service uses `pafortin/goaws`, unmaintained since 2019 and pulled as an unpinned `latest`, and the aws-spi-pekko-http tests (since #1901) use `pafortin/goaws:v0.3.1`. [Admiral-Piett/goaws](https://github.com/Admiral-Piett/goaws) is the maintained successor (its README documents the lineage: versions <= v0.3.1 are `pafortin/goaws`, newer ones `admiralpiett/goaws`).

### Modification
- Switch the `amazonsns` compose service to `admiralpiett/goaws:v0.5.4` (December 2025, pinned). The fork uses the same env-sectioned YAML config format, so the existing `sns/src/test/travis/goaws.yaml` is reused unchanged; the image's entrypoint now takes an explicit `-config /conf/goaws.yaml` argument pointing at the mounted file.
- Switch the `GoAwsSNSBaseAwsClientTest` testcontainers image in aws-spi-pekko-http from `pafortin/goaws:v0.3.1` to `admiralpiett/goaws:v0.5.4` as well (rebased on #1901).

### Result
The SNS and aws-spi-pekko-http tests run against a maintained, pinned goaws release.

### Tests
- `sbt aws-spi-pekko-http/Test/compile` passes locally; `scalafmt --list --mode diff-ref=upstream/main` clean.
- The `connectors (sns)` CI job (already passed on the pre-rebase head) and the `connectors (aws-spi-pekko-http)` CI job validate both usages.

### References
Refs #1901