### PR TITLE
DynamoDB: use official amazon/dynamodb-local test image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     ports:
       - "9324:9324"
   dynamodb:
-    image: deangiberson/aws-dynamodb-local
+    image: amazon/dynamodb-local:3.3.1
     ports:
       - "8001:8000"
   elasticsearch6:


### PR DESCRIPTION
### Motivation
The `dynamodb` docker-compose service uses `deangiberson/aws-dynamodb-local`, an unpinned third-party image last updated in 2017. Amazon publishes an official, maintained `amazon/dynamodb-local` image.

### Modification
Switch the service to `amazon/dynamodb-local:3.3.1` (latest release, July 2026). The official image serves on container port 8000 by default, same as the old image, so the existing `8001:8000` mapping and the tests' `localhost:8001` endpoint are unchanged.

### Result
The DynamoDB integration tests run against the official, pinned DynamoDB Local release.

### Tests
- Not run locally - the `connectors (dynamodb)` CI integration job starts this service (`docker compose up -d dynamodb`) and runs the DynamoDB suite against it.

### References
None - test docker image maintenance