### PR TITLE
JMS: update IBM MQ test image to icr.io/ibm-messaging/mq

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
     environment:
       LICENSE: accept
       MQ_QMGR_NAME: QM1
+      MQ_APP_PASSWORD: passw0rd
     ports:
       - "1414:1414"
       - "9443:9443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - 16201:16201
       - 16301:16301
   ibmmq:
-    image: ibmcom/mq:latest
+    image: icr.io/ibm-messaging/mq:9.4.5.1-r1
     environment:
       LICENSE: accept
       MQ_QMGR_NAME: QM1

--- a/docs/src/main/paradox/jms/ibm-mq.md
+++ b/docs/src/main/paradox/jms/ibm-mq.md
@@ -5,7 +5,7 @@ and creating a `JmsConsumerSettings` or `JmsProducerSettings` from it.
 The below snippets have been tested with a default IBM MQ docker image which contains queues and topics for testing.
 The following command starts MQ using docker:
 
-    docker run --env LICENSE=accept --env MQ_QMGR_NAME=QM1 --publish 1414:1414 --publish 9443:9443 icr.io/ibm-messaging/mq:9.4.5.1-r1
+    docker run --env LICENSE=accept --env MQ_QMGR_NAME=QM1 --env MQ_APP_PASSWORD=passw0rd --publish 1414:1414 --publish 9443:9443 icr.io/ibm-messaging/mq:9.4.5.1-r1
 
 MQ settings for this image are shown here: https://github.com/ibm-messaging/mq-container/blob/master/docs/developer-config.md
 

--- a/docs/src/main/paradox/jms/ibm-mq.md
+++ b/docs/src/main/paradox/jms/ibm-mq.md
@@ -3,11 +3,11 @@
 You can use IBM MQ like any other JMS Provider by creating a `QueueConnectionFactory` or a `TopicConnectionFactory`
 and creating a `JmsConsumerSettings` or `JmsProducerSettings` from it.
 The below snippets have been tested with a default IBM MQ docker image which contains queues and topics for testing.
-The following command starts MQ 9 using docker:
+The following command starts MQ using docker:
 
-    docker run --env LICENSE=accept --env MQ_QMGR_NAME=QM1 --publish 1414:1414 --publish 9443:9443 ibmcom/mq:9.1.1.0
+    docker run --env LICENSE=accept --env MQ_QMGR_NAME=QM1 --publish 1414:1414 --publish 9443:9443 icr.io/ibm-messaging/mq:9.4.5.1-r1
 
-MQ settings for this image are shown here: https://github.com/ibm-messaging/mq-docker#mq-developer-defaults
+MQ settings for this image are shown here: https://github.com/ibm-messaging/mq-container/blob/master/docs/developer-config.md
 
 ## Artifacts
 

--- a/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -74,7 +74,7 @@ public class JmsIbmmqConnectorsTest {
   private static MQConnectionFactory initDefaultFactory(MQConnectionFactory connectionFactory)
       throws JMSException {
     // #ibmmq-connection-factory
-    // align to docker image: ibmcom/mq:9.1.1.0
+    // align to docker image: icr.io/ibm-messaging/mq
     connectionFactory.setHostName("localhost");
     connectionFactory.setPort(1414);
     connectionFactory.setQueueManager("QM1");

--- a/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jakartams/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -19,6 +19,7 @@ import com.ibm.mq.jakarta.jms.MQConnectionFactory;
 import com.ibm.mq.jakarta.jms.MQQueueConnectionFactory;
 import com.ibm.mq.jakarta.jms.MQQueueSession;
 import com.ibm.mq.jakarta.jms.MQTopicConnectionFactory;
+import com.ibm.msg.client.jakarta.jms.JmsConstants;
 import com.ibm.msg.client.jakarta.wmq.common.CommonConstants;
 import jakarta.jms.Destination;
 import jakarta.jms.JMSException;
@@ -79,6 +80,9 @@ public class JmsIbmmqConnectorsTest {
     connectionFactory.setPort(1414);
     connectionFactory.setQueueManager("QM1");
     connectionFactory.setChannel("DEV.APP.SVRCONN");
+    // the developer image requires a password for the "app" user since MQ 9.3.4
+    connectionFactory.setStringProperty(JmsConstants.USERID, "app");
+    connectionFactory.setStringProperty(JmsConstants.PASSWORD, "passw0rd");
 
     // #ibmmq-connection-factory
     return connectionFactory;

--- a/jakartams/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
@@ -128,6 +128,8 @@ class JmsIbmmqConnectorsSpec extends JmsSpec {
       topicConnectionFactory.setPort(1414)
       topicConnectionFactory.setQueueManager("QM1")
       topicConnectionFactory.setChannel("DEV.APP.SVRCONN")
+      topicConnectionFactory.setStringProperty(JmsConstants.USERID, "app")
+      topicConnectionFactory.setStringProperty(JmsConstants.PASSWORD, "passw0rd")
 
       // #ibmmq-topic
       // Connect to IBM MQ over TCP/IP

--- a/jakartams/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
@@ -35,7 +35,7 @@ class JmsIbmmqConnectorsSpec extends JmsSpec {
       // Create the IBM MQ MQQueueConnectionFactory
       val connectionFactory = new MQQueueConnectionFactory()
 
-      // align to docker image: ibmcom/mq:9.1.1.0
+      // align to docker image: icr.io/ibm-messaging/mq
       connectionFactory.setHostName("localhost")
       connectionFactory.setPort(1414)
       connectionFactory.setQueueManager("QM1")

--- a/jakartams/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
+++ b/jakartams/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
@@ -14,6 +14,7 @@
 package docs.scaladsl
 
 import com.ibm.mq.jakarta.jms.{ MQQueueConnectionFactory, MQQueueSession, MQTopicConnectionFactory }
+import com.ibm.msg.client.jakarta.jms.JmsConstants
 import com.ibm.msg.client.jakarta.wmq.common.CommonConstants
 import org.apache.pekko
 import pekko.Done
@@ -40,6 +41,9 @@ class JmsIbmmqConnectorsSpec extends JmsSpec {
       connectionFactory.setPort(1414)
       connectionFactory.setQueueManager("QM1")
       connectionFactory.setChannel("DEV.APP.SVRCONN")
+      // the developer image requires a password for the "app" user since MQ 9.3.4
+      connectionFactory.setStringProperty(JmsConstants.USERID, "app")
+      connectionFactory.setStringProperty(JmsConstants.PASSWORD, "passw0rd")
 
       // #ibmmq-connection-factory
 

--- a/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -74,7 +74,7 @@ public class JmsIbmmqConnectorsTest {
   private static MQConnectionFactory initDefaultFactory(MQConnectionFactory connectionFactory)
       throws JMSException {
     // #ibmmq-connection-factory
-    // align to docker image: ibmcom/mq:9.1.1.0
+    // align to docker image: icr.io/ibm-messaging/mq
     connectionFactory.setHostName("localhost");
     connectionFactory.setPort(1414);
     connectionFactory.setQueueManager("QM1");

--- a/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
+++ b/jms/src/test/java/docs/javadsl/JmsIbmmqConnectorsTest.java
@@ -19,6 +19,7 @@ import com.ibm.mq.jms.MQConnectionFactory;
 import com.ibm.mq.jms.MQQueueConnectionFactory;
 import com.ibm.mq.jms.MQQueueSession;
 import com.ibm.mq.jms.MQTopicConnectionFactory;
+import com.ibm.msg.client.jms.JmsConstants;
 import com.ibm.msg.client.wmq.common.CommonConstants;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -79,6 +80,9 @@ public class JmsIbmmqConnectorsTest {
     connectionFactory.setPort(1414);
     connectionFactory.setQueueManager("QM1");
     connectionFactory.setChannel("DEV.APP.SVRCONN");
+    // the developer image requires a password for the "app" user since MQ 9.3.4
+    connectionFactory.setStringProperty(JmsConstants.USERID, "app");
+    connectionFactory.setStringProperty(JmsConstants.PASSWORD, "passw0rd");
 
     // #ibmmq-connection-factory
     return connectionFactory;

--- a/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
@@ -19,6 +19,7 @@ import pekko.stream.connectors.jms._
 import pekko.stream.connectors.jms.scaladsl.{ JmsConsumer, JmsConsumerControl, JmsProducer }
 import pekko.stream.scaladsl.{ Sink, Source }
 import com.ibm.mq.jms.{ MQQueueConnectionFactory, MQQueueSession, MQTopicConnectionFactory }
+import com.ibm.msg.client.jms.JmsConstants
 import com.ibm.msg.client.wmq.common.CommonConstants
 import javax.jms.{ Session, TextMessage }
 import scala.collection.immutable
@@ -39,6 +40,9 @@ class JmsIbmmqConnectorsSpec extends JmsSpec {
       connectionFactory.setPort(1414)
       connectionFactory.setQueueManager("QM1")
       connectionFactory.setChannel("DEV.APP.SVRCONN")
+      // the developer image requires a password for the "app" user since MQ 9.3.4
+      connectionFactory.setStringProperty(JmsConstants.USERID, "app")
+      connectionFactory.setStringProperty(JmsConstants.PASSWORD, "passw0rd")
 
       // #ibmmq-connection-factory
 

--- a/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
@@ -127,6 +127,8 @@ class JmsIbmmqConnectorsSpec extends JmsSpec {
       topicConnectionFactory.setPort(1414)
       topicConnectionFactory.setQueueManager("QM1")
       topicConnectionFactory.setChannel("DEV.APP.SVRCONN")
+      topicConnectionFactory.setStringProperty(JmsConstants.USERID, "app")
+      topicConnectionFactory.setStringProperty(JmsConstants.PASSWORD, "passw0rd")
 
       // #ibmmq-topic
       // Connect to IBM MQ over TCP/IP

--- a/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
+++ b/jms/src/test/scala/docs/scaladsl/JmsIbmmqConnectorsSpec.scala
@@ -34,7 +34,7 @@ class JmsIbmmqConnectorsSpec extends JmsSpec {
       // Create the IBM MQ MQQueueConnectionFactory
       val connectionFactory = new MQQueueConnectionFactory()
 
-      // align to docker image: ibmcom/mq:9.1.1.0
+      // align to docker image: icr.io/ibm-messaging/mq
       connectionFactory.setHostName("localhost")
       connectionFactory.setPort(1414)
       connectionFactory.setQueueManager("QM1")


### PR DESCRIPTION
### Motivation
The `ibmmq` docker-compose service (used by both the `jms` and `jakartams` CI jobs) pulls `ibmcom/mq:latest`. The `ibmcom` Docker Hub namespace was abandoned in December 2021 — its `latest` is actually MQ 9.2.4, and IBM has removed `ibmcom` images before, so two active CI jobs sit on a dead, unpinned image. IBM MQ images are now published to the IBM Container Registry as `icr.io/ibm-messaging/mq`.

### Modification
- Switch the `ibmmq` service to `icr.io/ibm-messaging/mq:9.4.5.1-r1` (current release, pinned).
- Since MQ 9.3.4 the developer image no longer allows the `app` user on `DEV.APP.SVRCONN` to connect without a password (the first CI run failed uniformly with `MQRC_NOT_AUTHORIZED`), so set `MQ_APP_PASSWORD` on the service and supply the `app` credentials in the four jms/jakartams IBM MQ test files via `setStringProperty(JmsConstants.USERID/PASSWORD, ...)` on the connection factories — these blocks are doc snippets, so the docs now show what real users of current images must do. (`MQ_APP_PASSWORD` is deprecated in 9.4 in favour of container secrets but still functional; secrets can follow if it is ever removed.)
- Update the docker run command and developer-defaults link in `docs/src/main/paradox/jms/ibm-mq.md` (the old `mq-docker` repo moved to `mq-container`) and the image reference comments in the test files.

### Result
The JMS and Jakarta Messaging IBM MQ integration tests run against a current, pinned IBM MQ release from IBM's own registry.

### Tests
- `sbt jms/Test/compile jakartams/Test/compile` passes locally; `scalafmt --list --mode diff-ref=upstream/main` and `javafmtCheckAll` for the two modules are clean.
- The `connectors (jms)` and `connectors (jakartams)` CI jobs start this service (`docker compose up -d ibmmq`) and run their suites against it.

### References
None - test docker image maintenance