### PR TITLE
Google Cloud Pub/Sub: drop unmaintained prep image, provision emulator via REST

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,20 +94,25 @@ services:
       - "8538:8538"
     command: gcloud beta emulators pubsub start --project=pekko-connectors --host-port=0.0.0.0:8538
   gcloud-pubsub-emulator_prep:
-    image: martynas/gcloud-pubsub-client
+    # same image as the emulator itself; creates the topics and subscriptions
+    # the tests expect, via the emulator's REST API
+    image: google/cloud-sdk:554.0.0
     links:
       - "gcloud-pubsub-emulator"
-    environment:
-      - "PUBSUB_PROJECT_ID=pekko-connectors"
-      - "PUBSUB_EMULATOR_HOST=gcloud-pubsub-emulator:8538"
     entrypoint: ""
-    command: >
-      bash -c "
-        python publisher.py pekko-connectors create simpleTopic &&
-        python subscriber.py pekko-connectors create simpleTopic simpleSubscription
-        python publisher.py pekko-connectors create testTopic &&
-        python subscriber.py pekko-connectors create testTopic testSubscription
-      "
+    command:
+      - bash
+      - -c
+      - |
+        set -ex
+        base=http://gcloud-pubsub-emulator:8538/v1/projects/pekko-connectors
+        until curl -s --fail $base/topics > /dev/null; do
+          sleep 2
+        done
+        curl -s -X PUT $base/topics/simpleTopic
+        curl -s -X PUT -H "Content-Type: application/json" -d '{"topic": "projects/pekko-connectors/topics/simpleTopic"}' $base/subscriptions/simpleSubscription
+        curl -s -X PUT $base/topics/testTopic
+        curl -s -X PUT -H "Content-Type: application/json" -d '{"topic": "projects/pekko-connectors/topics/testTopic"}' $base/subscriptions/testSubscription
   hbase:
     image: harisekhon/hbase:1.4
     hostname: hbase

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,14 +105,13 @@ services:
       - -c
       - |
         set -ex
-        base=http://gcloud-pubsub-emulator:8538/v1/projects/pekko-connectors
-        until curl -s --fail $base/topics > /dev/null; do
+        until curl -s --fail http://gcloud-pubsub-emulator:8538/v1/projects/pekko-connectors/topics > /dev/null; do
           sleep 2
         done
-        curl -s -X PUT $base/topics/simpleTopic
-        curl -s -X PUT -H "Content-Type: application/json" -d '{"topic": "projects/pekko-connectors/topics/simpleTopic"}' $base/subscriptions/simpleSubscription
-        curl -s -X PUT $base/topics/testTopic
-        curl -s -X PUT -H "Content-Type: application/json" -d '{"topic": "projects/pekko-connectors/topics/testTopic"}' $base/subscriptions/testSubscription
+        curl -s --fail -X PUT http://gcloud-pubsub-emulator:8538/v1/projects/pekko-connectors/topics/simpleTopic
+        curl -s --fail -X PUT -H "Content-Type: application/json" -d '{"topic": "projects/pekko-connectors/topics/simpleTopic"}' http://gcloud-pubsub-emulator:8538/v1/projects/pekko-connectors/subscriptions/simpleSubscription
+        curl -s --fail -X PUT http://gcloud-pubsub-emulator:8538/v1/projects/pekko-connectors/topics/testTopic
+        curl -s --fail -X PUT -H "Content-Type: application/json" -d '{"topic": "projects/pekko-connectors/topics/testTopic"}' http://gcloud-pubsub-emulator:8538/v1/projects/pekko-connectors/subscriptions/testSubscription
   hbase:
     image: harisekhon/hbase:1.4
     hostname: hbase


### PR DESCRIPTION
### Motivation
The `gcloud-pubsub-emulator_prep` docker-compose service uses `martynas/gcloud-pubsub-client`, an unpinned third-party image last updated in 2018, just to create the two topics and two subscriptions the `google-cloud-pub-sub` and `google-cloud-pub-sub-grpc` integration tests expect.

### Modification
Replace it with the Pub/Sub emulator's own REST API: the prep service now runs the same `google/cloud-sdk` image as the emulator (so no additional image is pulled at all), waits for the emulator to answer, then issues four `curl` PUTs to create `simpleTopic`/`simpleSubscription` and `testTopic`/`testSubscription`. The `gcloud` CLI cannot target the emulator for resource creation, which is why the REST API is used.

Note: #1886 bumps the sibling emulator service's `google/cloud-sdk` tag to 583.0.0; this PR uses the tag currently on main (554.0.0) for the prep service, and whichever PR lands second should align the two tags (a one-line follow-up).

### Result
The Pub/Sub emulator tests no longer depend on an abandoned third-party image; the prep logic is visible in the compose file.

### Tests
- `docker compose config` validates.
- The `connectors (google-cloud-pub-sub)` and `connectors (google-cloud-pub-sub-grpc)` CI jobs start this service (`docker compose up -d gcloud-pubsub-emulator_prep`) and their suites depend on the topics/subscriptions it creates.

### References
None - test docker image maintenance