### PR TITLE
AWS EventBridge: replace last localstack usage with motoserver/moto

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,12 +4,9 @@
 
 services:
   amazoneventbridge:
-    image: localstack/localstack:0.10.7
-    environment:
-      - "SERVICES=events"
-      - "DEBUG=true"
+    image: motoserver/moto:5.2.3
     ports:
-      - "4587:4587"
+      - "4587:5000"
   amazonsns:
     image: pafortin/goaws
     ports:


### PR DESCRIPTION
### Motivation
The `amazoneventbridge` docker-compose service is the last LocalStack usage in the repo (now that #1901 moved the aws-spi tests to dynamodb-local/goaws), pinned to `localstack/localstack:0.10.7` from 2020. Newer LocalStack releases require an auth token (#1517), so the pin is a dead end.

### Modification
Switch the service to `motoserver/moto:5.2.3` (actively maintained, Apache-2.0). Moto's server mode implements the EventBridge `events` API; the aws-event-bridge tests only exercise `PutEvents`, which moto supports. Moto listens on container port 5000, so the mapping becomes `4587:5000` and the tests' `http://localhost:4587` endpoint is unchanged; the LocalStack-specific `SERVICES`/`DEBUG` environment is dropped.

### Result
The EventBridge integration tests run against a maintained mock, and the repo no longer depends on LocalStack anywhere.

### Tests
- `docker compose config` validates.
- The `connectors (aws-event-bridge)` CI job starts this service (`docker compose up -d amazoneventbridge`) and runs the EventBridge suite against it.

### References
Refs #1517