### PR TITLE
HDFS: remove obsolete cats-kernel cache probe from CI

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -122,7 +122,7 @@ jobs:
           - { connector: google-fcm }
           # hbase disabled until we resolve why new docker image fails our build: https://github.com/akka/alpakka/issues/2185
           # - { connector: hbase,                        pre_cmd: 'docker compose up -d hbase' }
-          - { connector: hdfs,                         pre_cmd: 'file ${HOME}/.cache/coursier/v1/https/repo1.maven.org/maven2/org/typelevel/cats-kernel_2.13/2.0.0/cats-kernel_2.13-2.0.0.jar' }
+          - { connector: hdfs }
           - { connector: huawei-push-kit }
           - { connector: influxdb,                     pre_cmd: 'docker compose up -d influxdb' }
           # ironmq disabled while we resolve https://github.com/apache/pekko-connectors/issues/697


### PR DESCRIPTION
### Motivation
The hdfs CI matrix entry carries `pre_cmd: 'file ${HOME}/.cache/coursier/.../cats-kernel_2.13-2.0.0.jar'`. This was a debugging probe added for akka/alpakka#2436 (October 2020), when a corrupted cats-kernel jar kept poisoning the Travis coursier cache — the `file` call printed what the cached file actually was whenever the failure recurred. It sets nothing up and gates nothing (`file` exits 0 even for a missing path). The Travis cache it investigated is long gone, CI now uses `coursier/cache-action`, and the build is on cats-core 2.13.0, so the probe inspects a jar that is not even in the cache — it has printed "No such file" into every hdfs job log since, surviving the Travis-to-Actions port and the alpakka fork by copy-paste.

### Modification
Drop the `pre_cmd` from the hdfs matrix entry.

### Result
The hdfs CI job runs its tests exactly as before, without the dead diagnostic.

### Tests
- Not run locally - CI-config-only change; the `connectors (hdfs)` job on this PR demonstrates the unchanged behavior.

### References
Refs https://github.com/akka/alpakka/issues/2436