### PR TITLE
AWS SPI: make close() non-throwing and give auto-created actor systems unique names

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -19,6 +19,7 @@ package org.apache.pekko.stream.connectors.awsspi
 
 import java.util.Locale
 import java.util.concurrent.{ CompletableFuture, TimeUnit }
+import java.util.concurrent.atomic.AtomicLong
 import java.nio.charset.StandardCharsets
 import java.security.SecureRandom
 import java.security.cert.X509Certificate
@@ -44,6 +45,7 @@ import software.amazon.awssdk.utils.AttributeMap
 import scala.collection.immutable
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ Await, ExecutionContext }
+import scala.util.control.NonFatal
 import scala.jdk.DurationConverters._
 import scala.jdk.OptionConverters._
 
@@ -53,7 +55,7 @@ class PekkoHttpClient(
     private[awsspi] val connectionContext: HttpsConnectionContext
 )(
     implicit
-    actorSystem: ActorSystem,
+    private[awsspi] val actorSystem: ActorSystem,
     ec: ExecutionContext) extends SdkAsyncHttpClient {
   import PekkoHttpClient._
 
@@ -69,7 +71,11 @@ class PekkoHttpClient(
   }
 
   override def close(): Unit =
-    shutdownHandle()
+    try shutdownHandle()
+    catch {
+      case NonFatal(e) =>
+        logger.warn("Failure while shutting down the PekkoHttpClient", e)
+    }
 
   override def clientName(): String = "pekko-http"
 }
@@ -77,6 +83,8 @@ class PekkoHttpClient(
 object PekkoHttpClient {
 
   val logger = LoggerFactory.getLogger(this.getClass)
+
+  private val autoCreatedSystemCounter = new AtomicLong()
 
   private[awsspi] def toPekkoRequest(request: SdkHttpRequest,
       contentPublisher: SdkHttpContentPublisher): HttpRequest = {
@@ -197,7 +205,10 @@ object PekkoHttpClient {
         (c, _) => c)
       extends SdkAsyncHttpClient.Builder[PekkoHttpClientBuilder] {
     def buildWithDefaults(serviceDefaults: AttributeMap): SdkAsyncHttpClient = {
-      implicit val as = actorSystem.getOrElse(ActorSystem("aws-pekko-http"))
+      // Give each auto-created system a unique name so that multiple clients in one JVM
+      // remain distinguishable in logs and thread names.
+      implicit val as = actorSystem.getOrElse(
+        ActorSystem(s"aws-pekko-http-${autoCreatedSystemCounter.incrementAndGet()}"))
       implicit val ec = executionContext.getOrElse(as.dispatcher)
 
       val resolvedOptions = serviceDefaults.merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS);

--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
@@ -19,9 +19,12 @@ package org.apache.pekko.stream.connectors.awsspi
 
 import java.util.Collections
 import java.nio.ByteBuffer
+import javax.net.ssl.SSLContext
 import com.typesafe.config.ConfigFactory
 
 import org.apache.pekko
+import pekko.actor.ActorSystem
+import pekko.http.scaladsl.ConnectionContext
 import pekko.http.scaladsl.model.headers.`Content-Type`
 import pekko.http.scaladsl.model.{ ContentTypes, HttpMethods, MediaTypes }
 import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
@@ -33,6 +36,7 @@ import software.amazon.awssdk.http.SdkHttpConfigurationOption
 import software.amazon.awssdk.http.async.SdkHttpContentPublisher
 import software.amazon.awssdk.utils.AttributeMap
 
+import scala.concurrent.Await
 import scala.concurrent.duration._
 import scala.jdk.DurationConverters._
 
@@ -159,6 +163,36 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
         .asInstanceOf[PekkoHttpClient]
 
       pekkoClient.connectionSettings shouldBe connectionPoolSettings
+    }
+
+    "give each auto-created client a uniquely named actor system" in {
+      val client1 = new PekkoHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .build()
+        .asInstanceOf[PekkoHttpClient]
+      val client2 = new PekkoHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .build()
+        .asInstanceOf[PekkoHttpClient]
+      try {
+        client1.actorSystem.name should startWith("aws-pekko-http")
+        client2.actorSystem.name should startWith("aws-pekko-http")
+        client1.actorSystem.name should not be client2.actorSystem.name
+      } finally {
+        client1.close()
+        client2.close()
+      }
+    }
+
+    "not propagate failures from the shutdown handle on close()" in {
+      implicit val system: ActorSystem = ActorSystem("pekko-http-client-close-spec")
+      try {
+        val client = new PekkoHttpClient(
+          () => throw new IllegalStateException("simulated shutdown failure"),
+          ConnectionPoolSettings(system),
+          ConnectionContext.httpsClient(SSLContext.getDefault))(system, system.dispatcher)
+        noException should be thrownBy client.close()
+      } finally {
+        Await.result(system.terminate(), 10.seconds)
+      }
     }
 
     "withConnectionPoolSettings().build() should use passed ConnectionPoolSettings" in {


### PR DESCRIPTION
### Motivation
`SdkAsyncHttpClient.close()` is an AutoCloseable-style method that SDK callers do not expect to throw, but the builder's shutdown handle blocks with `Await.result(..., 10s)` and could propagate a `TimeoutException` (or any termination failure) out of `close()`. Separately, every client built without an explicit `ActorSystem` created a system named `aws-pekko-http`, so multiple clients in one JVM produced identically named actor systems that are indistinguishable in logs and thread names.

### Modification
- `PekkoHttpClient.close()` now catches `NonFatal` failures from the shutdown handle and logs a warning instead of throwing.
- Auto-created actor system names get a monotonically increasing suffix (`aws-pekko-http-1`, `aws-pekko-http-2`, ...).
- The client's actor system is exposed as `private[awsspi]` for the new tests (binary-additive).

### Result
`close()` never throws to SDK callers, and each auto-created client gets a uniquely named actor system.

### Tests
- `sbt "aws-spi-pekko-http/Test/testOnly org.apache.pekko.stream.connectors.awsspi.PekkoHttpClientSpec"` — 13 passed, including 2 new directional tests ("give each auto-created client a uniquely named actor system", "not propagate failures from the shutdown handle on close()"); both fail without the fix
- `sbt "aws-spi-pekko-http/Test/testOnly ...RequestRunnerSpec ...PekkoHttpClientH1TestSuite"` — 8 passed
- `sbt "aws-spi-pekko-http/mimaReportBinaryIssues"` — no issues
- `scalafmt --mode diff-ref=origin/main` — clean; no Java files changed, no new files (no header changes needed)

### References
None - hardening found during a review of the aws-spi-pekko-http client

🤖 Generated with [Claude Code](https://claude.com/claude-code)