### PR TITLE
AWS SPI: preserve content-type parameters and drop unreachable map entry

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -167,7 +167,7 @@ object PekkoHttpClient {
   }
 
   private[awsspi] def tryCreateCustomContentType(contentTypeStr: String): ContentType = {
-    logger.debug(s"Try to parse content type from $contentTypeStr")
+    logger.debug("Try to parse content type from {}", contentTypeStr)
     // Prefer a proper parse so that values with parameters (e.g. "text/plain; charset=UTF-8")
     // keep their parameters instead of ending up embedded in the subtype.
     ContentType.parse(contentTypeStr) match {

--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -168,10 +168,16 @@ object PekkoHttpClient {
 
   private[awsspi] def tryCreateCustomContentType(contentTypeStr: String): ContentType = {
     logger.debug(s"Try to parse content type from $contentTypeStr")
-    val mainAndsubType = contentTypeStr.split('/')
-    if (mainAndsubType.length == 2)
-      ContentType(MediaType.customBinary(mainAndsubType(0), mainAndsubType(1), Compressible))
-    else throw new RuntimeException(s"Could not parse custom content type '$contentTypeStr'.")
+    // Prefer a proper parse so that values with parameters (e.g. "text/plain; charset=UTF-8")
+    // keep their parameters instead of ending up embedded in the subtype.
+    ContentType.parse(contentTypeStr) match {
+      case Right(contentType) => contentType
+      case Left(_)            =>
+        val mainAndsubType = contentTypeStr.split('/')
+        if (mainAndsubType.length == 2)
+          ContentType(MediaType.customBinary(mainAndsubType(0), mainAndsubType(1), Compressible))
+        else throw new RuntimeException(s"Could not parse custom content type '$contentTypeStr'.")
+    }
   }
 
   private[awsspi] def buildConnectionPoolSettings(
@@ -248,7 +254,8 @@ object PekkoHttpClient {
     "application/x-amz-json-1.0" -> xAmzJson,
     "application/x-amz-json-1.1" -> xAmzJson11,
     "application/x-amz-cbor-1.1" -> xAmzCbor11, // used by Kinesis
-    "application/x-www-form-urlencoded; charset-UTF-8" -> formUrlEncoded,
+    // No charset-suffixed key is needed: `application/x-www-form-urlencoded` is a fixed-charset
+    // media type, so a parsed Content-Type header always renders without a charset parameter.
     "application/x-www-form-urlencoded" -> formUrlEncoded,
     "application/xml" -> applicationXml)
 

--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
@@ -23,7 +23,7 @@ import com.typesafe.config.ConfigFactory
 
 import org.apache.pekko
 import pekko.http.scaladsl.model.headers.`Content-Type`
-import pekko.http.scaladsl.model.{ ContentTypes, HttpMethods, MediaTypes }
+import pekko.http.scaladsl.model.{ ContentTypes, HttpHeader, HttpMethods, MediaTypes }
 import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
 import org.reactivestreams.Subscriber
 import org.scalatest.OptionValues
@@ -44,6 +44,29 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
       val contentTypeStr = "application/xml"
       val contentType = PekkoHttpClient.tryCreateCustomContentType(contentTypeStr)
       contentType.mediaType should be(MediaTypes.`application/xml`)
+    }
+
+    "parse custom content type with parameters preserving the parameters" in {
+      val contentType = PekkoHttpClient.tryCreateCustomContentType("text/plain; charset=UTF-8")
+      contentType.mediaType.mainType shouldBe "text"
+      contentType.mediaType.subType shouldBe "plain"
+      contentType.charsetOption.map(_.value) shouldBe Some("UTF-8")
+    }
+
+    "fall back to a custom binary content type when proper parsing fails" in {
+      val contentType = PekkoHttpClient.tryCreateCustomContentType("foo/bar baz")
+      contentType.mediaType.mainType shouldBe "foo"
+      contentType.mediaType.subType shouldBe "bar baz"
+    }
+
+    "map form-urlencoded content type with charset to the predefined content type" in {
+      val header = HttpHeader.parse("Content-Type", "application/x-www-form-urlencoded; charset=UTF-8") match {
+        case HttpHeader.ParsingResult.Ok(h, _) => h
+        case error                             => fail(s"could not parse header: $error")
+      }
+      val contentType = PekkoHttpClient.contentTypeHeaderToContentType(Some(header))
+      contentType.mediaType.subType shouldBe "x-www-form-urlencoded"
+      contentType shouldBe PekkoHttpClient.formUrlEncoded
     }
 
     "remove 'ContentType' return 'ContentLength' separate from sdk headers" in {


### PR DESCRIPTION
### Motivation
`PekkoHttpClient.tryCreateCustomContentType` split content-type values only on `/`, so a value with parameters (e.g. `text/plain; charset=UTF-8`) produced a custom binary media type whose subtype embedded the parameters (`plain; charset=UTF-8`) instead of a properly modeled `ContentType`. The `contentTypeMap` also carried an entry keyed `"application/x-www-form-urlencoded; charset-UTF-8"` (typo: `-` instead of `=`); the key is unreachable either way, because the lookup value is the re-rendered parsed `Content-Type` header, and pekko-http renders the fixed-charset form-urlencoded media type without a charset parameter.

### Modification
- `tryCreateCustomContentType` now tries `ContentType.parse` first and only falls back to the legacy `/`-split custom binary media type when proper parsing fails.
- Removed the unreachable typo'd map entry, with a comment explaining why no charset-suffixed key is needed.
- The debug log in `tryCreateCustomContentType` now uses slf4j parameterized logging instead of eager string interpolation.

### Result
Content-type values with parameters keep their parameters in the request entity's `ContentType`; unparseable values retain the previous fallback behavior; no behavior change for the mapped AWS content types (`x-amz-json`, `x-amz-cbor`, etc.).

### Tests
- `sbt "aws-spi-pekko-http/Test/testOnly org.apache.pekko.stream.connectors.awsspi.PekkoHttpClientSpec"` — 14 passed, 3 new tests: parameters preservation (fails without the fix — verified by reverting the main source), legacy fallback retention, and a characterization test that a parsed form-urlencoded header with an explicit charset still maps via the bare key
- `sbt "aws-spi-pekko-http/mimaReportBinaryIssues"` — no issues
- `scalafmt --mode diff-ref=origin/main` — clean; no Java files changed, no new files (no header changes needed)

### References
None - found during a review of the aws-spi-pekko-http client

🤖 Generated with [Claude Code](https://claude.com/claude-code)
