### PR TITLE
AWS SPI: accept multi-value request headers instead of throwing

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -143,28 +143,41 @@ object PekkoHttpClient {
     headersAsScala.foldLeft((Option.empty[HttpHeader], List.empty[HttpHeader], Option.empty[Long])) {
       case ((ctHeader, hdrs, contentLength), header) =>
         val (headerName, headerValue) = header
-        if (headerValue.size() != 1) {
-          throw new IllegalArgumentException(
-            s"Found invalid header: key: $headerName, Value: ${val list = List.newBuilder[String]
-              headerValue.forEach(v => list += v)
-              list.result()}.")
+        val values = {
+          val list = List.newBuilder[String]
+          headerValue.forEach(v => list += v)
+          list.result()
         }
+        def requireSingleValue(): String = {
+          if (values.size != 1) {
+            throw new IllegalArgumentException(s"Found invalid header: key: $headerName, Value: $values.")
+          }
+          values.head
+        }
+        if (values.isEmpty) {
+          throw new IllegalArgumentException(s"Found invalid header with no values: key: $headerName.")
+        }
+        val lowercaseName = headerName.toLowerCase(Locale.ROOT)
         // skip content-length as it will be managed by pekko-http in the entity, but capture its value
         // so we can use it to build a fixed-length entity, preventing a fallback to chunked transfer encoding
-        if (`Content-Length`.lowercaseName == headerName.toLowerCase(Locale.ROOT))
-          (ctHeader, hdrs, Some(headerValue.get(0).toLong))
-        else {
-          HttpHeader.parse(headerName, headerValue.get(0)) match {
-            case ok: Ok =>
-              // return content-type separately as it will be used to calculate ContentType, which is used on HttpEntity
-              if (ok.header.lowercaseName() == `Content-Type`.lowercaseName) (Some(ok.header), hdrs, contentLength)
-              else (ctHeader, hdrs :+ ok.header, contentLength)
-            case error: ParsingResult.Error =>
-              throw new IllegalArgumentException(s"Found invalid header: ${error.errors}.")
-          }
+        if (`Content-Length`.lowercaseName == lowercaseName)
+          (ctHeader, hdrs, Some(requireSingleValue().toLong))
+        else if (`Content-Type`.lowercaseName == lowercaseName) {
+          // return content-type separately as it will be used to calculate ContentType, which is used on HttpEntity
+          (Some(parseHeader(headerName, requireSingleValue())), hdrs, contentLength)
+        } else {
+          // repeated header fields are valid HTTP; emit one header per value
+          (ctHeader, hdrs ::: values.map(parseHeader(headerName, _)), contentLength)
         }
     }
   }
+
+  private def parseHeader(headerName: String, headerValue: String): HttpHeader =
+    HttpHeader.parse(headerName, headerValue) match {
+      case ok: Ok                     => ok.header
+      case error: ParsingResult.Error =>
+        throw new IllegalArgumentException(s"Found invalid header: ${error.errors}.")
+    }
 
   private[awsspi] def tryCreateCustomContentType(contentTypeStr: String): ContentType = {
     logger.debug(s"Try to parse content type from $contentTypeStr")

--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
@@ -59,6 +59,39 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
       contentLength shouldBe Some(123L)
     }
 
+    "convert a multi-value header to one header per value" in {
+      val headers = new java.util.HashMap[String, java.util.List[String]]
+      headers.put("Accept-Encoding", java.util.Arrays.asList("gzip", "deflate"))
+
+      val (contentTypeHeader, reqHeaders, contentLength) = PekkoHttpClient.convertHeaders(headers)
+
+      contentTypeHeader shouldBe None
+      contentLength shouldBe None
+      reqHeaders.map(h => (h.name(), h.value())) should contain theSameElementsInOrderAs
+      Seq(("Accept-Encoding", "gzip"), ("Accept-Encoding", "deflate"))
+    }
+
+    "reject a Content-Length header with multiple values" in {
+      val headers = new java.util.HashMap[String, java.util.List[String]]
+      headers.put("Content-Length", java.util.Arrays.asList("123", "456"))
+
+      an[IllegalArgumentException] should be thrownBy PekkoHttpClient.convertHeaders(headers)
+    }
+
+    "reject a Content-Type header with multiple values" in {
+      val headers = new java.util.HashMap[String, java.util.List[String]]
+      headers.put("Content-Type", java.util.Arrays.asList("application/xml", "application/json"))
+
+      an[IllegalArgumentException] should be thrownBy PekkoHttpClient.convertHeaders(headers)
+    }
+
+    "reject a header with no values" in {
+      val headers = new java.util.HashMap[String, java.util.List[String]]
+      headers.put("Accept", Collections.emptyList[String]())
+
+      an[IllegalArgumentException] should be thrownBy PekkoHttpClient.convertHeaders(headers)
+    }
+
     "return None content length when Content-Length header is absent" in {
       val headers = new java.util.HashMap[String, java.util.List[String]]
       headers.put("Content-Type", Collections.singletonList("application/xml"))


### PR DESCRIPTION
### Motivation
`PekkoHttpClient.convertHeaders` rejected any request header carrying more than one value with an `IllegalArgumentException`. Repeated header fields are valid HTTP, and the AWS SDK models request headers as `Map[String, List[String]]` precisely because a name can carry multiple values, so such requests failed client-side before they were ever sent.

### Modification
- Multi-value headers are now converted to one pekko-http header per value, preserving value order.
- `Content-Length` and `Content-Type` stay strict (they are special-cased into the request entity) and still throw when they carry more than one value; a header with no values at all also still throws.
- Header value parsing is factored into a `parseHeader` helper.

### Result
Requests with legitimately repeated header fields are converted and sent instead of failing client-side; conflicting `Content-Length`/`Content-Type` values are still rejected.

### Tests
- `sbt "aws-spi-pekko-http/Test/testOnly org.apache.pekko.stream.connectors.awsspi.PekkoHttpClientSpec"` — 15 passed, 4 new tests: multi-value conversion (fails without the fix — verified by reverting the main source), plus tests pinning the retained strictness for multi-value `Content-Length`, multi-value `Content-Type`, and empty value lists
- `sbt "aws-spi-pekko-http/Test/testOnly ...PekkoHttpClientH1TestSuite ...RequestRunnerSpec"` — 8 passed
- `sbt "aws-spi-pekko-http/mimaReportBinaryIssues"` — no issues
- `scalafmt --mode diff-ref=origin/main` — clean; no Java files changed, no new files (no header changes needed)

### References
None - found during a review of the aws-spi-pekko-http client

🤖 Generated with [Claude Code](https://claude.com/claude-code)