### PR TITLE
AWS SPI: send request bodies for GET and DELETE instead of dropping them

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -30,7 +30,7 @@ import pekko.http.scaladsl.{ ConnectionContext, Http, HttpsConnectionContext }
 import pekko.http.scaladsl.model.HttpHeader.ParsingResult
 import pekko.http.scaladsl.model.HttpHeader.ParsingResult.Ok
 import pekko.http.scaladsl.model.MediaType.Compressible
-import pekko.http.scaladsl.model.RequestEntityAcceptance.Expected
+import pekko.http.scaladsl.model.RequestEntityAcceptance.{ Expected, Tolerated }
 import pekko.http.scaladsl.model._
 import pekko.http.scaladsl.model.headers.{ `Content-Length`, `Content-Type` }
 import pekko.http.scaladsl.settings.ConnectionPoolSettings
@@ -94,22 +94,32 @@ object PekkoHttpClient {
   private[awsspi] def entityForMethodAndContentType(method: HttpMethod,
       contentType: ContentType,
       contentPublisher: SdkHttpContentPublisher,
-      sdkContentLength: Option[Long] = None): RequestEntity =
+      sdkContentLength: Option[Long] = None): RequestEntity = {
+    // Prefer the content length from the SDK request headers over the publisher's value.
+    // This ensures that when the AWS SDK has set a Content-Length (which it always does for
+    // non-chunked-signing requests like UploadPart), Pekko HTTP sends a Content-Length entity
+    // rather than falling back to chunked transfer encoding, which would break AWS SigV4 signing.
+    def contentLength: Option[Long] =
+      sdkContentLength.orElse(contentPublisher.contentLength().toScala.map(_.toLong))
+    def dataSource = Source.fromPublisher(contentPublisher).map(ByteString(_))
     method.requestEntityAcceptance match {
       case Expected =>
-        // Prefer the content length from the SDK request headers over the publisher's value.
-        // This ensures that when the AWS SDK has set a Content-Length (which it always does for
-        // non-chunked-signing requests like UploadPart), Pekko HTTP sends a Content-Length entity
-        // rather than falling back to chunked transfer encoding, which would break AWS SigV4 signing.
-        val contentLength: Option[Long] =
-          sdkContentLength.orElse(contentPublisher.contentLength().toScala.map(_.toLong))
         contentLength match {
-          case Some(length) =>
-            HttpEntity(contentType, length, Source.fromPublisher(contentPublisher).map(ByteString(_)))
-          case None => HttpEntity(contentType, Source.fromPublisher(contentPublisher).map(ByteString(_)))
+          case Some(length) => HttpEntity(contentType, length, dataSource)
+          case None         => HttpEntity(contentType, dataSource)
+        }
+      case Tolerated =>
+        // Methods such as GET and DELETE tolerate an entity: attach the SDK's payload when one
+        // is actually present instead of silently dropping it (its hash is part of the SigV4
+        // signature). Without a known positive length the request stays bodiless, as falling
+        // back to a chunked entity would break SigV4 signing.
+        contentLength match {
+          case Some(length) if length > 0 => HttpEntity(contentType, length, dataSource)
+          case _                          => HttpEntity.Empty
         }
       case _ => HttpEntity.Empty
     }
+  }
 
   private[awsspi] def convertMethod(method: String): HttpMethod =
     HttpMethods

--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
@@ -23,7 +23,7 @@ import com.typesafe.config.ConfigFactory
 
 import org.apache.pekko
 import pekko.http.scaladsl.model.headers.`Content-Type`
-import pekko.http.scaladsl.model.{ ContentTypes, HttpMethods, MediaTypes }
+import pekko.http.scaladsl.model.{ ContentTypes, HttpEntity, HttpMethods, MediaTypes }
 import pekko.http.scaladsl.settings.{ ClientConnectionSettings, ConnectionPoolSettings }
 import org.reactivestreams.Subscriber
 import org.scalatest.OptionValues
@@ -98,6 +98,48 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
         PekkoHttpClient.entityForMethodAndContentType(HttpMethods.PUT, ContentTypes.NoContentType, publisher,
           Some(42L))
       entity.contentLengthOption shouldBe Some(42L)
+    }
+
+    "attach the request body for a DELETE request when the SDK provides content" in {
+      val publisher = new SdkHttpContentPublisher {
+        override def contentLength(): java.util.Optional[java.lang.Long] = java.util.Optional.of(10L)
+        override def subscribe(s: Subscriber[? >: ByteBuffer]): Unit = {}
+      }
+      val entity =
+        PekkoHttpClient.entityForMethodAndContentType(HttpMethods.DELETE, ContentTypes.`application/json`, publisher)
+      entity.contentLengthOption shouldBe Some(10L)
+      entity.contentType shouldBe ContentTypes.`application/json`
+    }
+
+    "attach the request body for a GET request when the SDK headers provide a content length" in {
+      val publisher = new SdkHttpContentPublisher {
+        override def contentLength(): java.util.Optional[java.lang.Long] = java.util.Optional.empty()
+        override def subscribe(s: Subscriber[? >: ByteBuffer]): Unit = {}
+      }
+      val entity =
+        PekkoHttpClient.entityForMethodAndContentType(HttpMethods.GET, ContentTypes.NoContentType, publisher,
+          Some(5L))
+      entity.contentLengthOption shouldBe Some(5L)
+    }
+
+    "keep a GET request bodiless when no content is present" in {
+      val publisher = new SdkHttpContentPublisher {
+        override def contentLength(): java.util.Optional[java.lang.Long] = java.util.Optional.empty()
+        override def subscribe(s: Subscriber[? >: ByteBuffer]): Unit = {}
+      }
+      PekkoHttpClient.entityForMethodAndContentType(HttpMethods.GET, ContentTypes.NoContentType,
+        publisher) shouldBe HttpEntity.Empty
+      PekkoHttpClient.entityForMethodAndContentType(HttpMethods.GET, ContentTypes.NoContentType, publisher,
+        Some(0L)) shouldBe HttpEntity.Empty
+    }
+
+    "never attach a request body for a method that disallows an entity" in {
+      val publisher = new SdkHttpContentPublisher {
+        override def contentLength(): java.util.Optional[java.lang.Long] = java.util.Optional.of(10L)
+        override def subscribe(s: Subscriber[? >: ByteBuffer]): Unit = {}
+      }
+      PekkoHttpClient.entityForMethodAndContentType(HttpMethods.HEAD, ContentTypes.NoContentType,
+        publisher) shouldBe HttpEntity.Empty
     }
 
     "build() should use default ConnectionPoolSettings" in {


### PR DESCRIPTION
### Motivation
`entityForMethodAndContentType` only built a request entity when the method's `requestEntityAcceptance` was `Expected`. GET and DELETE are `Tolerated` in pekko-http, so any SDK request carrying a payload on those methods was silently sent bodiless (and the content publisher was never subscribed). The payload hash is part of the SigV4 signature, so such requests fail server-side in a hard-to-diagnose way.

### Modification
- For `Tolerated` methods, attach the SDK's payload when a positive content length is known (from the SDK request headers or the publisher); otherwise keep the request bodiless, since falling back to a chunked entity would break SigV4 signing.
- `Disallowed` methods (HEAD, TRACE, CONNECT) still never get an entity.
- The content-length resolution and body source are factored into local helpers.

### Result
GET and DELETE requests with payloads are sent with their bodies; bodiless GET/DELETE requests behave exactly as before.

### Tests
- `sbt "aws-spi-pekko-http/Test/testOnly org.apache.pekko.stream.connectors.awsspi.PekkoHttpClientSpec"` — 15 passed, 4 new tests: DELETE and GET body attachment (both fail without the fix — verified by reverting the main source), plus tests pinning that a GET without content stays bodiless and that entity-disallowing methods never get a body
- `sbt "aws-spi-pekko-http/Test/testOnly ...PekkoHttpClientH1TestSuite ...RequestRunnerSpec"` — 8 passed
- `sbt "aws-spi-pekko-http/mimaReportBinaryIssues"` — no issues
- `scalafmt --mode diff-ref=origin/main` — clean; no Java files changed, no new files (no header changes needed)

### References
None - found during a review of the aws-spi-pekko-http client

🤖 Generated with [Claude Code](https://claude.com/claude-code)