### PR TITLE
AWS SPI: validate Content-Length header values

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -152,7 +152,7 @@ object PekkoHttpClient {
         // skip content-length as it will be managed by pekko-http in the entity, but capture its value
         // so we can use it to build a fixed-length entity, preventing a fallback to chunked transfer encoding
         if (`Content-Length`.lowercaseName == headerName.toLowerCase(Locale.ROOT))
-          (ctHeader, hdrs, Some(headerValue.get(0).toLong))
+          (ctHeader, hdrs, Some(parseContentLength(headerValue.get(0))))
         else {
           HttpHeader.parse(headerName, headerValue.get(0)) match {
             case ok: Ok =>
@@ -164,6 +164,18 @@ object PekkoHttpClient {
           }
         }
     }
+  }
+
+  private def parseContentLength(headerValue: String): Long = {
+    val length =
+      try headerValue.toLong
+      catch {
+        case _: NumberFormatException =>
+          throw new IllegalArgumentException(s"Found invalid Content-Length header value: '$headerValue'.")
+      }
+    if (length < 0)
+      throw new IllegalArgumentException(s"Found invalid Content-Length header value: '$headerValue'.")
+    length
   }
 
   private[awsspi] def tryCreateCustomContentType(contentTypeStr: String): ContentType = {

--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
@@ -59,6 +59,21 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
       contentLength shouldBe Some(123L)
     }
 
+    "reject a non-numeric Content-Length header value with a clear error" in {
+      val headers = new java.util.HashMap[String, java.util.List[String]]
+      headers.put("Content-Length", Collections.singletonList("not-a-number"))
+
+      val e = the[IllegalArgumentException] thrownBy PekkoHttpClient.convertHeaders(headers)
+      e.getMessage should include("not-a-number")
+    }
+
+    "reject a negative Content-Length header value" in {
+      val headers = new java.util.HashMap[String, java.util.List[String]]
+      headers.put("Content-Length", Collections.singletonList("-1"))
+
+      an[IllegalArgumentException] should be thrownBy PekkoHttpClient.convertHeaders(headers)
+    }
+
     "return None content length when Content-Length header is absent" in {
       val headers = new java.util.HashMap[String, java.util.List[String]]
       headers.put("Content-Type", Collections.singletonList("application/xml"))


### PR DESCRIPTION
### Motivation
`convertHeaders` parsed the `Content-Length` request header with a bare `.toLong`: a negative value flowed unchecked into a fixed-length entity, and a malformed value surfaced as a raw `NumberFormatException` instead of the module's usual "Found invalid header" style of error.

### Modification
Parse `Content-Length` via a `parseContentLength` helper that rejects non-numeric and negative values with an `IllegalArgumentException` naming the offending value.

### Result
Negative `Content-Length` values are rejected instead of producing an invalid entity; malformed values produce a consistent, descriptive error.

### Tests
- `sbt "aws-spi-pekko-http/Test/testOnly org.apache.pekko.stream.connectors.awsspi.PekkoHttpClientSpec"` — 13 passed, 2 new tests: the negative-value test fails without the fix (verified by reverting the main source); the non-numeric test is characterization, since `NumberFormatException` already extends `IllegalArgumentException`
- `sbt "aws-spi-pekko-http/mimaReportBinaryIssues"` — no issues
- `scalafmt --mode diff-ref=origin/main` — clean; no Java files changed, no new files (no header changes needed)

### References
None - found during a review of the aws-spi-pekko-http client

🤖 Generated with [Claude Code](https://claude.com/claude-code)