### PR TITLE
AWS SPI: apply SDK configuration options in buildWithDefaults by default

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -190,11 +190,25 @@ object PekkoHttpClient {
 
   def builder() = PekkoHttpClientBuilder()
 
+  private val keepBaseConnectionPoolSettings: (ConnectionPoolSettings, AttributeMap) => ConnectionPoolSettings =
+    (c, _) => c
+
+  /**
+   * Builds [[PekkoHttpClient]] instances.
+   *
+   * Unless explicit [[pekko.http.scaladsl.settings.ConnectionPoolSettings]] or a custom settings builder are
+   * provided, the SDK's resolved configuration options are applied to the connection pool settings:
+   * `CONNECTION_TIMEOUT`, `CONNECTION_MAX_IDLE_TIMEOUT`, `MAX_CONNECTIONS` and `CONNECTION_TIME_TO_LIVE`
+   * are mapped; `READ_TIMEOUT`, `WRITE_TIMEOUT` and `CONNECTION_ACQUIRE_TIMEOUT` have no Pekko HTTP
+   * equivalent and are ignored. Settings passed via `withConnectionPoolSettings` are used untouched unless
+   * combined with `withConnectionPoolSettingsBuilderFromAttributeMap` or a custom
+   * `withConnectionPoolSettingsBuilder`.
+   */
   case class PekkoHttpClientBuilder(private val actorSystem: Option[ActorSystem] = None,
       private val executionContext: Option[ExecutionContext] = None,
       private val connectionPoolSettings: Option[ConnectionPoolSettings] = None,
       private val connectionPoolSettingsBuilder: (ConnectionPoolSettings, AttributeMap) => ConnectionPoolSettings =
-        (c, _) => c)
+        keepBaseConnectionPoolSettings)
       extends SdkAsyncHttpClient.Builder[PekkoHttpClientBuilder] {
     def buildWithDefaults(serviceDefaults: AttributeMap): SdkAsyncHttpClient = {
       implicit val as = actorSystem.getOrElse(ActorSystem("aws-pekko-http"))
@@ -202,7 +216,15 @@ object PekkoHttpClient {
 
       val resolvedOptions = serviceDefaults.merge(SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS);
 
-      val cps = connectionPoolSettingsBuilder(
+      // Honour the SDK's resolved configuration by default, as the SdkAsyncHttpClient.Builder
+      // contract expects; explicitly provided ConnectionPoolSettings are used untouched unless
+      // the user also opted into an attribute-map-aware settings builder.
+      val cpsBuilder =
+        if ((connectionPoolSettingsBuilder eq keepBaseConnectionPoolSettings) && connectionPoolSettings.isEmpty)
+          buildConnectionPoolSettings _
+        else connectionPoolSettingsBuilder
+
+      val cps = cpsBuilder(
         connectionPoolSettings.getOrElse(ConnectionPoolSettings(as)),
         resolvedOptions
       )

--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
@@ -100,12 +100,45 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
       entity.contentLengthOption shouldBe Some(42L)
     }
 
-    "build() should use default ConnectionPoolSettings" in {
+    "build() should apply SDK GLOBAL_HTTP_DEFAULTS by default" in {
       val pekkoClient: PekkoHttpClient = new PekkoHttpAsyncHttpService().createAsyncHttpClientFactory()
         .build()
         .asInstanceOf[PekkoHttpClient]
 
-      pekkoClient.connectionSettings shouldBe ConnectionPoolSettings(ConfigFactory.load())
+      pekkoClient.connectionSettings.connectionSettings.connectingTimeout shouldBe
+      SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS.get(SdkHttpConfigurationOption.CONNECTION_TIMEOUT).toScala
+      pekkoClient.connectionSettings.maxConnections shouldBe
+      SdkHttpConfigurationOption.GLOBAL_HTTP_DEFAULTS.get(SdkHttpConfigurationOption.MAX_CONNECTIONS).intValue()
+    }
+
+    "buildWithDefaults() should propagate configuration options without explicit opt-in" in {
+      val attributeMap = AttributeMap.builder()
+        .put(SdkHttpConfigurationOption.CONNECTION_TIMEOUT, 1.second.toJava)
+        .put(SdkHttpConfigurationOption.CONNECTION_MAX_IDLE_TIMEOUT, 2.second.toJava)
+        .put(SdkHttpConfigurationOption.MAX_CONNECTIONS, Integer.valueOf(3))
+        .put(SdkHttpConfigurationOption.CONNECTION_TIME_TO_LIVE, 4.second.toJava)
+        .build()
+      val pekkoClient: PekkoHttpClient = new PekkoHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .buildWithDefaults(attributeMap)
+        .asInstanceOf[PekkoHttpClient]
+
+      pekkoClient.connectionSettings.connectionSettings.connectingTimeout shouldBe 1.second
+      pekkoClient.connectionSettings.connectionSettings.idleTimeout shouldBe 2.seconds
+      pekkoClient.connectionSettings.maxConnections shouldBe 3
+      pekkoClient.connectionSettings.maxConnectionLifetime shouldBe 4.seconds
+    }
+
+    "withConnectionPoolSettings().buildWithDefaults() should use the passed settings untouched" in {
+      val connectionPoolSettings = ConnectionPoolSettings(ConfigFactory.load()).withMaxConnections(7)
+      val attributeMap = AttributeMap.builder()
+        .put(SdkHttpConfigurationOption.MAX_CONNECTIONS, Integer.valueOf(3))
+        .build()
+      val pekkoClient: PekkoHttpClient = new PekkoHttpAsyncHttpService().createAsyncHttpClientFactory()
+        .withConnectionPoolSettings(connectionPoolSettings)
+        .buildWithDefaults(attributeMap)
+        .asInstanceOf[PekkoHttpClient]
+
+      pekkoClient.connectionSettings shouldBe connectionPoolSettings
     }
 
     "withConnectionPoolSettingsBuilderFromAttributeMap().buildWithDefaults() should propagate configuration options" in {


### PR DESCRIPTION
### Motivation
The default connection-pool-settings builder discarded the `AttributeMap` entirely (`(c, _) => c`), so SDK options such as `CONNECTION_TIMEOUT` and `MAX_CONNECTIONS` configured on the SDK client silently did nothing unless the caller opted in via `withConnectionPoolSettingsBuilderFromAttributeMap()`. That violates the `SdkAsyncHttpClient.Builder.buildWithDefaults` contract, which expects the service defaults to be applied.

### Modification
- When neither explicit `ConnectionPoolSettings` nor a custom settings builder is provided, `buildWithDefaults` now applies the SDK's resolved options (`CONNECTION_TIMEOUT`, `CONNECTION_MAX_IDLE_TIMEOUT`, `MAX_CONNECTIONS`, `CONNECTION_TIME_TO_LIVE`) on top of the config-based settings.
- Explicitly provided `ConnectionPoolSettings` are still used untouched, and a custom builder still wins.
- The default builder function is a shared sentinel value, so the case class shape (apply/copy signatures) is unchanged for binary compatibility.
- New scaladoc on the builder documents the mapping and notes that `READ_TIMEOUT`, `WRITE_TIMEOUT` and `CONNECTION_ACQUIRE_TIMEOUT` have no Pekko HTTP equivalent and are ignored.

### Result
SDK-configured HTTP options take effect by default. Note this is a deliberate behavior change for clients built without explicit settings: pekko-http config defaults (e.g. `max-connections=4`, `connecting-timeout=10s`) are now overridden by the SDK's resolved defaults (e.g. 50 connections, 2s connect timeout), matching how the SDK's own HTTP clients behave. Users passing explicit `ConnectionPoolSettings` see no change.

### Tests
- `sbt "aws-spi-pekko-http/Test/testOnly org.apache.pekko.stream.connectors.awsspi.PekkoHttpClientSpec"` — 13 passed; the two directional tests ("build() should apply SDK GLOBAL_HTTP_DEFAULTS by default", "buildWithDefaults() should propagate configuration options without explicit opt-in") fail without the fix (verified by reverting the main source), and a new test pins that explicit settings stay untouched
- `sbt "aws-spi-pekko-http/Test/testOnly ...PekkoHttpClientH1TestSuite ...RequestRunnerSpec"` — 8 passed
- `sbt "aws-spi-pekko-http/mimaReportBinaryIssues"` — no issues
- `scalafmt --mode diff-ref=origin/main` — clean; no Java files changed, no new files (no header changes needed)

### References
None - found during a review of the aws-spi-pekko-http client

🤖 Generated with [Claude Code](https://claude.com/claude-code)