### PR TITLE
Sync CI actions with main, upgrade sbt, plugins, Pekko core 1.7.1 and Pekko HTTP 1.4.1

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -65,7 +65,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -152,7 +152,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'apache/pekko-connectors'    
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7.0.1
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18      
-      - uses: scalacenter/sbt-dependency-submission@f43202114d7522a4b233e052f82c2eea8d658134 # v3.2.1
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
+      - uses: scalacenter/sbt-dependency-submission@d84eef4c09e633bcf5f113bcad7fd5e9af1baee9 # v3.2.3

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check project is formatted
-        uses: jrouly/scalafmt-native-action@14620cde093e5ff6bfbbecd4f638370024287b9d # v4
+        uses: jrouly/scalafmt-native-action@a9c8e1032a02004c425d53ef8ce420fe2179eba7 # v5
         with:
           arguments: '--list --mode diff-ref=origin/main'

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -19,7 +19,7 @@ jobs:
     if: github.repository == 'apache/pekko-connectors'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -31,13 +31,13 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: Setup Coursier
-        uses: coursier/setup-action@7acb5c9ea69bc1a1bb185ec45ebce2ac114f3628 # v2.0.3
+        uses: coursier/setup-action@9b7939bf01fd1185ce2babe16135168361bf2c62 # v3.0.2
 
       - name: sbt site
         run: sbt docs/makeSite

--- a/.github/workflows/nightly-builds.yaml
+++ b/.github/workflows/nightly-builds.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -49,10 +49,10 @@ jobs:
           java-version: ${{ matrix.JDK }}
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: "compile, including  tests. Run locally with: sbt +Test/compile"
         run: sbt +Test/compile
@@ -63,7 +63,7 @@ jobs:
     if: github.repository == 'apache/pekko-connectors'
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0
 
@@ -74,10 +74,10 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@e47d7d35a0d3a2c7f649ca5c63dfc2bbfaa002e7 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: S3 Integration tests
         run:  |-

--- a/.github/workflows/nightly-pekko-1.0-builds.yaml
+++ b/.github/workflows/nightly-pekko-1.0-builds.yaml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -55,10 +55,10 @@ jobs:
           java-version: ${{ matrix.JDK }}
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@4e2615869d13561d626ed48655e1a39e5b192b3c # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.7
 
       - name: "compile, including  tests. Run locally with: sbt -Dpekko.build.pekko.version=1.0.x -Dpekko.build.pekko.http.version=1.0.x +Test/compile"
         run: sbt -Dpekko.build.pekko.version=1.0.x -Dpekko.build.pekko.http.version=1.0.x +Test/compile

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -30,7 +30,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Build Documentation
         run: |-

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -30,7 +30,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Build Documentation
         run: |-

--- a/.github/workflows/publish-1.3-docs.yml
+++ b/.github/workflows/publish-1.3-docs.yml
@@ -30,7 +30,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -43,7 +43,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@6bec67c98f542b9e17369bfca0ec822ac1363194 # v1.1.19
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Build Documentation
         run: |-

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -36,7 +36,7 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx3G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7.0.1
         with:
           fetch-tags: true
           fetch-depth: 0
@@ -49,7 +49,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@1cad58d595b729a71ca2254cdf5b43dd6f42d4bb # v1.1.18
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Publish to Apache Maven repo
         env:

--- a/.github/workflows/stage-release-candidate.yml
+++ b/.github/workflows/stage-release-candidate.yml
@@ -66,7 +66,7 @@ jobs:
           REF: ${{ github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -141,7 +141,7 @@ jobs:
           REF: ${{ github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -199,7 +199,7 @@ jobs:
           REF: ${{ github.ref_name }}
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v5.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5.0.1
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -212,7 +212,7 @@ jobs:
           java-version: 8
 
       - name: Install sbt
-        uses: sbt/setup-sbt@6bec67c98f542b9e17369bfca0ec822ac1363194 # v1.1.19
+        uses: sbt/setup-sbt@c7d2d6258b4bd0d3ec5129e6b3453199d3c79729 # v1.5.8
 
       - name: Install Graphviz
         run: |-

--- a/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
+++ b/amqp/src/test/java/docs/javadsl/AmqpDocsTest.java
@@ -145,7 +145,7 @@ public class AmqpDocsTest {
         Source.from(input)
             .map(ByteString::fromString)
             .viaMat(ampqRpcFlow, Keep.right())
-            .toMat(TestSink.probe(system), Keep.both())
+            .toMat(TestSink.create(system), Keep.both())
             .run(system);
     // #create-rpc-flow
     result.first().toCompletableFuture().get(3, TimeUnit.SECONDS);

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpConnectorsTest.java
@@ -149,7 +149,7 @@ public class AmqpConnectorsTest {
             .map(WriteMessage::create)
             .viaMat(ampqRpcFlow, Keep.right())
             .mapAsync(1, cm -> cm.ack().thenApply(unused -> cm.message()))
-            .toMat(TestSink.probe(system), Keep.both())
+            .toMat(TestSink.create(system), Keep.both())
             .run(system);
 
     result.first().toCompletableFuture().get(5, TimeUnit.SECONDS);

--- a/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
+++ b/amqp/src/test/java/org/apache/pekko/stream/connectors/amqp/javadsl/AmqpFlowTest.java
@@ -108,7 +108,7 @@ public class AmqpFlowTest {
         Source.from(input)
             .map(s -> WriteMessage.create(ByteString.fromString(s)))
             .via(flow)
-            .toMat(TestSink.probe(system), Keep.right())
+            .toMat(TestSink.create(system), Keep.right())
             .run(system);
 
     result
@@ -142,7 +142,7 @@ public class AmqpFlowTest {
             .map(s -> WriteMessage.create(ByteString.fromString(s)))
             .via(flowWithContext)
             .asSource()
-            .toMat(TestSink.probe(system), Keep.right())
+            .toMat(TestSink.create(system), Keep.right())
             .run(system);
 
     result
@@ -165,7 +165,7 @@ public class AmqpFlowTest {
         Source.from(input)
             .map(s -> Pair.create(WriteMessage.create(ByteString.fromString(s)), s))
             .via(flow)
-            .toMat(TestSink.probe(system), Keep.right())
+            .toMat(TestSink.create(system), Keep.right())
             .run(system);
 
     result

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCh
 sourceDistName := "apache-pekko-connectors"
 sourceDistIncubating := false
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+ThisBuild / resolvers += Resolver.ApacheMavenStagingRepo
 
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 

--- a/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
+++ b/cassandra/src/test/java/docs/javadsl/CassandraFlowTest.java
@@ -17,7 +17,6 @@ import org.apache.pekko.Done;
 // #prepared
 import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.ActorSystem;
-import org.apache.pekko.japi.Function2;
 import org.apache.pekko.japi.Pair;
 import org.apache.pekko.stream.connectors.cassandra.CassandraWriteSettings;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraFlow;
@@ -100,6 +99,7 @@ public class CassandraFlowTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation") // CassandraFlow.create takes the deprecated pekko.japi.Function2
   public void typedUpdate() throws InterruptedException, ExecutionException, TimeoutException {
     String table = helper.createTableName();
     await(
@@ -120,7 +120,7 @@ public class CassandraFlowTest {
             new Person(43, "Umberto", "Roma"),
             new Person(56, "James", "Chicago"));
 
-    Function2<Person, PreparedStatement, BoundStatement> statementBinder =
+    org.apache.pekko.japi.Function2<Person, PreparedStatement, BoundStatement> statementBinder =
         (person, preparedStatement) -> preparedStatement.bind(person.id, person.name, person.city);
 
     CompletionStage<List<Person>> written =

--- a/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
+++ b/ftp/src/test/java/org/apache/pekko/stream/connectors/ftp/CommonFtpStageTest.java
@@ -68,7 +68,7 @@ interface CommonFtpStageTest extends BaseSupport, PekkoSupport {
     Source<FtpFile, NotUsed> source = getBrowserSource(basePath);
 
     Pair<NotUsed, TestSubscriber.Probe<FtpFile>> pairResult =
-        source.toMat(TestSink.probe(system), Keep.both()).run(system);
+        source.toMat(TestSink.create(system), Keep.both()).run(system);
     TestSubscriber.Probe<FtpFile> probe = pairResult.second();
     probe.request(demand).expectNextN(numFiles);
     probe.expectComplete();
@@ -82,7 +82,7 @@ interface CommonFtpStageTest extends BaseSupport, PekkoSupport {
 
     Source<ByteString, CompletionStage<IOResult>> source = getIOSource(fileName);
     Pair<CompletionStage<IOResult>, TestSubscriber.Probe<ByteString>> pairResult =
-        source.toMat(TestSink.probe(system), Keep.both()).run(system);
+        source.toMat(TestSink.create(system), Keep.both()).run(system);
     TestSubscriber.Probe<ByteString> probe = pairResult.second();
     probe.request(100).expectNextOrComplete();
 

--- a/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqtt/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -314,7 +314,7 @@ public class MqttSourceTest {
         MqttSource.atMostOnce(settings1, subscriptions, bufferSize);
 
     Pair<CompletionStage<Done>, TestSubscriber.Probe<MqttMessage>> result2 =
-        source1.toMat(TestSink.probe(system), Keep.both()).run(system);
+        source1.toMat(TestSink.create(system), Keep.both()).run(system);
 
     // Ensure that the connection made it all the way to the server by waiting until it receives a
     // message

--- a/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
+++ b/mqttv5/src/test/java/docs/javadsl/MqttSourceTest.java
@@ -318,7 +318,7 @@ public class MqttSourceTest {
                 MqttSource.atMostOnce(settings1, subscriptions, bufferSize);
 
         Pair<CompletionStage<Done>, TestSubscriber.Probe<MqttMessage>> result2 =
-                source1.toMat(TestSink.probe(system), Keep.both()).run(system);
+                source1.toMat(TestSink.create(system), Keep.both()).run(system);
 
         // Ensure that the connection made it all the way to the server by waiting until it receives a
         // message

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -10,7 +10,7 @@
 import sbt._
 import sbt.Keys._
 import sbt.plugins.JvmPlugin
-import de.heikoseeberger.sbtheader._
+import sbtheader._
 import com.lightbend.paradox.projectinfo.ParadoxProjectInfoPluginKeys._
 import com.typesafe.tools.mima.plugin.MimaKeys._
 import org.mdedetrich.apache.sonatype.ApacheSonatypePlugin

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -90,7 +90,8 @@ object Common extends AutoPlugin {
     Compile / doc / scalacOptions -= "-Werror",
     compile / javacOptions ++= Seq(
       "-Xlint:cast",
-      "-Xlint:deprecation",
+      // deprecation warnings are informational only - they must not fail the build
+      "-Xlint:-deprecation",
       "-Xlint:dep-ann",
       "-Xlint:empty",
       "-Xlint:fallthrough",

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -11,8 +11,8 @@
  * Copyright (C) 2018-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
-import de.heikoseeberger.sbtheader.{ CommentCreator, HeaderPlugin, NewLine }
+import sbtheader.HeaderPlugin.autoImport._
+import sbtheader.{ CommentCreator, HeaderPlugin, NewLine }
 import org.apache.commons.lang3.StringUtils
 import sbt.Keys._
 import sbt._

--- a/project/CopyrightHeaderForBuild.scala
+++ b/project/CopyrightHeaderForBuild.scala
@@ -11,7 +11,7 @@
  * Copyright (C) 2019-2022 Lightbend Inc. <https://www.lightbend.com>
  */
 
-import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport.{ headerMappings, headerSources, HeaderFileType }
+import sbtheader.HeaderPlugin.autoImport.{ headerMappings, headerSources, HeaderFileType }
 import sbt.Keys.baseDirectory
 import sbt.{ inConfig, Compile, Def, PluginTrigger, Test, _ }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
   val NettyVersion = "4.2.10.Final"
 
   // Sync with plugins.sbt
-  val PekkoGrpcBinaryVersion = "1.1"
+  val PekkoGrpcBinaryVersion = "1.2"
   val PekkoHttpVersion = PekkoHttpDependency.version
   val PekkoStreamsCirceVersion = "1.1.0"
   val PekkoHttpBinaryVersion = PekkoHttpDependency.default.link

--- a/project/PekkoCoreDependency.scala
+++ b/project/PekkoCoreDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoCoreDependency extends PekkoDependency {
   override val checkProject: String = "pekko-cluster-sharding-typed"
   override val module: Option[String] = None
-  override val currentVersion: String = "1.1.5"
+  override val currentVersion: String = "1.7.1"
 }

--- a/project/PekkoHttpDependency.scala
+++ b/project/PekkoHttpDependency.scala
@@ -20,5 +20,5 @@ import com.github.pjfanning.pekkobuild.PekkoDependency
 object PekkoHttpDependency extends PekkoDependency {
   override val checkProject: String = "pekko-http-testkit"
   override val module: Option[String] = Some("http")
-  override val currentVersion: String = "1.1.0"
+  override val currentVersion: String = "1.4.1"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.12.5
+sbt.version=1.13.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,15 +9,15 @@
 
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.4.7")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
-addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
-addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
+addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.35")
+addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.2.0")
 addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
-addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.6.1")
-addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
+addSbtPlugin("com.github.sbt" % "sbt-license-report" % "1.10.0")
+addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.1.1")
 // discipline
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
+addSbtPlugin("com.github.sbt" % "sbt-header" % "5.11.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.9.0")
 
 // docs
@@ -28,7 +28,7 @@ addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.7.0").excludeAll(
 addSbtPlugin("com.github.sbt" % "sbt-unidoc" % "0.6.0")
 addSbtPlugin("com.thoughtworks.sbt-api-mappings" % "sbt-api-mappings" % "3.0.2")
 // Pekko gRPC -- sync with PekkoGrpcBinaryVersion in Dependencies.scala
-addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.1.1")
+addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "1.2.0")
 // templating
 addSbtPlugin("com.github.sbt" % "sbt-boilerplate" % "0.7.0")
 // Run JUnit 5 tests with sbt

--- a/udp/src/test/java/docs/javadsl/UdpTest.java
+++ b/udp/src/test/java/docs/javadsl/UdpTest.java
@@ -72,9 +72,9 @@ public class UdpTest {
             Pair<TestPublisher.Probe<Datagram>, CompletionStage<InetSocketAddress>>,
             TestSubscriber.Probe<Datagram>>
         materialized =
-            TestSource.<Datagram>probe(system)
+            TestSource.<Datagram>create(system)
                 .viaMat(bindFlow, Keep.both())
-                .toMat(TestSink.probe(system), Keep.both())
+                .toMat(TestSink.create(system), Keep.both())
                 .run(system);
 
     {
@@ -140,9 +140,9 @@ public class UdpTest {
             Pair<TestPublisher.Probe<Datagram>, CompletionStage<InetSocketAddress>>,
             TestSubscriber.Probe<Datagram>>
         materialized =
-            TestSource.<Datagram>probe(system)
+            TestSource.<Datagram>create(system)
                 .viaMat(bindFlow, Keep.both())
-                .toMat(TestSink.probe(system), Keep.both())
+                .toMat(TestSink.create(system), Keep.both())
                 .run(system);
 
     {


### PR DESCRIPTION
Targets the `1.4.x` branch. Rebased on the current `1.4.x` head.

## CI actions

Brings the GitHub Actions references in line with `main`. Only the `uses:` refs change — job logic (JDK versions, matrices, build commands) is deliberately left alone on this branch.

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | `v6` | `v7.0.1` |
| `actions/checkout` (pinned, release workflow) | `de0fac2e` | `3d3c42e5` |
| `sbt/setup-sbt` | `v1.1.18` / `v1.1.19` | `v1.5.8` |
| `coursier/cache-action` | `e47d7d35` / `4e261586` | `95e5b102` |
| `coursier/setup-action` | `v2.0.3` | `v3.0.2` |
| `jrouly/scalafmt-native-action` | `v4` | `v5` |
| `scalacenter/sbt-dependency-submission` | `v3.2.1` | `v3.2.3` |

## Build

- sbt `1.12.5` → `1.13.0`
- sbt-reproducible-builds `0.32` → `0.35`
- sbt-source-dist `0.1.12` → `0.2.0`
- sbt-license-report `1.6.1` → `1.10.0`
- sbt-bill-of-materials `1.0.2` → `1.1.1`
- sbt-header `5.10.0` → `5.11.0` — the group moved to `com.github.sbt` **and** the plugin package moved from `de.heikoseeberger.sbtheader` to `sbtheader`, so the imports in `project/CopyrightHeader.scala`, `project/CopyrightHeaderForBuild.scala` and `project/Common.scala` are updated to match
- sbt-mima-plugin `1.1.4` → `1.1.6`
- pekko-grpc-sbt-plugin `1.1.1` → `1.2.0`, with `PekkoGrpcBinaryVersion` moved to `1.2` to keep it in sync as the comment in `Dependencies.scala` requires

sbt-pekko-build stays at `0.4.7` — already the latest release.

## Pekko core 1.7.1 and Pekko HTTP 1.4.1

`PekkoCoreDependency` moves to `1.7.1` and `PekkoHttpDependency` from `1.1.0` to `1.4.1`, so the two stay in step. `PekkoHttpBinaryVersion` is derived from `PekkoHttpDependency`, so the Paradox/Scaladoc base URLs follow automatically.

Neither release is on Maven Central yet — both are in the ASF staging repository — so `Resolver.ApacheMavenStagingRepo` is added to the build resolvers.

## Deprecations no longer fail the build

Java compilation runs with `-Werror` under CI, so every API a new upstream release deprecates turns the test compile into a hard failure. That makes routine dependency bumps on a maintenance branch far more disruptive than they need to be — a deprecation is advisory, not a defect.

`project/Common.scala` now passes `-Xlint:-deprecation` to javac, so deprecated usages stay informational notes rather than warnings that `-Werror` escalates to errors. Every other `-Xlint` category stays fatal under CI.

`-Xlint:-removal` cannot be added alongside it — `removal` is a JDK 9+ lint category and this branch's connectors jobs build on JDK 8, whose javac rejects the flag outright (`invalid flag: -Xlint:-removal`). That is exactly what the existing commented-out `// JDK 11 "-Xlint:removal"` line records, so it stays. Deprecations marked `forRemoval` still warn, but only on JDK 9+ builds.

The Java test migration off APIs deprecated in Pekko 1.7.1 (`TestSink.probe`/`TestSource.probe` → `TestSink.create`/`TestSource.create` in amqp, ftp, mqtt, mqttv5 and udp; a call-site suppression in `CassandraFlowTest`, whose `javadsl` signature cannot change on this branch) is kept — it is worth doing on its own merits, independently of whether the warnings are fatal.

## Verification

The first push of this branch surfaced one real problem in CI, now fixed: `-Xlint:-removal` failed every JDK 8 connectors job with `invalid flag`. The flag is gone.

Beyond that this relies on CI — no local test run completed. A `CI=true sbt "print aws-spi-pekko-http/compile/javacOptions" "amqp/Test/compile" "cassandra/Test/compile" "udp/Test/compile"` run, which forces the CI `-Werror` path locally, was started but cancelled before finishing. An earlier build-definition load reported `Building Pekko Connectors 1.4.0-M0+... against Pekko 1.7.1`, confirming the upgraded plugins and the staging resolver resolve.
