### PR TITLE
Pin hbase to 2.x in scala-steward config

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,6 +1,9 @@
 updates.pin  = [
   # pin to hadoop 3.4.x until 3.5.x becomes more widely adopted
   { groupId = "org.apache.hadoop", version = "3.4." }
+  # hbase 3 clients default to RpcConnectionRegistry, which our test server
+  # (harisekhon/hbase:2.1, the newest published tag) is too old to serve
+  { groupId = "org.apache.hbase", version = "2." }
   # stick with solr 9 until 10 is more widely adopted
   { groupId = "org.apache.solr", version = "9." }
   # https://github.com/apache/pekko-connectors/issues/503


### PR DESCRIPTION
Closes out #1912 (`hbase-common`/`hbase-shaded-client` 2.6.6 -> 3.0.0), which fails every hbase test.

### Why the 3.0.0 bump fails

hbase 3.0.0 flipped the default connection registry. From `ConnectionRegistryFactory` in each client jar:

| hbase-client | default for `hbase.client.registry.impl` |
| --- | --- |
| 2.6.6 | `ZKConnectionRegistry` |
| 3.0.0 | `RpcConnectionRegistry` |

Our tests build their config from a bare `HBaseConfiguration.create()` (`hbase/src/test/scala/docs/scaladsl/HBaseStageSpec.scala`) and there is no `hbase-site.xml` under `hbase/src/test/resources`, so a 3.x client no longer goes to ZooKeeper on 2181. It falls back to the master at `<hostname>:16000` and calls `ClientMetaService`.

The test server is `harisekhon/hbase:2.1`, which predates `MasterRegistry`/`ClientMetaService` (added in 2.3), so the master just closes the socket. All 7 tests fail the same way at connection setup:

```
MasterRegistryFetchException: Exception making rpc to masters [...:16000]
  Cause: RetriesExhaustedException: Failed contacting masters after 1 attempts.
    ConnectionClosedException: Call to address=...:16000 failed on local exception
```

with this in the debug log:

```
ClusterIdFetcher: Failed to get connection registry info, should be an old server,
                  fallback to use null cluster id
```

### Why pin rather than fix

`harisekhon/hbase` has no tag newer than `2.1` and there is no official `apache/hbase` image, so moving the test server to 3.x is not a small change. And a 3.x client against a 2.1 server is not a combination hbase supports, so forcing `ZKConnectionRegistry` in the tests would only paper over a real behaviour change for users.

If we later stand up a real hbase 3 test server, drop this pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)