### PR TITLE
Google: add top-level project-id setting with environment fallback

### DIFF
--- a/docs/src/main/paradox/google-common.md
+++ b/docs/src/main/paradox/google-common.md
@@ -36,6 +36,24 @@ Credentials will be loaded automatically:
 
 Credentials can also be specified manually in your configuration file.
 
+## Project id
+
+The project id used for requests is resolved in this order:
+
+1. The `pekko.connectors.google.project-id` setting, if it is non-empty;
+2. the project id supplied by the configured credentials provider, if it is non-empty;
+3. the `pekko.connectors.google.default-project-id` setting, which reads the `GOOGLE_CLOUD_PROJECT`,
+   `GCLOUD_PROJECT` and `GCP_PROJECT` environment variables by default.
+
+Setting `project-id` explicitly is useful because the project that owns the principal your credentials
+authenticate as need not be the project whose resources you want to access; a service account in one
+project is often granted access to another. The environment variables behind `default-project-id` are
+commonly set for you by GCP runtimes such as App Engine, Cloud Run, Cloud Functions and by GKE
+Workload Identity.
+
+The resolved value is available as `GoogleSettings.projectId` and can still be overridden per stream
+with `withProjectId`.
+
 ## Accessing settings
 
 @apidoc[GoogleSettings$] provides methods to retrieve settings from your configuration and @apidoc[GoogleAttributes$] to access the settings attached to a stream.

--- a/google-common/src/main/resources/reference.conf
+++ b/google-common/src/main/resources/reference.conf
@@ -66,6 +66,23 @@ pekko.connectors.google {
     }
   }
 
+  # The GCP project id used for requests to Google APIs.
+  # If empty, the project id reported by the configured credentials provider is used, and if that is
+  # empty too, `default-project-id` is used.
+  # Set this when the project you want to access is not the project that owns the principal the
+  # credentials authenticate as, which is common when a service account in one project has been
+  # granted access to resources in another.
+  project-id = ""
+
+  # Fallback project id, used when neither `project-id` nor the credentials provider supplies one.
+  # These environment variables are commonly set for you by GCP runtimes such as App Engine,
+  # Cloud Run, Cloud Functions and by GKE Workload Identity.
+  # Later entries take precedence over earlier ones.
+  default-project-id = ""
+  default-project-id = ${?GCP_PROJECT}
+  default-project-id = ${?GCLOUD_PROJECT}
+  default-project-id = ${?GOOGLE_CLOUD_PROJECT}
+
   # Standard query parameters for all Google APIs sent with every request
   user-ip = ""
   quota-user = ""

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/GoogleSettings.scala
@@ -44,7 +44,21 @@ object GoogleSettings {
     val credentials = Credentials(c.getConfig("credentials"))
     val requestSettings = RequestSettings(c)
 
-    GoogleSettings(credentials.projectId, credentials, requestSettings)
+    GoogleSettings(resolveProjectId(c, credentials), credentials, requestSettings)
+  }
+
+  /**
+   * The `project-id` setting wins if it is set, otherwise the project id supplied by the credentials
+   * provider, otherwise the `default-project-id` setting, which is read from the environment by default.
+   */
+  private def resolveProjectId(c: Config, credentials: Credentials): String = {
+    def setting(path: String) =
+      if (c.hasPath(path)) Some(c.getString(path)).filter(_.nonEmpty) else None
+
+    setting("project-id")
+      .orElse(Some(credentials.projectId).filter(_.nonEmpty))
+      .orElse(setting("default-project-id"))
+      .getOrElse("")
   }
 
   /**

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/GoogleSettingsSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/GoogleSettingsSpec.scala
@@ -51,6 +51,87 @@ class GoogleSettingsSpec
         """.stripMargin)
         .resolve)
 
+  private def mkSettings(more: String): GoogleSettings =
+    GoogleSettings(
+      ConfigFactory
+        .parseString(more)
+        .withFallback(ConfigFactory.defaultReference().getConfig(GoogleSettings.ConfigPath))
+        .resolve)
+
+  it should "prefer the project-id setting over the one from the credentials provider" in {
+    mkSettings("""
+                 |project-id = "explicit-project"
+                 |default-project-id = "env-project"
+                 |credentials {
+                 |  provider = access-token
+                 |  access-token {
+                 |    project-id = "credentials-project"
+                 |    token = "yyyy.c.an-access-token"
+                 |  }
+                 |}
+      """.stripMargin).projectId shouldEqual "explicit-project"
+  }
+
+  it should "fall back to the project id from the credentials provider" in {
+    mkSettings("""
+                 |project-id = ""
+                 |default-project-id = "env-project"
+                 |credentials {
+                 |  provider = access-token
+                 |  access-token {
+                 |    project-id = "credentials-project"
+                 |    token = "yyyy.c.an-access-token"
+                 |  }
+                 |}
+      """.stripMargin).projectId shouldEqual "credentials-project"
+  }
+
+  it should "fall back to default-project-id when no other project id is available" in {
+    mkSettings("""
+                 |project-id = ""
+                 |default-project-id = "env-project"
+                 |credentials {
+                 |  provider = access-token
+                 |  access-token {
+                 |    project-id = ""
+                 |    token = "yyyy.c.an-access-token"
+                 |  }
+                 |}
+      """.stripMargin).projectId shouldEqual "env-project"
+  }
+
+  it should "leave the project id empty when nothing supplies one" in {
+    mkSettings("""
+                 |project-id = ""
+                 |default-project-id = ""
+                 |credentials {
+                 |  provider = access-token
+                 |  access-token {
+                 |    project-id = ""
+                 |    token = "yyyy.c.an-access-token"
+                 |  }
+                 |}
+      """.stripMargin).projectId shouldEqual ""
+  }
+
+  it should "resolve the project id from a config that predates the project-id settings" in {
+    val legacy = ConfigFactory
+      .parseString("""
+                     |credentials {
+                     |  provider = access-token
+                     |  access-token {
+                     |    project-id = "credentials-project"
+                     |    token = "yyyy.c.an-access-token"
+                     |  }
+                     |}
+        """.stripMargin)
+      .withFallback(ConfigFactory.defaultReference().getConfig(GoogleSettings.ConfigPath))
+      .resolve
+      .withoutPath("project-id")
+      .withoutPath("default-project-id")
+    GoogleSettings(legacy).projectId shouldEqual "credentials-project"
+  }
+
   it should "skip parsing forward-proxy when optional environment overrides exist but aren't set" in {
     @nowarn("msg=possible missing interpolator: detected an interpolated expression")
     val config = """


### PR DESCRIPTION
The project id used by the Google connectors was always taken from the credentials provider, so the only way to target a project other than the one owning the credentials' principal was to override `GoogleSettings.projectId` programmatically. That combination is common in practice — a service account in one project is frequently granted access to resources in another, since Google principals are global.

This adds two additive settings at the top level of `pekko.connectors.google`:

* `project-id` — used in preference to the project id reported by the credentials provider.
* `default-project-id` — used when neither `project-id` nor the credentials provider supplies one. It reads `GOOGLE_CLOUD_PROJECT`, `GCLOUD_PROJECT` and `GCP_PROJECT`, which GCP runtimes (App Engine, Cloud Run, Cloud Functions) and GKE Workload Identity commonly set for you.

So the resolution order is `project-id`, then the credentials provider, then `default-project-id`.

Both settings default to empty, so an existing configuration resolves exactly the project id it did before. `GoogleSettings.apply(Config)` guards the two new lookups with `hasPath`, so a hand-built `Config` that predates them keeps working rather than throwing `ConfigException.Missing`.

Note that `credentials.google-application-default.project-id` already read `GOOGLE_CLOUD_PROJECT`/`GCLOUD_PROJECT`; that is left alone, and the new top-level settings make the same environment fallback available to every provider.

Tested with new cases in `GoogleSettingsSpec` covering each step of the resolution order, the all-empty case, and a config with the new keys removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

