### PR TITLE
Google: close the credentials file when parsing it fails

### DIFF
--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/ServiceAccountCredentials.scala
@@ -42,8 +42,9 @@ private[connectors] object ServiceAccountCredentials {
           c.getString("private-key"))
       } else {
         val src = Source.fromFile(c.getString("path"))
-        val credentials = JsonParser(src.mkString).convertTo[ServiceAccountCredentialsFile]
-        src.close()
+        val credentials =
+          try JsonParser(src.mkString).convertTo[ServiceAccountCredentialsFile]
+          finally src.close()
         (credentials.project_id, credentials.client_email, credentials.private_key)
       }
     }

--- a/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/UserAccessCredentials.scala
+++ b/google-common/src/main/scala/org/apache/pekko/stream/connectors/google/auth/UserAccessCredentials.scala
@@ -46,8 +46,9 @@ private[connectors] object UserAccessCredentials {
         projectId = c.getString("project-id"))
     } else {
       val src = Source.fromFile(c.getString("path"))
-      val credentials = JsonParser(src.mkString).convertTo[UserAccessCredentialsFile]
-      src.close()
+      val credentials =
+        try JsonParser(src.mkString).convertTo[UserAccessCredentialsFile]
+        finally src.close()
       apply(
         clientId = credentials.client_id,
         clientSecret = credentials.client_secret,

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/CredentialsSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/CredentialsSpec.scala
@@ -25,6 +25,9 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 
+import java.nio.charset.StandardCharsets.UTF_8
+import java.nio.file.{ Files, Path }
+
 class CredentialsSpec
     extends TestKit(ActorSystem("CredentialsSpec"))
     with AnyWordSpecLike
@@ -34,6 +37,78 @@ class CredentialsSpec
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
     super.afterAll()
+  }
+
+  private def withJsonFile(contents: String)(test: String => Unit): Unit = {
+    val file = Files.createTempFile("pekko-connectors-credentials", ".json")
+    Files.write(file, contents.getBytes(UTF_8))
+    try test(hoconPath(file))
+    finally Files.deleteIfExists(file): Unit
+  }
+
+  // backslashes are escapes in a HOCON quoted string, and Java accepts forward slashes on Windows too
+  private def hoconPath(file: Path): String = file.toAbsolutePath.toString.replace('\\', '/')
+
+  private val serviceAccountJson =
+    """{"project_id":"a-project","client_email":"a@b.com","private_key":"a-key"}"""
+
+  private val userAccessJson =
+    """{"client_id":"an-id","client_secret":"a-secret","refresh_token":"a-token","quota_project_id":"a-project"}"""
+
+  "ServiceAccountCredentials" should {
+
+    "read a service account file" in withJsonFile(serviceAccountJson) { path =>
+      val config = ConfigFactory.parseString(s"""
+           |project-id = ""
+           |client-email = ""
+           |private-key = ""
+           |path = "$path"
+        """.stripMargin)
+
+      ServiceAccountCredentials(config, Set("a-scope")).projectId shouldBe "a-project"
+    }
+
+    "propagate the failure, having closed the file, when the file is not a service account" in
+    withJsonFile(userAccessJson) { path =>
+      val config = ConfigFactory.parseString(s"""
+           |project-id = ""
+           |client-email = ""
+           |private-key = ""
+           |path = "$path"
+        """.stripMargin)
+
+      // this is the routine case: `gcloud auth application-default login` writes a user access file,
+      // and the application-default provider tries the service account parser against it first
+      a[Exception] should be thrownBy ServiceAccountCredentials(config, Set("a-scope"))
+    }
+  }
+
+  "UserAccessCredentials" should {
+
+    "read a user access file" in withJsonFile(userAccessJson) { path =>
+      val config = ConfigFactory.parseString(s"""
+           |project-id = ""
+           |client-id = ""
+           |client-secret = ""
+           |refresh-token = ""
+           |path = "$path"
+        """.stripMargin)
+
+      UserAccessCredentials(config).projectId shouldBe "a-project"
+    }
+
+    "propagate the failure, having closed the file, when the file is not a user access file" in
+    withJsonFile(serviceAccountJson) { path =>
+      val config = ConfigFactory.parseString(s"""
+           |project-id = ""
+           |client-id = ""
+           |client-secret = ""
+           |refresh-token = ""
+           |path = "$path"
+        """.stripMargin)
+
+      a[Exception] should be thrownBy UserAccessCredentials(config)
+    }
   }
 
   "Credentials" should {

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/CredentialsSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/CredentialsSpec.scala
@@ -79,7 +79,7 @@ class CredentialsSpec
 
       // this is the routine case: `gcloud auth application-default login` writes a user access file,
       // and the application-default provider tries the service account parser against it first
-      a[Exception] should be thrownBy ServiceAccountCredentials(config, Set("a-scope"))
+      an[Exception] should be thrownBy ServiceAccountCredentials(config, Set("a-scope"))
     }
   }
 

--- a/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/CredentialsSpec.scala
+++ b/google-common/src/test/scala/org/apache/pekko/stream/connectors/google/auth/CredentialsSpec.scala
@@ -107,7 +107,7 @@ class CredentialsSpec
            |path = "$path"
         """.stripMargin)
 
-      a[Exception] should be thrownBy UserAccessCredentials(config)
+      an[Exception] should be thrownBy UserAccessCredentials(config)
     }
   }
 


### PR DESCRIPTION
`ServiceAccountCredentials` and `UserAccessCredentials` both read their JSON file like this:

```scala
val src = Source.fromFile(c.getString("path"))
val credentials = JsonParser(src.mkString).convertTo[ServiceAccountCredentialsFile]
src.close()
```

`close()` is not in a `finally`, so a parse failure skips it and the file descriptor leaks.

That is not a rare path — it is the expected one. The `application-default` provider tries `parseServiceAccount` first inside a `NonFatal` catch, and on any machine set up with `gcloud auth application-default login` the well-known file is an *authorized user* file. So `convertTo[ServiceAccountCredentialsFile]` throws, the descriptor leaks, and the cascade falls through to the user access parser, which reads the same file successfully.

One leaked descriptor per `Credentials` construction on the standard developer path. `GoogleExt` caches settings per config path per `ActorSystem`, so it is bounded in normal use, but `GoogleSettings(config)` is public and un-cached, so building credentials per tenant or per request scope leaks one each time.

Both sites now close in a `finally`.

### Testing

Four cases in `CredentialsSpec`: each parser reading its own file format, and each parser being handed the *other* format, which is the case that used to leak. The failure cases assert the exception still propagates, so the `finally` is not swallowing it.

There is no portable way to assert descriptor closure from a JVM test, so these are behavioural guards around the change rather than a direct assertion that the handle was released. `google-common/test` passes (28) and `checkCodeStyle` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)