### PR TITLE
File: open zip archives in preStart rather than the stage constructor

### DIFF
--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipReaderSource.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipReaderSource.scala
@@ -25,6 +25,24 @@ import pekko.util.ByteString
 import java.io.{ File, FileInputStream }
 import java.nio.charset.{ Charset, StandardCharsets }
 import java.util.zip.{ ZipEntry, ZipInputStream }
+import scala.util.control.NonFatal
+
+@InternalApi private[archive] object ZipReaderSource {
+
+  /**
+   * Opens `f` as a zip stream, closing the underlying file if the zip stream itself cannot be opened.
+   */
+  def openZip(f: File, fileCharset: Charset): ZipInputStream = {
+    val fis = new FileInputStream(f)
+    try new ZipInputStream(fis, fileCharset)
+    catch {
+      case NonFatal(e) =>
+        try fis.close()
+        catch { case NonFatal(suppressed) => e.addSuppressed(suppressed) }
+        throw e
+    }
+  }
+}
 
 @InternalApi class ZipEntrySource(n: ZipArchiveMetadata, f: File, chunkSize: Int, fileCharset: Charset)
     extends GraphStage[SourceShape[ByteString]] {
@@ -34,9 +52,14 @@ import java.util.zip.{ ZipEntry, ZipInputStream }
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) {
-      val zis = new ZipInputStream(new FileInputStream(f), fileCharset)
+      private var zis: ZipInputStream = _
       var entry: ZipEntry = null
       val data = new Array[Byte](chunkSize)
+
+      override def preStart(): Unit = {
+        super.preStart()
+        zis = ZipReaderSource.openZip(f, fileCharset)
+      }
 
       def seek() = {
         while ({
@@ -69,7 +92,7 @@ import java.util.zip.{ ZipEntry, ZipInputStream }
 
       override def postStop(): Unit = {
         super.postStop()
-        zis.close()
+        if (zis ne null) zis.close()
       }
     }
 }
@@ -82,7 +105,12 @@ import java.util.zip.{ ZipEntry, ZipInputStream }
 
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) {
-      val zis = new ZipInputStream(new FileInputStream(f), fileCharset)
+      private var zis: ZipInputStream = _
+
+      override def preStart(): Unit = {
+        super.preStart()
+        zis = ZipReaderSource.openZip(f, fileCharset)
+      }
 
       setHandler(
         out,
@@ -102,7 +130,7 @@ import java.util.zip.{ ZipEntry, ZipInputStream }
 
       override def postStop(): Unit = {
         super.postStop()
-        zis.close()
+        if (zis ne null) zis.close()
       }
     }
 }

--- a/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipReaderSource.scala
+++ b/file/src/main/scala/org/apache/pekko/stream/connectors/file/impl/archive/ZipReaderSource.scala
@@ -22,8 +22,9 @@ import pekko.stream.scaladsl.Source
 import pekko.stream.stage.{ GraphStage, GraphStageLogic, OutHandler }
 import pekko.util.ByteString
 
-import java.io.{ File, FileInputStream }
+import java.io.File
 import java.nio.charset.{ Charset, StandardCharsets }
+import java.nio.file.Files
 import java.util.zip.{ ZipEntry, ZipInputStream }
 import scala.util.control.NonFatal
 
@@ -33,11 +34,11 @@ import scala.util.control.NonFatal
    * Opens `f` as a zip stream, closing the underlying file if the zip stream itself cannot be opened.
    */
   def openZip(f: File, fileCharset: Charset): ZipInputStream = {
-    val fis = new FileInputStream(f)
-    try new ZipInputStream(fis, fileCharset)
+    val in = Files.newInputStream(f.toPath)
+    try new ZipInputStream(in, fileCharset)
     catch {
       case NonFatal(e) =>
-        try fis.close()
+        try in.close()
         catch { case NonFatal(suppressed) => e.addSuppressed(suppressed) }
         throw e
     }

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -14,7 +14,7 @@
 package docs.scaladsl
 
 import java.io._
-import java.nio.file.{ Files, Path, Paths }
+import java.nio.file.{ Files, NoSuchFileException, Path, Paths }
 import java.util.zip.Deflater
 import org.apache.pekko
 import pekko.actor.ActorSystem
@@ -187,7 +187,7 @@ class ArchiveSpec
           .zipReader(missing)
           .runWith(Sink.ignore)
           .failed
-          .futureValue shouldBe a[FileNotFoundException]
+          .futureValue shouldBe a[NoSuchFileException]
       }
     }
   }

--- a/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
+++ b/file/src/test/scala/docs/scaladsl/ArchiveSpec.scala
@@ -179,6 +179,16 @@ class ArchiveSpec
             Files.delete(p))
         }
       }
+
+      "fail the stream when the archive cannot be opened" in {
+        val missing = new File(Files.createTempDirectory("pekko-connectors-zip-").toFile, "no-such-file.zip")
+
+        Archive
+          .zipReader(missing)
+          .runWith(Sink.ignore)
+          .failed
+          .futureValue shouldBe a[FileNotFoundException]
+      }
     }
   }
 


### PR DESCRIPTION
`ZipEntrySource` and `ZipSource` both opened the archive in the body of their `GraphStageLogic`:

```scala
val zis = new ZipInputStream(new FileInputStream(f), fileCharset)
```

Both close it in `postStop()`, so the ordinary path was never leaking. Two narrower problems:

* A logic that is constructed but whose materialization then fails never reaches `postStop`, so the handle is never released. Pekko's guidance is to acquire in `preStart` for exactly this reason.
* If the `ZipInputStream` constructor throws — an unsupported charset, say — the input stream it was handed is orphaned with no reference left to close it.

Acquisition moves to `preStart`, and a small `openZip` helper closes the underlying file if the zip stream cannot be opened, attaching any secondary failure as a suppressed exception. `postStop` null-guards, since it also runs for a logic that never started.

### Behaviour change

Failing to open the archive now fails the stream instead of throwing out of the caller. Previously the exception escaped from `runWith` synchronously, because logic construction happens during materialization; now it arrives as a failed future like every other stage failure. The new test asserts this, and it does fail against the current code — the exception is thrown rather than returned — so it is a real guard rather than a restatement.

The archive is opened with `Files.newInputStream` rather than `new FileInputStream`. One consequence: a missing archive now surfaces as `NoSuchFileException` instead of `FileNotFoundException`. Both are `IOException`s, and both reach callers the same way, as a failed stream.

`file/test` passes (62) and `checkCodeStyle` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
