### PR TITLE
S3: release disk-buffered chunks when the upload is done with them

### DIFF
--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Chunk.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Chunk.scala
@@ -20,16 +20,26 @@ import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model.{ ContentTypes, HttpEntity, RequestEntity }
 import pekko.util.ByteString
 
+import java.io.File
+
 /**
  * Internal Api
  */
 @InternalApi private[impl] sealed trait Chunk {
   def asEntity(): RequestEntity
   def size: Int
+
+  /**
+   * Releases whatever backs this chunk, once it is known that `data` will not be materialized again.
+   * Must not be called while an upload attempt for the chunk may still be retried.
+   */
+  def dispose(): Unit = ()
 }
 
-@InternalApi private[impl] final case class DiskChunk(data: Source[ByteString, NotUsed], size: Int) extends Chunk {
+@InternalApi private[impl] final case class DiskChunk(data: Source[ByteString, NotUsed], size: Int, file: File)
+    extends Chunk {
   def asEntity(): RequestEntity = HttpEntity(ContentTypes.`application/octet-stream`, size, data)
+  override def dispose(): Unit = { file.delete(): Unit }
 }
 
 @InternalApi private[impl] final case class MemoryChunk(data: ByteString) extends Chunk {

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Chunk.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/Chunk.scala
@@ -18,6 +18,8 @@ import pekko.stream.scaladsl.Source
 import pekko.NotUsed
 import pekko.annotation.InternalApi
 import pekko.http.scaladsl.model.{ ContentTypes, HttpEntity, RequestEntity }
+import pekko.stream.FlowShape
+import pekko.stream.stage.GraphStage
 import pekko.util.ByteString
 
 import java.io.File
@@ -36,10 +38,24 @@ import java.io.File
   def dispose(): Unit = ()
 }
 
-@InternalApi private[impl] final case class DiskChunk(data: Source[ByteString, NotUsed], size: Int, file: File)
-    extends Chunk {
+@InternalApi private[impl] final class DiskChunk(val data: Source[ByteString, NotUsed],
+    val size: Int,
+    file: File,
+    registry: TempFileRegistry) extends Chunk {
   def asEntity(): RequestEntity = HttpEntity(ContentTypes.`application/octet-stream`, size, data)
-  override def dispose(): Unit = { file.delete(): Unit }
+  override def dispose(): Unit = registry.release(file)
+}
+
+/**
+ * A stage that buffers a chunk, and can release whatever any chunk it emitted still holds.
+ */
+@InternalApi private[impl] trait ChunkBuffer extends GraphStage[FlowShape[ByteString, Chunk]] {
+
+  /**
+   * Releases the resources of every chunk this buffer emitted that was not disposed of individually.
+   * Called once the stream the chunks were emitted into has terminated, however it terminated.
+   */
+  def cleanUp(): Unit = ()
 }
 
 @InternalApi private[impl] final case class MemoryChunk(data: ByteString) extends Chunk {

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBuffer.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBuffer.scala
@@ -44,7 +44,9 @@ import scala.concurrent.ExecutionContext
  * The stage waits for the incoming stream to complete. After that, it emits a single Chunk item on its output. The Chunk
  * contains a bytestream source that can be materialized multiple times, and the total size of the file.
  *
- * @param maxMaterializations Number of expected materializations for the completed chunk. After this, the temp file is deleted.
+ * @param maxMaterializations Maximum number of materializations the completed chunk may see, which is reached only
+ *                            when every upload retry is used. After this, the temp file is deleted. In the ordinary
+ *                            case the chunk is disposed of as soon as the upload it belongs to is finished with it.
  * @param maxSize Maximum size on disk to buffer
  */
 @InternalApi private[impl] final class DiskBuffer(maxMaterializations: Int, maxSize: Int, tempPath: Option[Path])
@@ -82,6 +84,8 @@ import scala.concurrent.ExecutionContext
         pull(in)
       }
 
+      private var emitted = false
+
       override def onUpstreamFinish(): Unit = {
         if (isAvailable(out)) emit()
         completeStage()
@@ -92,9 +96,14 @@ import scala.concurrent.ExecutionContext
         try {
           pathOut.close()
         } catch { case x: Throwable => () }
+        finally {
+          // nothing downstream can reference the file if the chunk was never emitted
+          if (!emitted) path.delete(): Unit
+        }
 
       private def emit(): Unit = {
         pathOut.close()
+        emitted = true
 
         val deleteCounter = new AtomicInteger(maxMaterializations)
         val src = FileIO.fromPath(path.toPath, 65536).mapMaterializedValue { f =>
@@ -105,7 +114,7 @@ import scala.concurrent.ExecutionContext
             }(ExecutionContext.parasitic)
           NotUsed
         }
-        emit(out, DiskChunk(src, length), () => completeStage())
+        emit(out, DiskChunk(src, length, path), () => completeStage())
       }
       setHandlers(in, out, this)
     }

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBuffer.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBuffer.scala
@@ -15,8 +15,10 @@ package org.apache.pekko.stream.connectors.s3.impl
 
 import java.io.{ File, FileOutputStream }
 import java.nio.BufferOverflowException
+import java.io.File
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
 import org.apache.pekko
@@ -28,13 +30,35 @@ import pekko.stream.FlowShape
 import pekko.stream.Inlet
 import pekko.stream.Outlet
 import pekko.stream.scaladsl.FileIO
-import pekko.stream.stage.GraphStage
 import pekko.stream.stage.GraphStageLogic
 import pekko.stream.stage.InHandler
 import pekko.stream.stage.OutHandler
 import pekko.util.ByteString
 
 import scala.concurrent.ExecutionContext
+
+/**
+ * Internal Api
+ *
+ * Tracks the temp files of chunks that have been emitted but not yet released, so that they can be deleted
+ * as soon as they are no longer needed, and at the latest when the stream they were emitted into ends.
+ */
+@InternalApi private[impl] final class TempFileRegistry {
+  private val files = ConcurrentHashMap.newKeySet[File]()
+
+  def register(file: File): Unit = { files.add(file): Unit }
+
+  /** Deletes the file and stops tracking it. Deleting a file that is already gone is a no-op. */
+  def release(file: File): Unit = {
+    files.remove(file)
+    file.delete(): Unit
+  }
+
+  def releaseAll(): Unit = {
+    files.forEach { file => file.delete(): Unit }
+    files.clear()
+  }
+}
 
 /**
  * Internal Api
@@ -50,9 +74,13 @@ import scala.concurrent.ExecutionContext
  * @param maxSize Maximum size on disk to buffer
  */
 @InternalApi private[impl] final class DiskBuffer(maxMaterializations: Int, maxSize: Int, tempPath: Option[Path])
-    extends GraphStage[FlowShape[ByteString, Chunk]] {
+    extends ChunkBuffer {
   require(maxMaterializations > 0, "maxMaterializations should be at least 1")
   require(maxSize > 0, "maximumSize should be at least 1")
+
+  private val registry = new TempFileRegistry
+
+  override def cleanUp(): Unit = registry.releaseAll()
 
   val in = Inlet[ByteString]("DiskBuffer.in")
   val out = Outlet[Chunk]("DiskBuffer.out")
@@ -67,7 +95,6 @@ import scala.concurrent.ExecutionContext
         .map(dir => Files.createTempFile(dir, "s3-buffer-", ".bin"))
         .getOrElse(Files.createTempFile("s3-buffer-", ".bin"))
         .toFile
-      path.deleteOnExit()
       var length = 0
       val pathOut = new FileOutputStream(path)
 
@@ -105,16 +132,18 @@ import scala.concurrent.ExecutionContext
         pathOut.close()
         emitted = true
 
+        registry.register(path)
+
         val deleteCounter = new AtomicInteger(maxMaterializations)
         val src = FileIO.fromPath(path.toPath, 65536).mapMaterializedValue { f =>
           if (deleteCounter.decrementAndGet() <= 0)
             f.onComplete { _ =>
-              path.delete()
+              registry.release(path)
 
             }(ExecutionContext.parasitic)
           NotUsed
         }
-        emit(out, DiskChunk(src, length, path), () => completeStage())
+        emit(out, new DiskChunk(src, length, path, registry), () => completeStage())
       }
       setHandlers(in, out, this)
     }

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/MemoryBuffer.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/MemoryBuffer.scala
@@ -29,7 +29,7 @@ import pekko.util.ByteString
  *
  * @param maxSize Maximum size to buffer
  */
-@InternalApi private[impl] final class MemoryBuffer(maxSize: Int) extends GraphStage[FlowShape[ByteString, Chunk]] {
+@InternalApi private[impl] final class MemoryBuffer(maxSize: Int) extends ChunkBuffer {
   val in = Inlet[ByteString]("MemoryBuffer.in")
   val out = Outlet[Chunk]("MemoryBuffer.out")
   override val shape = FlowShape.of(in, out)

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
@@ -1126,7 +1126,8 @@ import scala.util.{ Failure, Success, Try }
       initialUploadState: Option[(String, Int)] = None)(
       parallelism: Int): Flow[ByteString, UploadPartResponse, NotUsed] = {
 
-    def getChunkBuffer(chunkSize: Int, bufferSize: Int, maxRetriesPerChunk: Int)(implicit settings: S3Settings) =
+    def getChunkBuffer(chunkSize: Int, bufferSize: Int, maxRetriesPerChunk: Int)(
+        implicit settings: S3Settings): ChunkBuffer =
       settings.bufferType match {
         case MemoryBufferType =>
           new MemoryBuffer(bufferSize)
@@ -1185,8 +1186,10 @@ import scala.util.{ Failure, Success, Try }
 
         import conf.multipartUploadSettings.retrySettings._
 
+        val chunkBuffer = getChunkBuffer(chunkSize, chunkBufferSize, maxRetries) // creates the chunks
+
         SplitAfterSize(chunkSize, chunkBufferSize)(atLeastOneByteString)
-          .via(getChunkBuffer(chunkSize, chunkBufferSize, maxRetries)) // creates the chunks
+          .via(chunkBuffer)
           .mergeSubstreamsWithParallelism(parallelism)
           .filter(_.size > 0)
           .via(atLeastOne)
@@ -1212,6 +1215,12 @@ import scala.util.{ Failure, Success, Try }
               handleChunkResponse(response, upload, index, conf.multipartUploadSettings.retrySettings)
           }
           .mergeSubstreamsWithParallelism(parallelism)
+          .watchTermination((_, done) => {
+            // a chunk that was emitted and then abandoned - a cancelled or failed upload - is never disposed
+            // of individually, so release whatever is still held once this upload has finished either way
+            done.onComplete(_ => chunkBuffer.cleanUp())(ExecutionContext.parasitic)
+            NotUsed
+          })
       }
       .mapMaterializedValue(_ => NotUsed)
   }

--- a/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
+++ b/s3/src/main/scala/org/apache/pekko/stream/connectors/s3/impl/S3Stream.scala
@@ -1198,8 +1198,11 @@ import scala.util.{ Failure, Success, Try }
               if (isTransientError(r.status)) {
                 r.entity.discardBytes()
                 Some(chunkAndUploadInfo)
-              } else
+              } else {
+                // the request has been sent and will not be retried, so the buffered chunk is no longer needed
+                chunkAndUploadInfo._1.dispose()
                 None
+              }
             case (chunkAndUploadInfo, (Failure(_), _)) =>
               // Treat any exception as transient.
               Some(chunkAndUploadInfo)

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBufferSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBufferSpec.scala
@@ -114,6 +114,20 @@ class DiskBufferSpec(_system: ActorSystem)
     tmpDir.list().size should be(before)
   }
 
+  it should "delete the temp files of chunks that were never disposed of when it is cleaned up" in {
+    val tmpDir = Files.createTempDirectory("DiskBufferSpec").toFile()
+    val before = tmpDir.list().size
+    val buffer = new DiskBuffer(8, 200, Some(tmpDir.toPath))
+
+    Source(Vector(ByteString(1, 2, 3))).via(buffer).runWith(Sink.seq).futureValue
+
+    // the chunk was emitted and then abandoned, as it would be by a cancelled upload
+    tmpDir.list().size should be(before + 1)
+
+    buffer.cleanUp()
+    tmpDir.list().size should be(before)
+  }
+
   it should "delete its temp file if it fails before emitting a chunk" in {
     val tmpDir = Files.createTempDirectory("DiskBufferSpec").toFile()
     val before = tmpDir.list().size

--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBufferSpec.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/impl/DiskBufferSpec.scala
@@ -95,4 +95,38 @@ class DiskBufferSpec(_system: ActorSystem)
     }
 
   }
+
+  it should "delete its temp file when the chunk is disposed" in {
+    val tmpDir = Files.createTempDirectory("DiskBufferSpec").toFile()
+    val before = tmpDir.list().size
+    val chunk = Source(Vector(ByteString(1, 2, 3)))
+      .via(new DiskBuffer(8, 200, Some(tmpDir.toPath)))
+      .runWith(Sink.seq)
+      .futureValue
+      .head
+
+    // a successful upload materializes the chunk far fewer times than the retry budget allows,
+    // so disposal, not the materialization count, is what releases the file
+    chunk.asInstanceOf[DiskChunk].data.runWith(Sink.ignore).futureValue
+    tmpDir.list().size should be(before + 1)
+
+    chunk.dispose()
+    tmpDir.list().size should be(before)
+  }
+
+  it should "delete its temp file if it fails before emitting a chunk" in {
+    val tmpDir = Files.createTempDirectory("DiskBufferSpec").toFile()
+    val before = tmpDir.list().size
+
+    Source
+      .failed(new RuntimeException("boom"))
+      .via(new DiskBuffer(8, 200, Some(tmpDir.toPath)))
+      .runWith(Sink.seq)
+      .failed
+      .futureValue shouldBe a[RuntimeException]
+
+    eventually {
+      tmpDir.list().size should be(before)
+    }
+  }
 }


### PR DESCRIPTION
`DiskBuffer` writes each multipart chunk to a temp file and deletes it through a countdown:

```scala
val deleteCounter = new AtomicInteger(maxMaterializations)
val src = FileIO.fromPath(path.toPath, 65536).mapMaterializedValue { f =>
  if (deleteCounter.decrementAndGet() <= 0) f.onComplete(_ => path.delete())
  NotUsed
}
```

`maxMaterializations` is `(maxRetriesPerChunk + 1) * 2` — every possible upload attempt times two materializations per attempt. So the file is deleted only when *every* retry has been used. A chunk that uploads successfully first time materializes twice out of a budget of eight, the counter never reaches zero, and the file stays on disk until the JVM exits via `deleteOnExit`.

For a long-running service uploading through the disk buffer that means every 5MB+ chunk it has ever sent is still on disk. `deleteOnExit` is a poor backstop for it: it only runs on an orderly shutdown, so a `SIGKILL`, a container eviction or a JVM crash leaves everything behind, and its JVM-global `DeleteOnExitHook` set is never pruned.

Every temp file is now deleted in code, at the point it stops being needed.

### Changes

* `Chunk` gains `dispose()`, a no-op by default. `DiskChunk` implements it by releasing its temp file.
* `chunkAndRequest` calls `dispose()` in the branch of the `RetryFlow` decision function that returns `None` — the point at which the chunk is definitively finished with, because the request has been sent and the result will not be retried. The retry branch leaves the file alone, since a retry re-materializes the source.
* `TempFileRegistry`, owned by the `DiskBuffer` for the upload it belongs to, tracks the temp file of every chunk emitted. A `cleanUp()` hung off `watchTermination` deletes whatever is still registered when the upload stream terminates, however it terminates. That covers the chunk that is emitted and then abandoned by a cancelled or failed upload, which is never disposed of individually.
* `DiskBuffer` deletes its temp file in `postStop` when it never emitted a chunk at all.
* `deleteOnExit` is gone.

The existing countdown stays as-is and now releases through the registry. It covers the one case individual disposal does not: retries exhausted, where `RetryFlow` emits the final failure without asking the decision function again — and that is exactly when the counter reaches zero.

`MemoryChunk` inherits the no-op `dispose()`, and `MemoryBuffer` the no-op `cleanUp()`, so the memory buffer path and `chunkAndRequestWithContext` (memory-only) are unaffected. `buffer = "memory"` is the default, so this only affects users who opt into `DiskBufferType` or `MemoryAndDiskBufferType`.

### Testing

Four cases in `DiskBufferSpec`: disposal releases the file after a materialization count well below the retry budget; `cleanUp()` releases a chunk that was emitted and abandoned; a failure before emission leaves nothing behind; and the existing "after N materializations" test still passes unchanged.

`s3/test` passes — 170 tests, 20 suites. `MinioS3IntegrationSpec` aborts in my environment because Docker is not available, not from this change. `checkCodeStyle` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
