### PR TITLE
Elasticsearch: delete test indices by name instead of _all

### DIFF
--- a/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
+++ b/elasticsearch/src/test/java/docs/javadsl/ElasticsearchTestBase.java
@@ -16,10 +16,12 @@ package docs.javadsl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.pekko.actor.ActorSystem;
 import org.apache.pekko.http.javadsl.Http;
 import org.apache.pekko.http.javadsl.model.ContentTypes;
 import org.apache.pekko.http.javadsl.model.HttpRequest;
+import org.apache.pekko.http.javadsl.model.HttpResponse;
 import org.apache.pekko.stream.connectors.elasticsearch.ApiVersion;
 import org.apache.pekko.stream.connectors.elasticsearch.ApiVersionBase;
 import org.apache.pekko.stream.connectors.elasticsearch.ElasticsearchConnectionSettings;
@@ -79,9 +81,48 @@ public class ElasticsearchTestBase {
     flushAndRefresh("source");
   }
 
+  /**
+   * Deletes every index the tests created on the server.
+   *
+   * <p>{@code DELETE /_all} is refused from Elasticsearch 8 on, where {@code
+   * action.destructive_requires_name} defaults to true, so the indices are listed and deleted by
+   * explicit name instead. Both responses are checked, so a cleanup that silently stops working
+   * cannot leave documents behind for the next suite to trip over.
+   */
   protected static void cleanIndex() throws IOException {
-    HttpRequest request = HttpRequest.DELETE("%s/_all".formatted(connectionSettings.baseUrl()));
-    http.singleRequest(request).toCompletableFuture().join();
+    HttpRequest listRequest =
+        HttpRequest.GET("%s/_cat/indices?h=index".formatted(connectionSettings.baseUrl()));
+    HttpResponse listResponse = http.singleRequest(listRequest).toCompletableFuture().join();
+    if (!listResponse.status().isSuccess()) {
+      throw new IOException("Failed to list indices: " + listResponse.status());
+    }
+
+    String body =
+        listResponse
+            .entity()
+            .toStrict(5000, system)
+            .toCompletableFuture()
+            .join()
+            .getData()
+            .utf8String();
+
+    List<String> indices =
+        body.lines()
+            .map(String::trim)
+            // leave the server's own bookkeeping indices alone
+            .filter(name -> !name.isEmpty() && !name.startsWith("."))
+            .collect(Collectors.toList());
+
+    if (!indices.isEmpty()) {
+      HttpRequest deleteRequest =
+          HttpRequest.DELETE(
+              "%s/%s".formatted(connectionSettings.baseUrl(), String.join(",", indices)));
+      HttpResponse deleteResponse = http.singleRequest(deleteRequest).toCompletableFuture().join();
+      if (!deleteResponse.status().isSuccess()) {
+        throw new IOException(
+            "Failed to delete indices " + indices + ": " + deleteResponse.status());
+      }
+    }
   }
 
   protected static void flushAndRefresh(String indexName) throws IOException {

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpec.scala
@@ -16,8 +16,6 @@ package docs.scaladsl
 import org.apache.pekko
 import pekko.actor.ActorSystem
 import pekko.http.scaladsl.{ Http, HttpExt }
-import pekko.http.scaladsl.model.Uri.Path
-import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest, Uri }
 import pekko.stream.connectors.elasticsearch._
 import pekko.stream.connectors.testkit.scaladsl.LogCapturing
 import pekko.testkit.TestKit
@@ -45,13 +43,8 @@ class ElasticsearchSpec
     ElasticsearchConnectionSettings("http://localhost:9202")
 
   override def afterAll(): Unit = {
-    val deleteRequestV5 = HttpRequest(HttpMethods.DELETE)
-      .withUri(Uri(clientV5.baseUrl).withPath(Path("/_all")))
-    http.singleRequest(deleteRequestV5).futureValue
-
-    val deleteRequestV7 = HttpRequest(HttpMethods.DELETE)
-      .withUri(Uri(clientV7.baseUrl).withPath(Path("/_all")))
-    http.singleRequest(deleteRequestV7).futureValue
+    deleteAllIndices(clientV5)
+    deleteAllIndices(clientV7)
 
     TestKit.shutdownActorSystem(system)
   }

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchSpecUtils.scala
@@ -18,6 +18,7 @@ import pekko.actor.ActorSystem
 import pekko.http.scaladsl.HttpExt
 import pekko.http.scaladsl.model.Uri.Path
 import pekko.http.scaladsl.model.{ ContentTypes, HttpMethods, HttpRequest, Uri }
+import pekko.http.scaladsl.unmarshalling.Unmarshal
 import pekko.stream.connectors.elasticsearch.scaladsl.ElasticsearchSource
 import pekko.stream.connectors.elasticsearch.{
   ApiVersionBase,
@@ -32,7 +33,7 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.wordspec.AnyWordSpec
 
 import scala.collection.immutable
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait ElasticsearchSpecUtils { this: AnyWordSpec with ScalaFutures =>
   implicit def system: ActorSystem
@@ -56,6 +57,43 @@ trait ElasticsearchSpecUtils { this: AnyWordSpec with ScalaFutures =>
       .withUri(Uri(connectionSettings.baseUrl).withPath(Path(s"/$indexName/_doc")))
       .withEntity(ContentTypes.`application/json`, s"""{"title": "$title", "price": $price}""")
     http.singleRequest(request).futureValue
+  }
+
+  /**
+   * Deletes every index the tests created on the server.
+   *
+   * `DELETE /_all` is refused from Elasticsearch 8 on, where `action.destructive_requires_name`
+   * defaults to true, so the indices are listed and deleted by explicit name instead. Both
+   * responses are checked, so a cleanup that silently stops working cannot leave documents behind
+   * for the next suite to trip over.
+   */
+  def deleteAllIndices(connectionSettings: ElasticsearchConnectionSettings): Unit = {
+    implicit val ec: ExecutionContext = system.dispatcher
+
+    val listRequest = HttpRequest(HttpMethods.GET)
+      .withUri(
+        Uri(connectionSettings.baseUrl)
+          .withPath(Path("/_cat/indices"))
+          .withQuery(Uri.Query("h" -> "index")))
+    val listResponse = http.singleRequest(listRequest).futureValue
+    require(listResponse.status.isSuccess(), s"Failed to list indices: ${listResponse.status}")
+
+    val indices = Unmarshal(listResponse.entity)
+      .to[String]
+      .futureValue
+      .linesIterator
+      .map(_.trim)
+      // leave the server's own bookkeeping indices alone
+      .filter(name => name.nonEmpty && !name.startsWith("."))
+      .toList
+
+    if (indices.nonEmpty) {
+      val deleteRequest = HttpRequest(HttpMethods.DELETE)
+        .withUri(Uri(connectionSettings.baseUrl).withPath(Path("/" + indices.mkString(","))))
+      val deleteResponse = http.singleRequest(deleteRequest).futureValue
+      require(deleteResponse.status.isSuccess(),
+        s"Failed to delete indices ${indices.mkString(", ")}: ${deleteResponse.status}")
+    }
   }
 
   def flushAndRefresh(connectionSettings: ElasticsearchConnectionSettings, indexName: String): Unit = {

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV5Spec.scala
@@ -14,8 +14,6 @@
 package docs.scaladsl
 
 import org.apache.pekko
-import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest, Uri }
-import pekko.http.scaladsl.model.Uri.Path
 import pekko.stream.connectors.elasticsearch.scaladsl.{ ElasticsearchFlow, ElasticsearchSink, ElasticsearchSource }
 import pekko.stream.connectors.elasticsearch.{
   ApiVersion,
@@ -48,9 +46,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   override def afterAll() = {
-    val deleteRequest = HttpRequest(HttpMethods.DELETE)
-      .withUri(Uri(connectionSettings.baseUrl).withPath(Path("/_all")))
-    http.singleRequest(deleteRequest).futureValue
+    deleteAllIndices(connectionSettings)
 
     TestKit.shutdownActorSystem(system)
   }
@@ -154,7 +150,7 @@ class ElasticsearchV5Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
     }
 
     "store properly formatted JSON from Strings" in {
-      val indexName = "sink3-0"
+      val indexName = "sink3-0-scala"
       // #string
       val write: Future[immutable.Seq[WriteResult[String, NotUsed]]] = Source(
         immutable.Seq(

--- a/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/ElasticsearchV7Spec.scala
@@ -14,8 +14,6 @@
 package docs.scaladsl
 
 import org.apache.pekko
-import pekko.http.scaladsl.model.Uri.Path
-import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest, Uri }
 import pekko.stream.connectors.elasticsearch.scaladsl.{ ElasticsearchFlow, ElasticsearchSink, ElasticsearchSource }
 import pekko.stream.connectors.elasticsearch._
 import pekko.stream.scaladsl.{ Sink, Source }
@@ -40,9 +38,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
   }
 
   override def afterAll() = {
-    val deleteRequest = HttpRequest(HttpMethods.DELETE)
-      .withUri(Uri(connectionSettings.baseUrl).withPath(Path("/_all")))
-    http.singleRequest(deleteRequest).futureValue
+    deleteAllIndices(connectionSettings)
 
     TestKit.shutdownActorSystem(system)
   }
@@ -143,7 +139,7 @@ class ElasticsearchV7Spec extends ElasticsearchSpecBase with ElasticsearchSpecUt
     }
 
     "store properly formatted JSON from Strings" in {
-      val indexName = "sink3-0"
+      val indexName = "sink3-0-scala"
 
       val write: Future[immutable.Seq[WriteResult[String, NotUsed]]] = Source(
         immutable.Seq(

--- a/elasticsearch/src/test/scala/docs/scaladsl/OpensearchV1Spec.scala
+++ b/elasticsearch/src/test/scala/docs/scaladsl/OpensearchV1Spec.scala
@@ -14,8 +14,6 @@
 package docs.scaladsl
 
 import org.apache.pekko
-import pekko.http.scaladsl.model.Uri.Path
-import pekko.http.scaladsl.model.{ HttpMethods, HttpRequest, Uri }
 import pekko.stream.connectors.elasticsearch.{
   ElasticsearchConnectionSettings,
   OpensearchApiVersion,
@@ -48,9 +46,7 @@ class OpensearchV1Spec extends ElasticsearchSpecBase with ElasticsearchSpecUtils
   }
 
   override def afterAll() = {
-    val deleteRequest = HttpRequest(HttpMethods.DELETE)
-      .withUri(Uri(connectionSettings.baseUrl).withPath(Path("/_all")))
-    http.singleRequest(deleteRequest).futureValue
+    deleteAllIndices(connectionSettings)
 
     TestKit.shutdownActorSystem(system)
   }
@@ -158,7 +154,7 @@ class OpensearchV1Spec extends ElasticsearchSpecBase with ElasticsearchSpecUtils
     }
 
     "store properly formatted JSON from Strings" in {
-      val indexName = "sink3-0"
+      val indexName = "sink3-0-scala"
 
       // #string
       val write: Future[immutable.Seq[WriteResult[String, NotUsed]]] = Source(


### PR DESCRIPTION
### Motivation
Every Elasticsearch/Opensearch test suite wipes its server between runs with `DELETE /_all`, and none of them check the response.

Elasticsearch 8 [changed `action.destructive_requires_name` to default to `true`](https://www.elastic.co/guide/en/elasticsearch/reference/8.19/indices-delete-index.html), which refuses wildcard and `_all` destructive operations. So from Elasticsearch 8 on, the cleanup silently does nothing — the request is rejected, the response is discarded, and the suite carries on.

The consequence is not a cleanup failure but a confusing failure somewhere else entirely. Documents survive into the next suite, which reads them back and cannot deserialize them: the Java `Book` has only a `title`, while the Scala `Book` also carries a `price`, so the Java suite fails with `UnrecognizedPropertyException: Unrecognized field "price"` on an index it believed it had just created. This was hit for real on #1934, which adds Elasticsearch 8 and 9 test servers.

The suites are not racing — `Test / parallelExecution := false` applies to every connector project, so they run one at a time and `_all` deletion between them is the intended isolation. It just stopped working.

### Modification
- Replaced the `_all` deletions with a helper that lists indices via `_cat/indices?h=index` and deletes them by explicit name, which every supported server accepts. Index names starting with `.` are left alone.
- Both the list and the delete response are now checked, so a cleanup that stops working fails the suite instead of passing quietly.
- Added as `deleteAllIndices` in `ElasticsearchSpecUtils` for the four Scala suites, and rewrote `ElasticsearchTestBase.cleanIndex` for the Java ones.
- Renamed the Scala `sink3-0` index to `sink3-0-scala` — the last index name shared between a Java and a Scala suite running against the same server. Harmless while cleanup works, but it is the exact trap that produced the failure above.
- Dropped the imports left unused by the change.

Test-only; no main source touched.

### Result
Cleanup works against every server the tests run against, including Elasticsearch 8 and 9, and a future regression in it surfaces as a cleanup failure rather than as a deserialization error in an unrelated suite.

### Tests
- `sbt "elasticsearch/Test/compile"` — success, no warnings
- `sbt "++3.3.8 elasticsearch/Test/compile"` — success (Scala 3)
- `sbt "elasticsearch/scalafmtAll" "elasticsearch/javafmtAll"` — success
- Integration run not done locally (no Docker on this machine); relying on the `elasticsearch` CI job.

### References
Refs #1934 — this is the underlying cause of the failure seen there