### PR TITLE
AWS SPI Pekko HTTP, Testkit: use parameterized slf4j logging

### DIFF
--- a/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
+++ b/aws-spi-pekko-http/src/main/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClient.scala
@@ -167,7 +167,7 @@ object PekkoHttpClient {
   }
 
   private[awsspi] def tryCreateCustomContentType(contentTypeStr: String): ContentType = {
-    logger.debug(s"Try to parse content type from $contentTypeStr")
+    logger.debug("Try to parse content type from {}", contentTypeStr)
     val mainAndsubType = contentTypeStr.split('/')
     if (mainAndsubType.length == 2)
       ContentType(MediaType.customBinary(mainAndsubType(0), mainAndsubType(1), Compressible))

--- a/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
+++ b/aws-spi-pekko-http/src/test/scala/org/apache/pekko/stream/connectors/awsspi/PekkoHttpClientSpec.scala
@@ -19,6 +19,9 @@ package org.apache.pekko.stream.connectors.awsspi
 
 import java.util.Collections
 import java.nio.ByteBuffer
+import ch.qos.logback.classic.{ Level, Logger => LogbackLogger }
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
 import com.typesafe.config.ConfigFactory
 
 import org.apache.pekko
@@ -34,6 +37,7 @@ import software.amazon.awssdk.http.async.SdkHttpContentPublisher
 import software.amazon.awssdk.utils.AttributeMap
 
 import scala.concurrent.duration._
+import scala.jdk.CollectionConverters._
 import scala.jdk.DurationConverters._
 
 class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
@@ -44,6 +48,26 @@ class PekkoHttpClientSpec extends AnyWordSpec with Matchers with OptionValues {
       val contentTypeStr = "application/xml"
       val contentType = PekkoHttpClient.tryCreateCustomContentType(contentTypeStr)
       contentType.mediaType should be(MediaTypes.`application/xml`)
+    }
+
+    "log the content type it parses with the argument substituted into the message" in {
+      val contentTypeStr = "application/xml"
+      val logbackLogger = PekkoHttpClient.logger.asInstanceOf[LogbackLogger]
+      val appender = new ListAppender[ILoggingEvent]
+      val previousLevel = logbackLogger.getLevel
+      appender.start()
+      logbackLogger.addAppender(appender)
+      logbackLogger.setLevel(Level.DEBUG)
+      try {
+        PekkoHttpClient.tryCreateCustomContentType(contentTypeStr)
+      } finally {
+        logbackLogger.setLevel(previousLevel)
+        logbackLogger.detachAppender(appender)
+        appender.stop()
+      }
+
+      val messages = appender.list.asScala.map(_.getFormattedMessage).toList
+      messages should contain(s"Try to parse content type from $contentTypeStr")
     }
 
     "remove 'ContentType' return 'ContentLength' separate from sdk headers" in {

--- a/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/javadsl/LogCapturingJunit4.scala
+++ b/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/javadsl/LogCapturingJunit4.scala
@@ -56,10 +56,12 @@ final class LogCapturingJunit4 extends TestRule {
     new Statement {
       override def evaluate(): Unit = {
         try {
-          myLogger.info(s"Logging started for test [${description.getClassName}: ${description.getMethodName}]")
+          myLogger.info("Logging started for test [{}: {}]", description.getClassName, description.getMethodName)
           base.evaluate()
           myLogger.info(
-            s"Logging finished for test [${description.getClassName}: ${description.getMethodName}] that was successful")
+            "Logging finished for test [{}: {}] that was successful",
+            description.getClassName,
+            description.getMethodName)
         } catch {
           case NonFatal(e) =>
             println(

--- a/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/scaladsl/LogCapturing.scala
+++ b/testkit/src/main/scala/org/apache/pekko/stream/connectors/testkit/scaladsl/LogCapturing.scala
@@ -65,11 +65,11 @@ trait LogCapturing extends BeforeAndAfterAll { self: TestSuite =>
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
     sourceActorSystem.foreach(MDC.put("sourceActorSystem", _))
-    myLogger.info(s"Logging started for test [${self.getClass.getName}: ${test.name}]")
+    myLogger.info("Logging started for test [{}: {}]", self.getClass.getName, test.name)
     sourceActorSystem.foreach(_ => MDC.remove("sourceActorSystem"))
     val res = test()
     sourceActorSystem.foreach(MDC.put("sourceActorSystem", _))
-    myLogger.info(s"Logging finished for test [${self.getClass.getName}: ${test.name}] that [$res]")
+    myLogger.info("Logging finished for test [{}: {}] that [{}]", self.getClass.getName, test.name, res)
     sourceActorSystem.foreach(_ => MDC.remove("sourceActorSystem"))
 
     if (!(res.isSucceeded || res.isPending)) {


### PR DESCRIPTION
### Motivation
Several slf4j log calls in main sources built their message with an s-interpolator, so the string was concatenated even when the level was disabled. slf4j can defer that formatting to the point where it knows the event will actually be emitted.

### Modification
Replaced the interpolated messages with `{}` placeholders and argument lists in:

- `PekkoHttpClient.tryCreateCustomContentType` (`logger.debug`)
- `LogCapturing.withFixture` (two `info` calls)
- `LogCapturingJunit4.apply` (two `info` calls)

Log output is unchanged. Non-slf4j logging (Pekko `LoggingAdapter` in `mqttv5`, `sse`, `file`, `jms`, `jakartams`, `unix-domain-socket`) and non-logging interpolations were left alone.

### Result
No message is formatted unless the level is enabled. The `debug` call in `tryCreateCustomContentType` is the one on a request path, so it no longer builds a string per request when debug logging is off.

### Tests
- `sbt "aws-spi-pekko-http/compile" "s3/compile" "testkit/compile"` / pass
- `sbt -batch "++3.3.8" "aws-spi-pekko-http/compile" "s3/compile" "testkit/compile"` / pass (checked Scala 3 explicitly because the 2-arg vs varargs slf4j overload resolution can differ)
- `scalafmt --list` on the changed files / clean
- `PekkoHttpClientSpec` gains a directional test that captures the logback output and asserts the debug line renders as `Try to parse content type from application/xml`, which fails if the placeholder and argument counts ever drift. Not executed locally, left to CI.
- MiMa not run: method-body-only changes, no signature or public API impact.

### References
None - follow-up cleanup of slf4j usage in main sources
