### PR TITLE
AWS S3: replace removed minio/minio test image with pgsty/silo

### DIFF
--- a/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
+++ b/s3/src/test/scala/org/apache/pekko/stream/connectors/s3/MinioContainer.scala
@@ -20,13 +20,13 @@ import java.time.Duration
 
 class MinioContainer(accessKey: String, secretKey: String, domain: String)
     extends GenericContainer(
-      "minio/minio:RELEASE.2025-09-07T16-13-09Z",
+      "pgsty/silo:RELEASE.2026-09-03T13-18-01Z",
       exposedPorts = List(9000),
       waitStrategy = Some(Wait.forHttp("/minio/health/ready").forPort(9000).withStartupTimeout(Duration.ofSeconds(10))),
       command = List("server", "/data"),
       env = Map(
-        "MINIO_ACCESS_KEY" -> accessKey,
-        "MINIO_SECRET_KEY" -> secretKey,
+        "MINIO_ROOT_USER" -> accessKey,
+        "MINIO_ROOT_PASSWORD" -> secretKey,
         "MINIO_DOMAIN" -> domain)) {
 
   def getHostAddress: String =

--- a/scripts/create-slow-minio.sh
+++ b/scripts/create-slow-minio.sh
@@ -23,11 +23,11 @@ docker run -i --rm \
   --name minio \
   --device "$LO_DEV" \
   --device-read-bps "$LO_DEV":1mb --device-write-bps "$LO_DEV":1mb \
-  -e MINIO_ACCESS_KEY=TESTKEY -e MINIO_SECRET_KEY=TESTSECRET -e MINIO_DOMAIN=s3minio.alpakka -e MINIO_FS_OSYNC=true \
+  -e MINIO_ROOT_USER=TESTKEY -e MINIO_ROOT_PASSWORD=TESTSECRET -e MINIO_DOMAIN=s3minio.alpakka -e MINIO_FS_OSYNC=true \
   -e CONFIG_BLK_CGROUP=y -e CONFIG_BLK_DEV_THROTTLING=y \
   --mount "type=volume,source=miniodata,target=/data,volume-driver=local,volume-opt=type=ext4,volume-opt=device=$LO_DEV" \
   -p 9001:9000 \
-  minio/minio \
+  pgsty/silo \
   server /data
 
 # We can verify that the throttling is properly configured by running dd


### PR DESCRIPTION
### Motivation
Docker Hub removed the `minio/minio` image after upstream MinIO was archived (April 2026), so `MinioS3IntegrationSpec` can no longer pull its test container.

### Modification
- `MinioContainer` now uses `pgsty/silo:RELEASE.2026-09-03T13-18-01Z`, the PGSTY-maintained fork of the MinIO server. It keeps the S3 API, `MINIO_*` env vars, `/minio/health/ready` route and `server /data` command unchanged, so it is a drop-in image swap.
- Credentials env switched from the long-deprecated `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` to `MINIO_ROOT_USER`/`MINIO_ROOT_PASSWORD`.
- Same changes in `scripts/create-slow-minio.sh`.

### Result
S3 integration tests run against a pullable image again.

### Tests
- `sbt "s3/testOnly *.MinioS3IntegrationSpec"` - 34 succeeded, 0 failed, 8 canceled (the AWS-only tests gated by `assume(isInstanceOf[AWSS3IntegrationSpec])`, unchanged)
- `scalafmt` run on the changed Scala file

### References
None - `minio/minio` removed from Docker Hub; see https://github.com/pgsty/silo and https://silo.pgsty.com/compatibility/migration/
